### PR TITLE
Fix references to api outside of `parity.js`

### DIFF
--- a/js/src/dapps/registry/Application/application.js
+++ b/js/src/dapps/registry/Application/application.js
@@ -23,6 +23,7 @@ import CircularProgress from 'material-ui/CircularProgress';
 import { Card, CardText } from 'material-ui/Card';
 
 import { nullableProptype } from '~/util/proptypes';
+import { api } from '../parity';
 
 import styles from './application.css';
 import Accounts from '../Accounts';
@@ -39,7 +40,7 @@ export default class Application extends Component {
   };
 
   getChildContext () {
-    return { muiTheme, api: window.parity.api };
+    return { muiTheme, api };
   }
 
   static propTypes = {
@@ -49,7 +50,6 @@ export default class Application extends Component {
   };
 
   render () {
-    const { api } = window.parity;
     const { contract, fee } = this.props;
     let warning = null;
 

--- a/js/src/dapps/tokenreg/Accounts/actions.js
+++ b/js/src/dapps/tokenreg/Accounts/actions.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-const { api } = window.parity;
+import { api } from '../parity';
 
 export const SET_ACCOUNTS = 'SET_ACCOUNTS';
 export const setAccounts = (accounts) => ({

--- a/js/src/dapps/tokenreg/Status/actions.js
+++ b/js/src/dapps/tokenreg/Status/actions.js
@@ -17,8 +17,7 @@
 import Contracts from '~/contracts';
 
 import { loadToken, setTokenPending, deleteToken, setTokenData } from '../Tokens/actions';
-
-const { api } = window.parity;
+import { api } from '../parity';
 
 export const SET_LOADING = 'SET_LOADING';
 export const setLoading = (isLoading) => ({

--- a/js/src/dapps/tokenreg/Status/status.js
+++ b/js/src/dapps/tokenreg/Status/status.js
@@ -16,11 +16,10 @@
 
 import React, { Component, PropTypes } from 'react';
 
+import { api } from '../parity';
 import Chip from '../Chip';
 
 import styles from './status.css';
-
-const { api } = window.parity;
 
 export default class Status extends Component {
   static propTypes = {

--- a/js/src/dapps/tokenreg/Tokens/actions.js
+++ b/js/src/dapps/tokenreg/Tokens/actions.js
@@ -16,8 +16,9 @@
 
 import { URL_TYPE } from '../Inputs/validation';
 import { getTokenTotalSupply, urlToHash } from '../utils';
+import { api } from '../parity';
 
-const { bytesToHex } = window.parity.api.util;
+const { bytesToHex } = api.util;
 
 export const SET_TOKENS_LOADING = 'SET_TOKENS_LOADING';
 export const setTokensLoading = (isLoading) => ({


### PR DESCRIPTION
Fixes #4966 