### PR TITLE
fix json format of state snapshot

### DIFF
--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -461,7 +461,7 @@ fn execute_export_state(cmd: ExportState) -> Result<(), String> {
 	let at = cmd.at;
 	let mut i = 0usize;
 
-	out.write_fmt(format_args!("{{ \"state\": [", )).expect("Couldn't write to stream.");
+	out.write_fmt(format_args!("{{ \"state\": {{", )).expect("Couldn't write to stream.");
 	loop {
 		let accounts = client.list_accounts(at, last.as_ref(), 1000).ok_or("Specified block not found")?;
 		if accounts.is_empty() {
@@ -498,13 +498,11 @@ fn execute_export_state(cmd: ExportState) -> Result<(), String> {
 							break;
 						}
 
-						let mut si = 0;
 						for key in keys.into_iter() {
-							if si != 0 {
+							if last_storage.is_some() {
 								out.write(b",").expect("Write error");
 							}
 							out.write_fmt(format_args!("\n\t\"0x{}\": \"0x{}\"", key.hex(), client.storage_at(&account, &key, at).unwrap_or_else(Default::default).hex())).expect("Write error");
-							si += 1;
 							last_storage = Some(key);
 						}
 					}
@@ -519,7 +517,7 @@ fn execute_export_state(cmd: ExportState) -> Result<(), String> {
 			last = Some(account);
 		}
 	}
-	out.write_fmt(format_args!("\n]}}")).expect("Write error");
+	out.write_fmt(format_args!("\n}}}}")).expect("Write error");
 	info!("Export completed.");
 	Ok(())
 }


### PR DESCRIPTION
This fixes two issues that were resulting in invalid json for state snapshot exports. The first issue is a missing comma between storage keys every 1000 keys, like this:
```
"0x1a4f6321151f54085bab4d1f17bcca6800c483e40ba7f811bf1682464955ca88": "0x7448222c2268617368223a226331383736643364316537626166613966646365",
"0xedd8d9633393f1fae912ef22f43f0fad7bbff7e9012f2cdb3b25c41e7a5041dd": "0x0000000000000000000000000000000000000000000000000000000000000089",
"0xe3369c486faf53ed805570a6e56d8c7525e90dbc492f409ad25aa32285b46295": "0x643134326664646162636130323362616337306530613130366164646561227d"
"0x79ada0df808ddc8c2aa81d87015e839a1c12ba87b4593664b45153db6646ff7c": "0x6531616261227d00000000000000000000000000000000000000000000000000",
...
"0x6f947e281f6f627d03ed30d3596daa8749d4f09cb9213e8fdbeddca3da541827": "0x2c2268617368223a223866323865633532643461373333393035396136386366",
"0x0c193ec8c4ccb03b3c6a0652c2fbddc55f1fc18c4fdd8bbe86825e0e8b57f22e": "0x0000000000000000000000003d6f8823ad21cd299814b62d198d9001e67e20b3"
"0x3237d1919f9d769b6c74563e43df54f91acc374eb83cabd7ef95f43f0b7a2a4b": "0x6639646236396266356161653435333264326465363364346362633439623731",
```

The second issue is square brackets `[ ... ]` where they should be curly `{ ... }`:
```
"state":[
  "0x1067dcb77e3390563819a94907adb53a402dd707":{
    "balance":"0x260407a553800",
    "nonce":"0x2"
  },
  ....
]
```