### PR TITLE
Set earliest era in snapshot restoration

### DIFF
--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -166,7 +166,7 @@ impl Restoration {
 		}
 
 		// check for missing code.
-		self.state.check_missing()?;
+		self.state.finalize(self.manifest.block_number, self.manifest.block_hash)?;
 
 		// connect out-of-order chunks and verify chain integrity.
 		self.blocks.finalize(self.canonical_hashes)?;


### PR DESCRIPTION
...otherwise when we start the client after restoring from a file, initializing the genesis state will set `earliest_era` to 0. This causes the pruning loop to try and prune states all the way from the genesis.