### PR TITLE
EIP198 and built-in activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.1.0",

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -44,6 +44,7 @@ ethcore-stratum = { path = "../stratum" }
 ethcore-bloom-journal = { path = "../util/bloom" }
 hardware-wallet = { path = "../hw" }
 stats = { path = "../util/stats" }
+num = "0.1"
 
 [dependencies.hyper]
 git = "https://github.com/ethcore/hyper"

--- a/ethcore/res/ethereum/foundation.json
+++ b/ethcore/res/ethereum/foundation.json
@@ -189,6 +189,7 @@
 		"0000000000000000000000000000000000000002": { "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
 		"0000000000000000000000000000000000000003": { "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
 		"0000000000000000000000000000000000000004": { "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x7fffffffffffff", "pricing": { "modexp": { "divisor": 20 } } } },
 		"3282791d6fd713f1e94f4bfd565eaa78b3a0599d": {
 			"balance": "1337000000000000000000"
 		},

--- a/ethcore/src/builtin.rs
+++ b/ethcore/src/builtin.rs
@@ -14,11 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::cmp::{max, min};
+use std::io::{self, Read};
+
+use byteorder::{ByteOrder, BigEndian};
 use crypto::sha2::Sha256 as Sha256Digest;
 use crypto::ripemd160::Ripemd160 as Ripemd160Digest;
 use crypto::digest::Digest;
-use std::cmp::min;
-use util::{U256, H256, Hashable, BytesRef};
+use num::{BigUint, Zero, One};
+
+use util::{U256, H256, Uint, Hashable, BytesRef};
 use ethkey::{Signature, recover as ec_recover};
 use ethjson;
 
@@ -30,8 +35,8 @@ pub trait Impl: Send + Sync {
 
 /// A gas pricing scheme for built-in contracts.
 pub trait Pricer: Send + Sync {
-	/// The gas cost of running this built-in for the given size of input data.
-	fn cost(&self, in_size: usize) -> U256;
+	/// The gas cost of running this built-in for the given input data.
+	fn cost(&self, input: &[u8]) -> U256;
 }
 
 /// A linear pricing model. This computes a price using a base cost and a cost per-word.
@@ -40,33 +45,86 @@ struct Linear {
 	word: usize,
 }
 
+/// A special pricing model for modular exponentiation.
+struct Modexp {
+	divisor: usize,
+}
+
 impl Pricer for Linear {
-	fn cost(&self, in_size: usize) -> U256 {
-		U256::from(self.base) + U256::from(self.word) * U256::from((in_size + 31) / 32)
+	fn cost(&self, input: &[u8]) -> U256 {
+		U256::from(self.base) + U256::from(self.word) * U256::from((input.len() + 31) / 32)
 	}
 }
 
-/// Pricing scheme and execution definition for a built-in contract.
+impl Pricer for Modexp {
+	fn cost(&self, input: &[u8]) -> U256 {
+		let mut reader = input.chain(io::repeat(0));
+		let mut buf = [0; 32];
+
+		// read lengths as U256 here for accurate gas calculation.
+		let mut read_len = || {
+			reader.read_exact(&mut buf[..]).expect("reading from zero-extended memory cannot fail; qed");
+			U256::from(H256::from_slice(&buf[..]))
+		};
+		let base_len = read_len();
+		let exp_len = read_len();
+		let mod_len = read_len();
+
+		// floor(max(length_of_MODULUS, length_of_BASE) ** 2 * max(length_of_EXPONENT, 1) / GQUADDIVISOR)
+		// TODO: is saturating the best bahavior here?
+		let m = max(mod_len, base_len);
+		match m.overflowing_mul(m) {
+			(_, true) => U256::max_value(),
+			(val, _) => {
+				match val.overflowing_mul(max(exp_len, U256::one())) {
+					(_, true) => U256::max_value(),
+					(val, _) => val / (self.divisor as u64).into()
+				}
+			}
+		}
+	}
+}
+
+/// Pricing scheme, execution definition, and activation block for a built-in contract.
+///
+/// Call `cost` to compute cost for the given input, `execute` to execute the contract
+/// on the given input, and `is_active` to determine whether the contract is active.
+///
+/// Unless `is_active` is true,
 pub struct Builtin {
 	pricer: Box<Pricer>,
 	native: Box<Impl>,
+	activate_at: u64,
 }
 
 impl Builtin {
 	/// Simple forwarder for cost.
-	pub fn cost(&self, s: usize) -> U256 { self.pricer.cost(s) }
+	pub fn cost(&self, input: &[u8]) -> U256 { self.pricer.cost(input) }
 
 	/// Simple forwarder for execute.
 	pub fn execute(&self, input: &[u8], output: &mut BytesRef) { self.native.execute(input, output) }
+
+	/// Whether the builtin is activated at the given block number.
+	pub fn is_active(&self, at: u64) -> bool { at >= self.activate_at }
 }
 
 impl From<ethjson::spec::Builtin> for Builtin {
 	fn from(b: ethjson::spec::Builtin) -> Self {
-		let pricer = match b.pricing {
+		let pricer: Box<Pricer> = match b.pricing {
 			ethjson::spec::Pricing::Linear(linear) => {
 				Box::new(Linear {
 					base: linear.base,
 					word: linear.word,
+				})
+			}
+			ethjson::spec::Pricing::Modexp(exp) => {
+				Box::new(Modexp {
+					divisor: if exp.divisor == 0 {
+						warn!("Zero modexp divisor specified. Falling back to default.");
+						10
+					} else {
+						exp.divisor
+					}
 				})
 			}
 		};
@@ -74,6 +132,7 @@ impl From<ethjson::spec::Builtin> for Builtin {
 		Builtin {
 			pricer: pricer,
 			native: ethereum_builtin(&b.name),
+			activate_at: b.activate_at.map(Into::into).unwrap_or(0),
 		}
 	}
 }
@@ -85,6 +144,7 @@ fn ethereum_builtin(name: &str) -> Box<Impl> {
 		"ecrecover" => Box::new(EcRecover) as Box<Impl>,
 		"sha256" => Box::new(Sha256) as Box<Impl>,
 		"ripemd160" => Box::new(Ripemd160) as Box<Impl>,
+		"modexp" => Box::new(ModexpImpl) as Box<Impl>,
 		_ => panic!("invalid builtin name: {}", name),
 	}
 }
@@ -95,6 +155,7 @@ fn ethereum_builtin(name: &str) -> Box<Impl> {
 // - ec recovery
 // - sha256
 // - ripemd160
+// - modexp (EIP198)
 
 #[derive(Debug)]
 struct Identity;
@@ -107,6 +168,9 @@ struct Sha256;
 
 #[derive(Debug)]
 struct Ripemd160;
+
+#[derive(Debug)]
+struct ModexpImpl;
 
 impl Impl for Identity {
 	fn execute(&self, input: &[u8], output: &mut BytesRef) {
@@ -166,9 +230,63 @@ impl Impl for Ripemd160 {
 	}
 }
 
+impl Impl for ModexpImpl {
+	fn execute(&self, input: &[u8], output: &mut BytesRef) {
+		let mut reader = input.chain(io::repeat(0));
+		let mut buf = [0; 32];
+
+		// read lengths as usize.
+		// ignoring the first 24 bytes might technically lead us to fall out of consensus,
+		// but so would running out of addressable memory!
+		let mut read_len = |reader: &mut io::Chain<&[u8], io::Repeat>| {
+			reader.read_exact(&mut buf[..]).expect("reading from zero-extended memory cannot fail; qed");
+			BigEndian::read_u64(&buf[24..]) as usize
+		};
+
+		let base_len = read_len(&mut reader);
+		let exp_len = read_len(&mut reader);
+		let mod_len = read_len(&mut reader);
+
+		// read the numbers themselves.
+		let mut buf = vec![0; max(mod_len, max(base_len, exp_len))];
+		let mut read_num = |len| {
+			reader.read_exact(&mut buf[..len]).expect("reading from zero-extended memory cannot fail; qed");
+			BigUint::from_bytes_be(&buf[..len])
+		};
+
+		let base = read_num(base_len);
+		let exp = read_num(exp_len);
+		let modulus = read_num(mod_len);
+
+		// calculate modexp: exponentiation by squaring.
+		fn modexp(mut base: BigUint, mut exp: BigUint, modulus: BigUint) -> BigUint {
+			if base == BigUint::zero() || modulus <= BigUint::one() { return BigUint::zero() }
+
+			let mut result = BigUint::one();
+			base = base % &modulus;
+			while exp != BigUint::zero() {
+				// exp has to be on the right here to avoid move.
+				if BigUint::one() & &exp == BigUint::one() {
+					result = (result * &base) % &modulus;
+				}
+
+				exp = exp >> 1;
+				base = (base.clone() * base) % &modulus;
+			}
+
+			result
+		}
+
+		// write output to given memory, left padded to same length as the modulus.
+		let bytes = modexp(base, exp, modulus).to_bytes_be();
+		let res_start = mod_len - bytes.len();
+		output.write(res_start, &bytes);
+	}
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{Builtin, Linear, ethereum_builtin, Pricer};
+	use super::{Builtin, Linear, ethereum_builtin, Pricer, Modexp};
 	use ethjson;
 	use util::{U256, BytesRef};
 
@@ -296,9 +414,92 @@ mod tests {
 	}
 
 	#[test]
+	fn modexp() {
+		use rustc_serialize::hex::FromHex;
+
+		let f = Builtin {
+			pricer: Box::new(Modexp { divisor: 20 }),
+			native: ethereum_builtin("modexp"),
+			activate_at: 0,
+		};
+		// fermat's little theorem example.
+		{
+			let input = FromHex::from_hex("\
+				0000000000000000000000000000000000000000000000000000000000000001\
+				0000000000000000000000000000000000000000000000000000000000000020\
+				0000000000000000000000000000000000000000000000000000000000000020\
+				03\
+				fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e\
+				fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+			).unwrap();
+
+			let mut output = vec![0u8; 32];
+			let expected = FromHex::from_hex("0000000000000000000000000000000000000000000000000000000000000001").unwrap();
+			let expected_cost = 1638;
+
+			f.execute(&input[..], &mut BytesRef::Fixed(&mut output[..]));
+			assert_eq!(output, expected);
+			assert_eq!(f.cost(&input[..]), expected_cost.into());
+		}
+
+		// second example from EIP: zero base.
+		{
+			let input = FromHex::from_hex("\
+				0000000000000000000000000000000000000000000000000000000000000000\
+ 				0000000000000000000000000000000000000000000000000000000000000020\
+ 				0000000000000000000000000000000000000000000000000000000000000020\
+ 				fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e\
+ 				fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+			).unwrap();
+
+			let mut output = vec![0u8; 32];
+			let expected = FromHex::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap();
+			let expected_cost = 1638;
+
+			f.execute(&input[..], &mut BytesRef::Fixed(&mut output[..]));
+			assert_eq!(output, expected);
+			assert_eq!(f.cost(&input[..]), expected_cost.into());
+		}
+
+		// another example from EIP: zero-padding
+		{
+			let input = FromHex::from_hex("\
+				0000000000000000000000000000000000000000000000000000000000000001\
+				0000000000000000000000000000000000000000000000000000000000000002\
+				0000000000000000000000000000000000000000000000000000000000000020\
+				03\
+				ffff\
+				80"
+			).unwrap();
+
+			let mut output = vec![0u8; 32];
+			let expected = FromHex::from_hex("3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab").unwrap();
+			let expected_cost = 102;
+
+			f.execute(&input[..], &mut BytesRef::Fixed(&mut output[..]));
+			assert_eq!(output, expected);
+			assert_eq!(f.cost(&input[..]), expected_cost.into());
+		}
+	}
+
+	#[test]
 	#[should_panic]
 	fn from_unknown_linear() {
 		let _ = ethereum_builtin("foo");
+	}
+
+	#[test]
+	fn is_active() {
+		let pricer = Box::new(Linear { base: 10, word: 20} );
+		let b = Builtin {
+			pricer: pricer as Box<Pricer>,
+			native: ethereum_builtin("identity"),
+			activate_at: 100_000,
+		};
+
+		assert!(!b.is_active(99_999));
+		assert!(b.is_active(100_000));
+		assert!(b.is_active(100_001));
 	}
 
 	#[test]
@@ -307,12 +508,13 @@ mod tests {
 		let b = Builtin {
 			pricer: pricer as Box<Pricer>,
 			native: ethereum_builtin("identity"),
+			activate_at: 1,
 		};
 
-		assert_eq!(b.cost(0), U256::from(10));
-		assert_eq!(b.cost(1), U256::from(30));
-		assert_eq!(b.cost(32), U256::from(30));
-		assert_eq!(b.cost(33), U256::from(50));
+		assert_eq!(b.cost(&[0; 0]), U256::from(10));
+		assert_eq!(b.cost(&[0; 1]), U256::from(30));
+		assert_eq!(b.cost(&[0; 32]), U256::from(30));
+		assert_eq!(b.cost(&[0; 33]), U256::from(50));
 
 		let i = [0u8, 1, 2, 3];
 		let mut o = [255u8; 4];
@@ -327,13 +529,14 @@ mod tests {
 			pricing: ethjson::spec::Pricing::Linear(ethjson::spec::Linear {
 				base: 10,
 				word: 20,
-			})
+			}),
+			activate_at: None,
 		});
 
-		assert_eq!(b.cost(0), U256::from(10));
-		assert_eq!(b.cost(1), U256::from(30));
-		assert_eq!(b.cost(32), U256::from(30));
-		assert_eq!(b.cost(33), U256::from(50));
+		assert_eq!(b.cost(&[0; 0]), U256::from(10));
+		assert_eq!(b.cost(&[0; 1]), U256::from(30));
+		assert_eq!(b.cost(&[0; 32]), U256::from(30));
+		assert_eq!(b.cost(&[0; 33]), U256::from(50));
 
 		let i = [0u8, 1, 2, 3];
 		let mut o = [255u8; 4];

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -266,8 +266,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 			// Engines aren't supposed to return builtins until activation, but
 			// prefer to fail rather than silently break consensus.
 			if !builtin.is_active(self.info.number) {
-				let msg = format!("Engine returned unactivated built-in at {}", params.code_address);
-				return Err(evm::Error::Internal(msg));
+				panic!("Consensus failure: engine implementation prematurely enabled built-in at {}", params.code_address);
 			}
 
 			let default = [];

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -261,17 +261,23 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 		}
 		trace!("Executive::call(params={:?}) self.env_info={:?}", params, self.info);
 
-		if self.engine.is_builtin(&params.code_address) {
-			// if destination is builtin, try to execute it
+		// if destination is builtin, try to execute it
+		if let Some(builtin) = self.engine.builtin(&params.code_address, self.info.number) {
+			// Engines aren't supposed to return builtins until activation, but
+			// prefer to fail rather than silently break consensus.
+			if !builtin.is_active(self.info.number) {
+				let msg = format!("Engine returned unactivated built-in at {}", params.code_address);
+				return Err(evm::Error::Internal(msg));
+			}
 
 			let default = [];
 			let data = if let Some(ref d) = params.data { d as &[u8] } else { &default as &[u8] };
 
 			let trace_info = tracer.prepare_trace_call(&params);
 
-			let cost = self.engine.cost_of_builtin(&params.code_address, data);
+			let cost = builtin.cost(data);
 			if cost <= params.gas {
-				self.engine.execute_builtin(&params.code_address, data, &mut output);
+				builtin.execute(data, &mut output);
 				self.state.discard_checkpoint();
 
 				// trace only top level calls to builtins to avoid DDoS attacks

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -106,6 +106,7 @@ extern crate ethcore_stratum;
 extern crate ethabi;
 extern crate hardware_wallet;
 extern crate stats;
+extern crate num;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Implements [EIP198](https://github.com/ethereum/EIPs/pull/198) with exponentiation by squaring.

Changes to built-in declaration: optional `activate_at` field, defaults to 0. Built-ins won't be available  from the `Engine` until activated. Replaces the `builtin_cost`, `execute_builtin`, and `is_builtin` of engine with a single `builtin(&Address, block_number) -> Option<&Builtin>`, reducing the amount of lookups done.

Could use a few more test cases, although I expect the consensus tests will cover this in detail.

`num::BigUint` is known to be much slower than GMP. `ramp` is a faster pure-Rust alternative, but requires nightly. If this calculation starts to become a bottleneck, we can move to GMP.