### PR TITLE
Fix eth_sign showing as wallet account

### DIFF
--- a/js/src/views/Account/account.js
+++ b/js/src/views/Account/account.js
@@ -59,8 +59,6 @@ class Account extends Component {
   componentDidMount () {
     this.props.fetchCertifiers();
     this.setVisibleAccounts();
-
-    this.context.api.eth.sign(this.props.params.address, '0xdeadbeef');
   }
 
   componentWillReceiveProps (nextProps) {

--- a/js/src/views/Account/account.js
+++ b/js/src/views/Account/account.js
@@ -59,6 +59,8 @@ class Account extends Component {
   componentDidMount () {
     this.props.fetchCertifiers();
     this.setVisibleAccounts();
+
+    this.context.api.eth.sign(this.props.params.address, '0xdeadbeef');
   }
 
   componentWillReceiveProps (nextProps) {

--- a/js/src/views/Signer/components/RequestPending/requestPending.spec.js
+++ b/js/src/views/Signer/components/RequestPending/requestPending.spec.js
@@ -92,7 +92,7 @@ describe('views/Signer/RequestPending', () => {
     });
 
     it('renders SignRequest component', () => {
-      expect(component.find('SignRequest')).to.have.length(1);
+      expect(component.find('Connect(SignRequest)')).to.have.length(1);
     });
   });
 

--- a/js/src/views/Signer/components/SignRequest/signRequest.js
+++ b/js/src/views/Signer/components/SignRequest/signRequest.js
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+import { observer } from 'mobx-react';
 import React, { Component, PropTypes } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { observer } from 'mobx-react';
+import { connect } from 'react-redux';
 
 import Account from '../Account';
 import TransactionPendingForm from '../TransactionPendingForm';
@@ -36,12 +37,13 @@ function isAscii (data) {
 }
 
 @observer
-export default class SignRequest extends Component {
+class SignRequest extends Component {
   static contextTypes = {
     api: PropTypes.object
   };
 
   static propTypes = {
+    accounts: PropTypes.object.isRequired,
     address: PropTypes.string.isRequired,
     data: PropTypes.string.isRequired,
     id: PropTypes.object.isRequired,
@@ -152,7 +154,10 @@ export default class SignRequest extends Component {
   }
 
   renderActions () {
-    const { address, focus, isFinished, status } = this.props;
+    const { accounts, address, focus, isFinished, status } = this.props;
+    const account = Object
+      .values(accounts)
+      .find((account) => address === account.address.toLowerCase());
 
     if (isFinished) {
       if (status === 'confirmed') {
@@ -182,6 +187,7 @@ export default class SignRequest extends Component {
 
     return (
       <TransactionPendingForm
+        account={ account }
         address={ address }
         focus={ focus }
         isSending={ this.props.isSending }
@@ -203,3 +209,16 @@ export default class SignRequest extends Component {
     this.props.onReject(this.props.id);
   }
 }
+
+function mapStateToProps (state) {
+  const { accounts } = state.personal;
+
+  return {
+    accounts
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null
+)(SignRequest);

--- a/js/src/views/Signer/components/SignRequest/signRequest.spec.js
+++ b/js/src/views/Signer/components/SignRequest/signRequest.spec.js
@@ -20,15 +20,53 @@ import sinon from 'sinon';
 
 import SignRequest from './';
 
-const store = {
-  balances: {},
-  fetchBalance: sinon.stub()
-};
+let component;
+let reduxStore;
+let signerStore;
+
+function createSignerStore () {
+  return {
+    balances: {},
+    fetchBalance: sinon.stub()
+  };
+}
+
+function createReduxStore () {
+  return {
+    dispatch: sinon.stub(),
+    subscribe: sinon.stub(),
+    getState: () => {
+      return {
+        personal: {
+          accounts: {}
+        }
+      };
+    }
+  };
+}
+
+function render () {
+  reduxStore = createReduxStore();
+  signerStore = createSignerStore();
+
+  component = shallow(
+    <SignRequest signerStore={ signerStore } />,
+    {
+      context: {
+        store: reduxStore
+      }
+    }
+  ).find('SignRequest').shallow();
+
+  return component;
+}
 
 describe('views/Signer/components/SignRequest', () => {
+  beforeEach(() => {
+    render();
+  });
+
   it('renders', () => {
-    expect(shallow(
-      <SignRequest signerStore={ store } />,
-    )).to.be.ok;
+    expect(component).to.be.ok;
   });
 });

--- a/js/src/views/Signer/components/TransactionPendingForm/transactionPendingForm.js
+++ b/js/src/views/Signer/components/TransactionPendingForm/transactionPendingForm.js
@@ -25,7 +25,7 @@ import styles from './transactionPendingForm.css';
 
 export default class TransactionPendingForm extends Component {
   static propTypes = {
-    account: PropTypes.object.isRequired,
+    account: PropTypes.object,
     address: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
     isSending: PropTypes.bool.isRequired,
@@ -36,6 +36,7 @@ export default class TransactionPendingForm extends Component {
   };
 
   static defaultProps = {
+    account: {},
     focus: false
   };
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/parity/issues/5308

- Allow empty account in TransactionPendingForm (props warning)
- Find account for signing request (non-EIP155, find from value)
- Pass required account through to TransactionForm

![parity 2017-03-28 08-12-39](https://cloud.githubusercontent.com/assets/1424473/24391371/fe2c04b4-138e-11e7-8c09-28a75ba9ab82.png)
