### PR TITLE
Add ability to disallow API subscriptions

### DIFF
--- a/js/src/api/api.js
+++ b/js/src/api/api.js
@@ -26,7 +26,7 @@ import { isFunction } from './util/types';
 import { LocalAccountsMiddleware } from './local';
 
 export default class Api extends EventEmitter {
-  constructor (transport) {
+  constructor (transport, allowSubscriptions = true) {
     super();
 
     if (!transport || !isFunction(transport.execute)) {
@@ -45,7 +45,9 @@ export default class Api extends EventEmitter {
     this._trace = new Trace(transport);
     this._web3 = new Web3(transport);
 
-    this._subscriptions = new Subscriptions(this);
+    if (allowSubscriptions) {
+      this._subscriptions = new Subscriptions(this);
+    }
 
     // Doing a request here in test env would cause an error
     if (process.env.NODE_ENV !== 'test') {
@@ -112,10 +114,18 @@ export default class Api extends EventEmitter {
   }
 
   subscribe (subscriptionName, callback) {
+    if (!this._subscriptions) {
+      return Promise.resolve(1);
+    }
+
     return this._subscriptions.subscribe(subscriptionName, callback);
   }
 
   unsubscribe (subscriptionId) {
+    if (!this._subscriptions) {
+      return Promise.resolve(true);
+    }
+
     return this._subscriptions.unsubscribe(subscriptionId);
   }
 


### PR DESCRIPTION
Construct API with

```
const api = new Api(<transport>, false);
```

(default is true, i.e. subscriptions are allowed/active)