### PR TITLE
Correct contract address for EIP-86

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -46,7 +46,7 @@ pub fn contract_address(address_scheme: CreateContractAddress, sender: &Address,
 			From::from(stream.as_raw().sha3())
 		},
 		CreateContractAddress::FromCodeHash => {
-			let mut buffer = [0u8; 20 + 32];
+			let mut buffer = [0xffu8; 20 + 32];
 			&mut buffer[20..].copy_from_slice(&code_hash[..]);
 			From::from((&buffer[..]).sha3())
 		},

--- a/ethcore/src/types/transaction.rs
+++ b/ethcore/src/types/transaction.rs
@@ -127,7 +127,7 @@ impl From<ethjson::state::Transaction> for SignedTransaction {
 		};
 		match secret {
 			Some(s) => tx.sign(&s, None),
-			None => tx.null_sign(),
+			None => tx.null_sign(1),
 		}
 	}
 }
@@ -210,13 +210,13 @@ impl Transaction {
 	}
 
 	/// Add EIP-86 compatible empty signature.
-	pub fn null_sign(self) -> SignedTransaction {
+	pub fn null_sign(self, network_id: u64) -> SignedTransaction {
 		SignedTransaction {
 			transaction: UnverifiedTransaction {
 				unsigned: self,
 				r: U256::zero(),
 				s: U256::zero(),
-				v: 0,
+				v: network_id,
 				hash: 0.into(),
 			}.compute_hash(),
 			sender: UNSIGNED_SENDER,


### PR DESCRIPTION
Original code in #4697 was correct. `NULL_SENDER` used for address calculation is indeed 2^256-1