### PR TITLE
temporarily comment out checking zero prefixed int

### DIFF
--- a/util/src/bytes.rs
+++ b/util/src/bytes.rs
@@ -274,8 +274,8 @@ pub enum FromBytesError {
 	DataIsTooShort,
 	/// TODO [debris] Please document me
 	DataIsTooLong,
-	/// Integer-representation is non-canonically prefixed with zero byte(s).
-	ZeroPrefixedInt,
+	// Integer-representation is non-canonically prefixed with zero byte(s).
+	//ZeroPrefixedInt,
 }
 
 impl StdError for FromBytesError {
@@ -312,9 +312,9 @@ macro_rules! impl_uint_from_bytes {
 				match bytes.len() {
 					0 => Ok(0),
 					l if l <= mem::size_of::<$to>() => {
-						if bytes[0] == 0 {
-							return Err(FromBytesError::ZeroPrefixedInt)
-						}
+						//if bytes[0] == 0 {
+							//return Err(FromBytesError::ZeroPrefixedInt)
+						//}
 						let mut res = 0 as $to;
 						for i in 0..l {
 							let shift = (l - 1 - i) * 8;
@@ -349,9 +349,10 @@ macro_rules! impl_uint_from_bytes {
 	($name: ident) => {
 		impl FromBytes for $name {
 			fn from_bytes(bytes: &[u8]) -> FromBytesResult<$name> {
-				if !bytes.is_empty() && bytes[0] == 0 {
-					Err(FromBytesError::ZeroPrefixedInt)
-				} else if bytes.len() <= $name::SIZE {
+				//if !bytes.is_empty() && bytes[0] == 0 {
+					//Err(FromBytesError::ZeroPrefixedInt)
+				//} else 
+				if bytes.len() <= $name::SIZE {
 					Ok($name::from(bytes))
 				} else {
 					Err(FromBytesError::DataIsTooLong)


### PR DESCRIPTION
this caused blockchain sync to fail. Temporarily commented out.

related issue:

https://github.com/ethcore/parity/issues/237
