### PR TITLE
Add decryption to the UI (in the Signer)

### DIFF
--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -216,8 +216,8 @@ export function outSignerRequest (request) {
           break;
 
         case 'payload':
-          request[key].decrypt = outTransaction(request[key].decrypt);
-          request[key].sign = outTransaction(request[key].sign);
+          request[key].decrypt = outSigning(request[key].decrypt);
+          request[key].sign = outSigning(request[key].sign);
           request[key].signTransaction = outTransaction(request[key].signTransaction);
           request[key].sendTransaction = outTransaction(request[key].sendTransaction);
           break;
@@ -292,7 +292,6 @@ export function outTransaction (tx) {
             : null;
           break;
 
-        case 'address':
         case 'creates':
         case 'from':
         case 'to':
@@ -303,6 +302,20 @@ export function outTransaction (tx) {
   }
 
   return tx;
+}
+
+export function outSigning (payload) {
+  if (payload) {
+    Object.keys(payload).forEach((key) => {
+      switch (key) {
+        case 'address':
+          payload[key] = outAddress(payload[key]);
+          break;
+      }
+    });
+  }
+
+  return payload;
 }
 
 export function outTrace (trace) {

--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -216,8 +216,8 @@ export function outSignerRequest (request) {
           break;
 
         case 'payload':
-          request[key].decrypt = outSigning(request[key].decrypt);
-          request[key].sign = outSigning(request[key].sign);
+          request[key].decrypt = outSigningPayload(request[key].decrypt);
+          request[key].sign = outSigningPayload(request[key].sign);
           request[key].signTransaction = outTransaction(request[key].signTransaction);
           request[key].sendTransaction = outTransaction(request[key].sendTransaction);
           break;
@@ -304,7 +304,7 @@ export function outTransaction (tx) {
   return tx;
 }
 
-export function outSigning (payload) {
+export function outSigningPayload (payload) {
   if (payload) {
     Object.keys(payload).forEach((key) => {
       switch (key) {

--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -216,6 +216,8 @@ export function outSignerRequest (request) {
           break;
 
         case 'payload':
+          request[key].decrypt = outTransaction(request[key].decrypt);
+          request[key].sign = outTransaction(request[key].sign);
           request[key].signTransaction = outTransaction(request[key].signTransaction);
           request[key].sendTransaction = outTransaction(request[key].sendTransaction);
           break;
@@ -290,6 +292,7 @@ export function outTransaction (tx) {
             : null;
           break;
 
+        case 'address':
         case 'creates':
         case 'from':
         case 'to':

--- a/js/src/views/Signer/components/DecryptRequest/decryptRequest.js
+++ b/js/src/views/Signer/components/DecryptRequest/decryptRequest.js
@@ -23,21 +23,10 @@ import Account from '../Account';
 import TransactionPendingForm from '../TransactionPendingForm';
 import RequestOrigin from '../RequestOrigin';
 
-import styles from './signRequest.css';
-
-function isAscii (data) {
-  for (var i = 2; i < data.length; i += 2) {
-    let n = parseInt(data.substr(i, 2), 16);
-
-    if (n < 32 || n >= 128) {
-      return false;
-    }
-  }
-  return true;
-}
+import styles from '../SignRequest/signRequest.css';
 
 @observer
-class SignRequest extends Component {
+class DecryptRequest extends Component {
   static contextTypes = {
     api: PropTypes.object
   };
@@ -85,27 +74,6 @@ class SignRequest extends Component {
     );
   }
 
-  renderAsciiDetails (ascii) {
-    return (
-      <div className={ styles.signData }>
-        <p>{ascii}</p>
-      </div>
-    );
-  }
-
-  renderBinaryDetails (data) {
-    return (
-      <div className={ styles.signData }>
-        <p>
-          <FormattedMessage
-            id='signer.signRequest.unknownBinary'
-            defaultMessage='(Unknown binary data)'
-          />
-        </p>
-      </div>
-    );
-  }
-
   renderDetails () {
     const { api } = this.context;
     const { address, data, netVersion, origin, signerStore } = this.props;
@@ -132,23 +100,14 @@ class SignRequest extends Component {
         <div className={ styles.info } title={ api.util.sha3(data) }>
           <p>
             <FormattedMessage
-              id='signer.signRequest.request'
-              defaultMessage='A request to sign data using your account:'
+              id='signer.decryptRequest.request'
+              defaultMessage='A request to decrypt data using your account:'
             />
           </p>
-          {
-            isAscii(data)
-              ? this.renderAsciiDetails(api.util.hexToAscii(data))
-              : this.renderBinaryDetails(data)
-          }
-          <p>
-            <strong>
-              <FormattedMessage
-                id='signer.signRequest.warning'
-                defaultMessage='WARNING: This consequences of doing this may be grave. Confirm the request only if you are sure.'
-              />
-            </strong>
-          </p>
+
+          <div className={ styles.signData }>
+            <p>{ data }</p>
+          </div>
         </div>
       </div>
     );
@@ -164,7 +123,7 @@ class SignRequest extends Component {
           <div className={ styles.actions }>
             <span className={ styles.isConfirmed }>
               <FormattedMessage
-                id='signer.signRequest.state.confirmed'
+                id='signer.decryptRequest.state.confirmed'
                 defaultMessage='Confirmed'
               />
             </span>
@@ -176,7 +135,7 @@ class SignRequest extends Component {
         <div className={ styles.actions }>
           <span className={ styles.isRejected }>
             <FormattedMessage
-              id='signer.signRequest.state.rejected'
+              id='signer.decryptRequest.state.rejected'
               defaultMessage='Rejected'
             />
           </span>
@@ -221,4 +180,4 @@ function mapStateToProps (state) {
 export default connect(
   mapStateToProps,
   null
-)(SignRequest);
+)(DecryptRequest);

--- a/js/src/views/Signer/components/DecryptRequest/index.js
+++ b/js/src/views/Signer/components/DecryptRequest/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './decryptRequest';

--- a/js/src/views/Signer/components/RequestOrigin/requestOrigin.css
+++ b/js/src/views/Signer/components/RequestOrigin/requestOrigin.css
@@ -33,7 +33,7 @@
   }
 
   .hash {
-    margin-left: .2em;
+    margin-left: .5em;
   }
 
   .hash, .url {

--- a/js/src/views/Signer/components/RequestPending/requestPending.js
+++ b/js/src/views/Signer/components/RequestPending/requestPending.js
@@ -16,8 +16,9 @@
 
 import React, { Component, PropTypes } from 'react';
 
-import TransactionPending from '../TransactionPending';
+import DecryptRequest from '../DecryptRequest';
 import SignRequest from '../SignRequest';
+import TransactionPending from '../TransactionPending';
 
 export default class RequestPending extends Component {
   static propTypes = {
@@ -32,6 +33,7 @@ export default class RequestPending extends Component {
     onReject: PropTypes.func.isRequired,
     origin: PropTypes.object.isRequired,
     payload: PropTypes.oneOfType([
+      PropTypes.shape({ decrypt: PropTypes.object.isRequired }),
       PropTypes.shape({ sendTransaction: PropTypes.object.isRequired }),
       PropTypes.shape({ sign: PropTypes.object.isRequired }),
       PropTypes.shape({ signTransaction: PropTypes.object.isRequired })
@@ -56,6 +58,27 @@ export default class RequestPending extends Component {
           className={ className }
           focus={ focus }
           data={ sign.data }
+          id={ id }
+          isFinished={ false }
+          isSending={ isSending }
+          netVersion={ netVersion }
+          onConfirm={ this.onConfirm }
+          onReject={ onReject }
+          origin={ origin }
+          signerStore={ signerStore }
+        />
+      );
+    }
+
+    if (payload.decrypt) {
+      const { decrypt } = payload;
+
+      return (
+        <DecryptRequest
+          address={ decrypt.address }
+          className={ className }
+          focus={ focus }
+          data={ decrypt.msg }
           id={ id }
           isFinished={ false }
           isSending={ isSending }

--- a/js/src/views/Signer/components/SignRequest/signRequest.css
+++ b/js/src/views/Signer/components/SignRequest/signRequest.css
@@ -19,7 +19,7 @@
 
 .container {
   display: flex;
-  padding: 1.5em 0 1em;
+  padding: 1.5em 1em 1.5em 0;
 }
 
 .actions, .signDetails {
@@ -28,35 +28,43 @@
 }
 
 .signData {
-    border: 0.25em solid red;
-    padding: 0.5em;
-    margin-left: -2em;
-    overflow: auto;
-    max-height: 6em;
+  border: 0.25em solid red;
+  margin-left: 2em;
+  padding: 0.5em;
+  overflow: auto;
+  max-height: 6em;
+  max-width: calc(100% - 2em);
 }
 
 .signData > p {
-    color: white;
+  color: white;
 }
 
 .signDetails {
-  flex: 10;
+  flex: 1;
+  overflow: auto;
+}
+
+.account img {
+  display: inline-block;
+  height: 50px;
+  margin: 5px;
+  width: 50px;
 }
 
 .address, .info {
   box-sizing: border-box;
   display: inline-block;
-  width: 50%;
+  vertical-align: top;
 }
 
 .address {
-  padding-right: $accountPadding;
+  width: 40%;
 }
 
 .info {
-  padding: 0 30px;
   color: #E53935;
-  vertical-align: top;
+  width: 60%;
 }
 
 .info p:first-child {
@@ -80,11 +88,4 @@
 .actions {
   display: inline-block;
   min-height: $finishedHeight;
-}
-
-.signDetails img {
-  display: inline-block;
-  width: 50px;
-  height: 50px;
-  margin: 5px;
 }


### PR DESCRIPTION
Using `parity_decryptMessage` RPC call would crash the Signer.

NB : The QR Signer code might not work with these methods (signing and decrypting)