### PR TITLE
trigger js build release

### DIFF
--- a/js/scripts/test.js
+++ b/js/scripts/test.js
@@ -1,2 +1,1 @@
-// test script 9
-// trigger rebuild on master 15 Mar 2017, 11:19
+// test script 10


### PR DESCRIPTION
CI builds refer to non-existent js-precompiled/nightly branch. Builds fail since it is not available, e.g https://gitlab.ethcore.io/parity/parity/builds/51754

Trigger build after creation of relevant branch on js-precompiled.