### PR TITLE
systemd: Start parity after network.target

### DIFF
--- a/scripts/parity.service
+++ b/scripts/parity.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Parity Daemon
+After=network.target
 
 [Service]
 EnvironmentFile=%h/.parity/parity.conf


### PR DESCRIPTION
This allows parity to cleanly terminate connections before going down, instead of abruptly losing connectivity for ongoing connections, leaving them in an undefined state ([NetworkTarget - freedesktop.org](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/)).