### PR TITLE
Fix default list sorting

### DIFF
--- a/js/src/ui/Actionbar/Sort/sortStore.js
+++ b/js/src/ui/Actionbar/Sort/sortStore.js
@@ -47,7 +47,9 @@ export default class SortStore {
   @action restoreSavedOrder = () => {
     const order = this.getSavedOrder();
 
-    this.onChange(order);
+    if (order) {
+      this.onChange(order);
+    }
   }
 
   getSavedOrder = () => {

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -66,7 +66,7 @@ class Contracts extends Component {
   state = {
     addContract: false,
     deployContract: false,
-    sortOrder: 'blockNumber',
+    sortOrder: 'blockNumber:-1',
     searchValues: [],
     searchTokens: []
   }
@@ -121,18 +121,16 @@ class Contracts extends Component {
   }
 
   renderSortButton () {
-    const onChange = (sortOrder) => {
-      this.setState({ sortOrder });
-    };
+    const { sortOrder } = this.state;
 
     return (
       <ActionbarSort
         key='sortAccounts'
         id='sortContracts'
-        order={ this.state.sortOrder }
+        order={ sortOrder }
         metas={ META_SORT }
         showDefault={ false }
-        onChange={ onChange }
+        onChange={ this.handleSortChange }
       />
     );
   }
@@ -237,6 +235,11 @@ class Contracts extends Component {
         onClose={ this.onDeployContractClose }
       />
     );
+  }
+
+  handleSortChange = (sortOrder) => {
+  console.warn('handle sort change', { sortOrder });
+    this.setState({ sortOrder });
   }
 
   onAddSearchToken = (token) => {

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -238,7 +238,6 @@ class Contracts extends Component {
   }
 
   handleSortChange = (sortOrder) => {
-  console.warn('handle sort change', { sortOrder });
     this.setState({ sortOrder });
   }
 


### PR DESCRIPTION
Should close #5292 
As stated, the default sorting for contracts is by mined block number if available. Otherwise, should be by name.