### PR TITLE
Force two decimals for USD conversion rate

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -163,7 +163,7 @@ impl GasPriceCalibrator {
 				let wei_per_usd: f32 = 1.0e18 / usd_per_eth;
 				let gas_per_tx: f32 = 21000.0;
 				let wei_per_gas: f32 = wei_per_usd * usd_per_tx / gas_per_tx;
-				info!(target: "miner", "Updated conversion rate to Ξ1 = {} ({} wei/gas)", Colour::White.bold().paint(format!("US${}", usd_per_eth)), Colour::Yellow.bold().paint(format!("{}", wei_per_gas)));
+				info!(target: "miner", "Updated conversion rate to Ξ1 = {} ({} wei/gas)", Colour::White.bold().paint(format!("US${:.2}", usd_per_eth)), Colour::Yellow.bold().paint(format!("{}", wei_per_gas)));
 				set_price(U256::from(wei_per_gas as u64));
 			});
 

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -640,7 +640,7 @@ impl Configuration {
 
 		info!(
 			"Using a fixed conversion rate of Ξ1 = {} ({} wei/gas)",
-			Colour::White.bold().paint(format!("US${}", usd_per_eth)),
+			Colour::White.bold().paint(format!("US${:.2}", usd_per_eth)),
 			Colour::Yellow.bold().paint(format!("{}", wei_per_gas))
 		);
 


### PR DESCRIPTION
> 2017-03-07 09:17:56  Updated conversion rate to Ξ1 = **US$19.4** (6136475000 wei/gas)

Cosmetic: force two decimals for USD conversion rate.