### PR TITLE
Optimistic snapshot

### DIFF
--- a/ethcore/src/snapshot/tests/service.rs
+++ b/ethcore/src/snapshot/tests/service.rs
@@ -76,9 +76,16 @@ fn restored_is_equivalent() {
 	};
 
 	let service = Service::new(service_params).unwrap();
-	service.take_snapshot(&client, NUM_BLOCKS as u64).unwrap();
 
-	let manifest = service.manifest().unwrap();
+	// create snapshot.
+	service.take_snapshot(&client, NUM_BLOCKS as u64).expect("failed to take snapshot");
+	assert!(service.manifest().is_none());
+
+	let canon_hash = client.block_hash(::ids::BlockId::Number(NUM_BLOCKS as u64)).expect("failed to get block hash");
+
+	// make it available (under the assumption of more confirmations)
+	service.solidify(NUM_BLOCKS as u64, canon_hash).expect("failed to solidify snapshot.");
+	let manifest = service.manifest().expect("failed to get manifest");
 
 	service.init_restore(manifest.clone(), true).unwrap();
 	assert!(service.init_restore(manifest.clone(), true).is_ok());

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -58,8 +58,8 @@ use url;
 // how often to take periodic snapshots.
 const SNAPSHOT_PERIOD: u64 = 10000;
 
-// how many blocks to wait before starting a periodic snapshot.
-const SNAPSHOT_HISTORY: u64 = 100;
+// how many blocks to wait before starting to propagate a periodic snapshot.
+const SNAPSHOT_HISTORY: u64 = 1000;
 
 // Pops along with error messages when a password is missing or invalid.
 const VERIFY_PASSWORD_HINT: &'static str = "Make sure valid password is present in files passed using `--password` or in the configuration file.";
@@ -508,7 +508,8 @@ pub fn execute(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>) -> R
 				move || is_major_importing(Some(sync.status().state), client.queue_info()),
 				service.io().channel(),
 				SNAPSHOT_PERIOD,
-				SNAPSHOT_HISTORY,
+				cmd.pruning_history, // take snapshot after `--pruning-history`.
+				SNAPSHOT_HISTORY, // and propagate it if still accurate after this amount.
 			));
 
 			service.add_notify(watcher.clone());


### PR DESCRIPTION
Closes #4727 

cc @keorn

This will need a bit of testing before merge, so will ice this for now.

Changes snapshot creation behavior. Previously, snapshots were created into `snapshot_dir` after a delay and immediately propagated after that. The delay was too long for pruned nodes to be able to create the snapshot.

Now, snapshots are initially created at `--pruning-history` blocks behind, and are only propagated after a certain amount of time.