### PR TITLE
Public node: perf and fixes

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -176,7 +176,7 @@
     "geopattern": "1.2.3",
     "isomorphic-fetch": "2.2.1",
     "js-sha3": "0.5.5",
-    "keythereum": "0.4.3",
+    "keythereum": "0.4.6",
     "lodash": "4.17.2",
     "loglevel": "1.4.1",
     "marked": "0.3.6",

--- a/js/src/api/local/accounts/accounts.js
+++ b/js/src/api/local/accounts/accounts.js
@@ -39,7 +39,8 @@ export default class Accounts {
   create (secret, password) {
     const privateKey = Buffer.from(secret.slice(2), 'hex');
 
-    return Account.fromPrivateKey(this.persist, privateKey, password)
+    return Account
+      .fromPrivateKey(this.persist, privateKey, password)
       .then((account) => {
         const { address } = account;
 
@@ -87,7 +88,8 @@ export default class Accounts {
       return false;
     }
 
-    return account.isValidPassword(password)
+    return account
+      .isValidPassword(password)
       .then((isValid) => {
         if (!isValid) {
           return false;

--- a/js/src/api/local/ethkey/index.js
+++ b/js/src/api/local/ethkey/index.js
@@ -22,7 +22,8 @@ export function createKeyObject (key, password) {
 }
 
 export function decryptPrivateKey (keyObject, password) {
-  return workerPool.getWorker()
+  return workerPool
+    .getWorker()
     .action('decryptPrivateKey', { keyObject, password })
     .then((privateKey) => {
       if (privateKey) {

--- a/js/src/api/local/ethkey/worker.js
+++ b/js/src/api/local/ethkey/worker.js
@@ -16,6 +16,7 @@
 
 import secp256k1 from 'secp256k1/js';
 import { keccak_256 as keccak256 } from 'js-sha3';
+import { bytesToHex } from '~/api/util/format';
 
 const isWorker = typeof self !== 'undefined';
 
@@ -106,10 +107,6 @@ const actions = {
     }
   }
 };
-
-function bytesToHex (bytes) {
-  return '0x' + Array.from(bytes).map(n => ('0' + n.toString(16)).slice(-2)).join('');
-}
 
 self.onmessage = function ({ data }) {
   const result = route(data);

--- a/js/src/api/local/ethkey/worker.js
+++ b/js/src/api/local/ethkey/worker.js
@@ -14,58 +14,107 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { keccak_256 as keccak256 } from 'js-sha3';
 import secp256k1 from 'secp256k1/js';
+import { keccak_256 as keccak256 } from 'js-sha3';
+
+const isWorker = typeof self !== 'undefined';
 
 // Stay compatible between environments
-if (typeof self !== 'object') {
+if (!isWorker) {
   const scope = typeof global === 'undefined' ? window : global;
 
   scope.self = scope;
 }
 
+// keythereum should never be used outside of the browser
+let keythereum = null;
+
+if (isWorker) {
+  require('keythereum/dist/keythereum');
+
+  keythereum = self.keythereum;
+}
+
+function route ({ action, payload }) {
+  if (action in actions) {
+    return actions[action](payload);
+  }
+
+  return null;
+}
+
+const actions = {
+  phraseToWallet (phrase) {
+    let secret = keccak256.array(phrase);
+
+    for (let i = 0; i < 16384; i++) {
+      secret = keccak256.array(secret);
+    }
+
+    while (true) {
+      secret = keccak256.array(secret);
+
+      const secretBuf = Buffer.from(secret);
+
+      if (secp256k1.privateKeyVerify(secretBuf)) {
+        // No compression, slice out last 64 bytes
+        const publicBuf = secp256k1.publicKeyCreate(secretBuf, false).slice(-64);
+        const address = keccak256.array(publicBuf).slice(12);
+
+        if (address[0] !== 0) {
+          continue;
+        }
+
+        const wallet = {
+          secret: bytesToHex(secretBuf),
+          public: bytesToHex(publicBuf),
+          address: bytesToHex(address)
+        };
+
+        return wallet;
+      }
+    }
+  },
+
+  verifySecret (secret) {
+    const key = Buffer.from(secret.slice(2), 'hex');
+
+    return secp256k1.privateKeyVerify(key);
+  },
+
+  createKeyObject ({ key, password }) {
+    key = Buffer.from(key);
+    password = Buffer.from(password);
+
+    const iv = keythereum.crypto.randomBytes(16);
+    const salt = keythereum.crypto.randomBytes(32);
+    const keyObject = keythereum.dump(password, key, salt, iv);
+
+    return JSON.stringify(keyObject);
+  },
+
+  decryptPrivateKey ({ keyObject, password }) {
+    password = Buffer.from(password);
+
+    try {
+      const key = keythereum.recover(password, keyObject);
+
+      // Convert to array to safely send from the worker
+      return Array.from(key);
+    } catch (e) {
+      return null;
+    }
+  }
+};
+
 function bytesToHex (bytes) {
   return '0x' + Array.from(bytes).map(n => ('0' + n.toString(16)).slice(-2)).join('');
 }
 
-// Logic ported from /ethkey/src/brain.rs
-function phraseToWallet (phrase) {
-  let secret = keccak256.array(phrase);
-
-  for (let i = 0; i < 16384; i++) {
-    secret = keccak256.array(secret);
-  }
-
-  while (true) {
-    secret = keccak256.array(secret);
-
-    const secretBuf = Buffer.from(secret);
-
-    if (secp256k1.privateKeyVerify(secretBuf)) {
-      // No compression, slice out last 64 bytes
-      const publicBuf = secp256k1.publicKeyCreate(secretBuf, false).slice(-64);
-      const address = keccak256.array(publicBuf).slice(12);
-
-      if (address[0] !== 0) {
-        continue;
-      }
-
-      const wallet = {
-        secret: bytesToHex(secretBuf),
-        public: bytesToHex(publicBuf),
-        address: bytesToHex(address)
-      };
-
-      return wallet;
-    }
-  }
-}
-
 self.onmessage = function ({ data }) {
-  const wallet = phraseToWallet(data);
+  const result = route(data);
 
-  postMessage(wallet);
-  close();
+  postMessage(result);
 };
 
 // Emulate a web worker in Node.js
@@ -73,9 +122,9 @@ class KeyWorker {
   postMessage (data) {
     // Force async
     setTimeout(() => {
-      const wallet = phraseToWallet(data);
+      const result = route(data);
 
-      this.onmessage({ data: wallet });
+      this.onmessage({ data: result });
     }, 0);
   }
 

--- a/js/src/api/local/ethkey/workerPool.js
+++ b/js/src/api/local/ethkey/workerPool.js
@@ -1,0 +1,61 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+// Allow a web worker in the browser, with a fallback for Node.js
+const hasWebWorkers = typeof Worker !== 'undefined';
+const KeyWorker = hasWebWorkers ? require('worker-loader!./worker')
+                                : require('./worker').KeyWorker;
+
+class WorkerContainer {
+  busy = false;
+  _worker = new KeyWorker();
+
+  action (action, payload) {
+    if (this.busy) {
+      throw new Error('Cannot issue an action on a busy worker!');
+    }
+
+    this.busy = true;
+
+    return new Promise((resolve, reject) => {
+      this._worker.postMessage({ action, payload });
+      this._worker.onmessage = ({ data }) => {
+        this.busy = false;
+        resolve(data);
+      };
+    });
+  }
+}
+
+class WorkerPool {
+  pool = [];
+
+  getWorker () {
+    let container = this.pool.find((container) => !container.busy);
+
+    if (container) {
+      return container;
+    }
+
+    container = new WorkerContainer();
+
+    this.pool.push(container);
+
+    return container;
+  }
+}
+
+export default new WorkerPool();

--- a/js/src/api/local/middleware.js
+++ b/js/src/api/local/middleware.js
@@ -60,7 +60,8 @@ export default class LocalAccountsMiddleware extends Middleware {
     register('parity_changePassword', ([address, oldPassword, newPassword]) => {
       const account = accounts.get(address);
 
-      return account.decryptPrivateKey(oldPassword)
+      return account
+        .decryptPrivateKey(oldPassword)
         .then((privateKey) => {
           if (!privateKey) {
             return false;

--- a/js/src/api/transport/jsonRpcBase.js
+++ b/js/src/api/transport/jsonRpcBase.js
@@ -80,12 +80,16 @@ export default class JsonRpcBase extends EventEmitter {
         const res = middleware.handle(method, params);
 
         if (res != null) {
-          const result = this._wrapSuccessResult(res);
-          const json = this.encode(method, params);
+          // If `res` isn't a promise, we need to wrap it
+          return Promise.resolve(res)
+            .then((res) => {
+              const result = this._wrapSuccessResult(res);
+              const json = this.encode(method, params);
 
-          Logging.send(method, params, { json, result });
+              Logging.send(method, params, { json, result });
 
-          return res;
+              return res;
+            });
         }
       }
 

--- a/js/src/api/util/format.js
+++ b/js/src/api/util/format.js
@@ -17,7 +17,7 @@
 import { range } from 'lodash';
 
 export function bytesToHex (bytes) {
-  return '0x' + bytes.map((b) => ('0' + b.toString(16)).slice(-2)).join('');
+  return '0x' + Buffer.from(bytes).toString('hex');
 }
 
 export function cleanupValue (value, type) {

--- a/js/src/modals/CreateAccount/NewAccount/newAccount.js
+++ b/js/src/modals/CreateAccount/NewAccount/newAccount.js
@@ -23,6 +23,7 @@ import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 import { Form, Input, IdentityIcon } from '~/ui';
 import PasswordStrength from '~/ui/Form/PasswordStrength';
 import { RefreshIcon } from '~/ui/Icons';
+import Loading from '~/ui/Loading';
 
 import ChangeVault from '../ChangeVault';
 import styles from '../createAccount.css';
@@ -170,7 +171,9 @@ export default class CreateAccount extends Component {
     const { accounts } = this.state;
 
     if (!accounts) {
-      return null;
+      return (
+        <Loading className={ styles.selector } size={ 1 } />
+      );
     }
 
     const identities = Object
@@ -204,6 +207,14 @@ export default class CreateAccount extends Component {
 
   createIdentities = () => {
     const { createStore } = this.props;
+
+    this.setState({
+      accounts: null,
+      selectedAddress: ''
+    });
+
+    createStore.setAddress('');
+    createStore.setPhrase('');
 
     return createStore
       .createIdentities()

--- a/js/src/modals/CreateAccount/NewAccount/newAccount.spec.js
+++ b/js/src/modals/CreateAccount/NewAccount/newAccount.spec.js
@@ -60,7 +60,6 @@ describe('modals/CreateAccount/NewAccount', () => {
 
       it('resets the accounts', () => {
         expect(instance.state.accounts).to.be.null;
-        // expect(Object.keys(instance.state.accounts).length).to.equal(7);
       });
 
       it('resets the initial selected value', () => {

--- a/js/src/modals/CreateAccount/NewAccount/newAccount.spec.js
+++ b/js/src/modals/CreateAccount/NewAccount/newAccount.spec.js
@@ -58,12 +58,13 @@ describe('modals/CreateAccount/NewAccount', () => {
         return instance.componentWillMount();
       });
 
-      it('creates initial accounts', () => {
-        expect(Object.keys(instance.state.accounts).length).to.equal(7);
+      it('resets the accounts', () => {
+        expect(instance.state.accounts).to.be.null;
+        // expect(Object.keys(instance.state.accounts).length).to.equal(7);
       });
 
-      it('sets the initial selected value', () => {
-        expect(instance.state.selectedAddress).to.equal(Object.keys(instance.state.accounts)[0]);
+      it('resets the initial selected value', () => {
+        expect(instance.state.selectedAddress).to.equal('');
       });
     });
   });

--- a/js/src/modals/CreateAccount/store.js
+++ b/js/src/modals/CreateAccount/store.js
@@ -69,7 +69,7 @@ export default class Store {
         return !(this.nameError || this.walletFileError);
 
       case 'fromNew':
-        return !(this.nameError || this.passwordRepeatError);
+        return !(this.nameError || this.passwordRepeatError) && this.hasAddress;
 
       case 'fromPhrase':
         return !(this.nameError || this.passwordRepeatError);
@@ -83,6 +83,10 @@ export default class Store {
       default:
         return false;
     }
+  }
+
+  @computed get hasAddress () {
+    return !!(this.address);
   }
 
   @computed get passwordRepeatError () {

--- a/js/src/modals/CreateAccount/store.spec.js
+++ b/js/src/modals/CreateAccount/store.spec.js
@@ -329,6 +329,7 @@ describe('modals/CreateAccount/Store', () => {
       describe('createType === fromNew', () => {
         beforeEach(() => {
           store.setCreateType('fromNew');
+          store.setAddress('0x0000000000000000000000000000000000000000');
         });
 
         it('returns true on no errors', () => {
@@ -337,11 +338,13 @@ describe('modals/CreateAccount/Store', () => {
 
         it('returns false on nameError', () => {
           store.setName('');
+
           expect(store.canCreate).to.be.false;
         });
 
         it('returns false on passwordRepeatError', () => {
           store.setPassword('testing');
+
           expect(store.canCreate).to.be.false;
         });
       });


### PR DESCRIPTION
- Introduced a worker pool for webworkers, which speeds up re-generating of preview avatars (apparently each worker has to JIT the js on it's own, over and over again).
- All keythereum related stuff is now done in workers as well, so the UI never hangs.
- Regenerating the avatars on the new account modal now shows a spinner.
- Restoring accounts from private keys, testing passwords and changing passwords now works as intended.