### PR TITLE
Add the packaging metadata to build the parity snap

### DIFF
--- a/scripts/snapcraft.yaml
+++ b/scripts/snapcraft.yaml
@@ -17,6 +17,6 @@ apps:
 
 parts:
   parity:
-    source: .
+    source: ..
     plugin: rust
     build-packages: [g++, libudev-dev, libssl-dev, make, pkg-config]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: parity
+version: master
+summary: Fast, light, robust Ethereum implementation
+description: |
+  Parity's goal is to be the fastest, lightest, and most secure Ethereum
+  client. We are developing Parity using the sophisticated and cutting-edge
+  Rust programming language. Parity is licensed under the GPLv3, and can be
+  used for all your Ethereum needs.
+
+grade: devel
+confinement: strict
+
+apps:
+  parity:
+    command: parity
+    plugs: [network, network-bind]
+
+parts:
+  parity:
+    source: .
+    plugin: rust
+    build-packages: [g++, libudev-dev, libssl-dev, make, pkg-config]


### PR DESCRIPTION
This package will let you publish the latest parity in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.