### PR TITLE
Fix FireFox overflows

### DIFF
--- a/js/src/ui/Container/container.css
+++ b/js/src/ui/Container/container.css
@@ -24,6 +24,7 @@ $transitionAll: all 0.75s cubic-bezier(0.23, 1, 0.32, 1);
   flex: 1;
   height: 100%;
   padding: 0em;
+  max-width: 100%;
   position: relative;
   /*transform: translateZ(0);
   transition: $transitionAll;*/

--- a/js/src/ui/SectionList/sectionList.css
+++ b/js/src/ui/SectionList/sectionList.css
@@ -18,6 +18,7 @@
 $transition: all 0.25s;
 $widthNormal: 33.33%;
 $widthExpanded: 42%;
+$widthContracted: 29%;
 
 .section {
   position: relative;
@@ -45,6 +46,7 @@ $widthExpanded: 42%;
       display: flex;
       flex: 0 1 $widthNormal;
       max-width: $widthNormal;
+      min-width: $widthContracted;
       opacity: 0.85;
       padding: 0.25em;
 


### PR DESCRIPTION
Originally reported by @General-Beck , Closes https://github.com/paritytech/parity/issues/4998

Changes -

- Add max-width to Container to actually shrink via flex
- Set min-width on SectionList item as guidance on where to shrink to

Tested on Chrome, FireFox & Safari (they all look consistent now)
