### PR TITLE
fix panickers in tree-route

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1270,7 +1270,7 @@ impl BlockChainClient for Client {
 	fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {
 		let chain = self.chain.read();
 		match chain.is_known(from) && chain.is_known(to) {
-			true => Some(chain.tree_route(from.clone(), to.clone())),
+			true => chain.tree_route(from.clone(), to.clone()),
 			false => None
 		}
 	}


### PR DESCRIPTION
Originally reported by @svyatonik

Periodic chain head announcements by light servers would compute tree-route to determine depth of common ancestor between previous announcements. If an announcement was made directly after warp-syncing from the genesis, the tree-route would traverse into missing blocks and panic would be triggered.

Beta not affected as the light server is disabled by default, but we may want to backport regardless.