### PR TITLE
Add lint:i18n to find missing & extra keys

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -53,6 +53,7 @@
     "lint:cached": "npm run lint:css && npm run lint:js:cached",
     "lint:css": "stylelint ./src/**/*.css",
     "lint:fix": "npm run lint:js:fix",
+    "lint:i18n": "babel-node ./scripts/lint-i18n.js",
     "lint:js": "eslint --ignore-path .gitignore ./src/",
     "lint:js:cached": "eslint --cache --ignore-path .gitignore ./src/",
     "lint:js:fix": "eslint --fix --ignore-path .gitignore ./src/",

--- a/js/scripts/lint-i18n.js
+++ b/js/scripts/lint-i18n.js
@@ -1,0 +1,50 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import flatten from 'flat';
+
+import * as defaults from '../src/i18n/_default';
+import { MESSAGES } from '../src/i18n/store';
+
+const SKIP_LANG = ['en'];
+const DEFAULTS = flatten(defaults);
+
+Object
+  .keys(MESSAGES)
+  .filter((lang) => !SKIP_LANG.includes(lang))
+  .forEach((lang) => {
+    const messages = MESSAGES[lang];
+    let found = 0;
+    let missing = 0;
+    let total = 0;
+
+    console.log(`*** Checking translations for ${lang}`);
+
+    Object
+      .keys(DEFAULTS)
+      .forEach((key) => {
+        total++;
+
+        if (messages[key]) {
+          found++;
+        } else {
+          missing++;
+          console.log(`  Missing ${key}`);
+        }
+      });
+
+    console.log(`Checked ${total}, found ${found} keys, missing ${missing} keys\n`);
+  });

--- a/js/scripts/lint-i18n.js
+++ b/js/scripts/lint-i18n.js
@@ -17,34 +17,37 @@
 import flatten from 'flat';
 
 import * as defaults from '../src/i18n/_default';
-import { MESSAGES } from '../src/i18n/store';
+import { LANGUAGES, MESSAGES } from '../src/i18n/store';
 
 const SKIP_LANG = ['en'];
-const DEFAULTS = flatten(defaults);
+const defaultKeys = Object.keys(flatten(Object.assign({}, defaults, LANGUAGES)));
 
 Object
   .keys(MESSAGES)
   .filter((lang) => !SKIP_LANG.includes(lang))
   .forEach((lang) => {
-    const messages = MESSAGES[lang];
+    const messageKeys = Object.keys(MESSAGES[lang]);
+    let extra = 0;
     let found = 0;
     let missing = 0;
-    let total = 0;
 
     console.log(`*** Checking translations for ${lang}`);
 
-    Object
-      .keys(DEFAULTS)
-      .forEach((key) => {
-        total++;
+    defaultKeys.forEach((key) => {
+      if (messageKeys.includes(key)) {
+        found++;
+      } else {
+        missing++;
+        console.log(`  Missing ${key}`);
+      }
+    });
 
-        if (messages[key]) {
-          found++;
-        } else {
-          missing++;
-          console.log(`  Missing ${key}`);
-        }
-      });
+    messageKeys.forEach((key) => {
+      if (!defaultKeys.includes(key)) {
+        extra++;
+        console.log(`  Extra ${key}`);
+      }
+    });
 
-    console.log(`Checked ${total}, found ${found} keys, missing ${missing} keys\n`);
+    console.log(`Found ${found} keys, missing ${missing} keys, ${extra} extraneous keys\n`);
   });

--- a/js/src/i18n/store.js
+++ b/js/src/i18n/store.js
@@ -72,5 +72,6 @@ export default class Store {
 }
 
 export {
+  LANGUAGES,
   MESSAGES
 };

--- a/js/src/i18n/store.js
+++ b/js/src/i18n/store.js
@@ -70,3 +70,7 @@ export default class Store {
     return instance;
   }
 }
+
+export {
+  MESSAGES
+};


### PR DESCRIPTION
Add `npm run lint:i18n` reporting the missing keys (found in original, not in translation) as well as any extra keys (found in translation, not found in original)

```
*** Checking translations for de
  Missing account.button.delete
  Missing account.button.edit
  Missing account.button.password
...
  Missing walletSettings.rejected.busyStep.title
  Missing walletSettings.rejected.title
  Missing web.requestToken
Found 41 keys, missing 465 keys, 0 extraneous keys

*** Checking translations for nl
Found 506 keys, missing 0 keys, 0 extraneous keys
```