### PR TITLE
Calculate post-constructors state root in spec at load time

### DIFF
--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -78,6 +78,7 @@ pub struct AccountDB<'db> {
 
 impl<'db> AccountDB<'db> {
 	/// Create a new AccountDB from an address.
+	#[allow(dead_code)]
 	pub fn new(db: &'db HashDB, address: &Address) -> Self {
 		Self::from_hash(db, address.sha3())
 	}
@@ -131,6 +132,7 @@ pub struct AccountDBMut<'db> {
 
 impl<'db> AccountDBMut<'db> {
 	/// Create a new AccountDB from an address.
+	#[allow(dead_code)]
 	pub fn new(db: &'db mut HashDB, address: &Address) -> Self {
 		Self::from_hash(db, address.sha3())
 	}

--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -77,6 +77,12 @@ pub struct AccountDB<'db> {
 }
 
 impl<'db> AccountDB<'db> {
+	/// Create a new AccountDB from an address.
+	#[cfg(test)]
+	pub fn new(db: &'db HashDB, address: &Address) -> Self {
+		Self::from_hash(db, address.sha3())
+	}
+
 	/// Create a new AcountDB from an address' hash.
 	pub fn from_hash(db: &'db HashDB, address_hash: H256) -> Self {
 		AccountDB {
@@ -125,12 +131,23 @@ pub struct AccountDBMut<'db> {
 }
 
 impl<'db> AccountDBMut<'db> {
+	/// Create a new AccountDB from an address.
+	#[cfg(test)]
+	pub fn new(db: &'db mut HashDB, address: &Address) -> Self {
+		Self::from_hash(db, address.sha3())
+	}
+
 	/// Create a new AcountDB from an address' hash.
 	pub fn from_hash(db: &'db mut HashDB, address_hash: H256) -> Self {
 		AccountDBMut {
 			db: db,
 			address_hash: address_hash,
 		}
+	}
+
+	#[cfg(test)]
+	pub fn immutable(&'db self) -> AccountDB<'db> {
+		AccountDB { db: self.db, address_hash: self.address_hash.clone() }
 	}
 }
 

--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -77,12 +77,6 @@ pub struct AccountDB<'db> {
 }
 
 impl<'db> AccountDB<'db> {
-	/// Create a new AccountDB from an address.
-	#[allow(dead_code)]
-	pub fn new(db: &'db HashDB, address: &Address) -> Self {
-		Self::from_hash(db, address.sha3())
-	}
-
 	/// Create a new AcountDB from an address' hash.
 	pub fn from_hash(db: &'db HashDB, address_hash: H256) -> Self {
 		AccountDB {
@@ -131,23 +125,12 @@ pub struct AccountDBMut<'db> {
 }
 
 impl<'db> AccountDBMut<'db> {
-	/// Create a new AccountDB from an address.
-	#[allow(dead_code)]
-	pub fn new(db: &'db mut HashDB, address: &Address) -> Self {
-		Self::from_hash(db, address.sha3())
-	}
-
 	/// Create a new AcountDB from an address' hash.
 	pub fn from_hash(db: &'db mut HashDB, address_hash: H256) -> Self {
 		AccountDBMut {
 			db: db,
 			address_hash: address_hash,
 		}
-	}
-
-	#[allow(dead_code)]
-	pub fn immutable(&'db self) -> AccountDB<'db> {
-		AccountDB { db: self.db, address_hash: self.address_hash.clone() }
 	}
 }
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -166,8 +166,7 @@ impl Client {
 		db: Arc<KeyValueDB>,
 		miner: Arc<Miner>,
 		message_channel: IoChannel<ClientIoMessage>,
-	) -> Result<Arc<Client>, ClientError> {
-
+	) -> Result<Arc<Client>, ::error::Error> {
 		let trie_spec = match config.fat_db {
 			true => TrieSpec::Fat,
 			false => TrieSpec::Secure,

--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -91,10 +91,17 @@ mod tests {
 
 	#[test]
 	fn ensure_db_good() {
+		::ethcore_logger::init_log();
+
 		let spec = new_morden();
 		let engine = &spec.engine;
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
+
+		println!("ensured DB good: GH state root = {}", genesis_header.state_root());
+
+		assert!(db.as_hashdb().contains(genesis_header.state_root()));
+
 		let s = State::from_existing(db, genesis_header.state_root().clone(), engine.account_start_nonce(), Default::default()).unwrap();
 		assert_eq!(s.balance(&"0000000000000000000000000000000000000001".into()).unwrap(), 1u64.into());
 		assert_eq!(s.balance(&"0000000000000000000000000000000000000002".into()).unwrap(), 1u64.into());

--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -91,16 +91,10 @@ mod tests {
 
 	#[test]
 	fn ensure_db_good() {
-		::ethcore_logger::init_log();
-
 		let spec = new_morden();
 		let engine = &spec.engine;
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
-
-		println!("ensured DB good: GH state root = {}", genesis_header.state_root());
-
-		assert!(db.as_hashdb().contains(genesis_header.state_root()));
 
 		let s = State::from_existing(db, genesis_header.state_root().clone(), engine.account_start_nonce(), Default::default()).unwrap();
 		assert_eq!(s.balance(&"0000000000000000000000000000000000000001".into()).unwrap(), 1u64.into());

--- a/ethcore/src/json_tests/chain.rs
+++ b/ethcore/src/json_tests/chain.rs
@@ -51,7 +51,7 @@ pub fn json_chain_test(json_data: &[u8], era: ChainEra) -> Vec<String> {
 					ChainEra::_Eip161 => ethereum::new_eip161_test(),
 					ChainEra::TransitionTest => ethereum::new_transition_test(),
 				};
-				spec.set_genesis_state(state);
+				spec.set_genesis_state(state).expect("Failed to overwrite genesis state");
 				spec.overwrite_genesis_params(genesis);
 				assert!(spec.is_state_root_valid());
 				spec

--- a/ethcore/src/pod_account.rs
+++ b/ethcore/src/pod_account.rs
@@ -16,7 +16,6 @@
 
 use util::*;
 use state::Account;
-use account_db::AccountDBMut;
 use ethjson;
 use types::account_diff::*;
 use rlp::{self, RlpStream};
@@ -64,7 +63,7 @@ impl PodAccount {
 	}
 
 	/// Place additional data into given hash DB.
-	pub fn insert_additional(&self, db: &mut AccountDBMut, factory: &TrieFactory) {
+	pub fn insert_additional(&self, db: &mut HashDB, factory: &TrieFactory) {
 		match self.code {
 			Some(ref c) if !c.is_empty() => { db.insert(c); }
 			_ => {}

--- a/ethcore/src/pod_account.rs
+++ b/ethcore/src/pod_account.rs
@@ -54,8 +54,6 @@ impl PodAccount {
 
 	/// Returns the RLP for this account.
 	pub fn rlp(&self) -> Bytes {
-		println!("creating RLP for account: {:?}", self);
-
 		let mut stream = RlpStream::new_list(4);
 		stream.append(&self.nonce);
 		stream.append(&self.balance);

--- a/ethcore/src/pod_account.rs
+++ b/ethcore/src/pod_account.rs
@@ -54,6 +54,8 @@ impl PodAccount {
 
 	/// Returns the RLP for this account.
 	pub fn rlp(&self) -> Bytes {
+		println!("creating RLP for account: {:?}", self);
+
 		let mut stream = RlpStream::new_list(4);
 		stream.append(&self.nonce);
 		stream.append(&self.balance);

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -185,22 +185,19 @@ impl Spec {
 
 		// basic accounts in spec.
 		{
+			let mut t = factories.trie.create(db.as_hashdb_mut(), &mut root);
+
 			for (address, account) in self.genesis_state.get().iter() {
-				let mut t = factories.trie.create(db.as_hashdb_mut(), &mut root);
 				t.insert(&**address, &account.rlp())?;
 			}
+		}
 
-			println!("root after writing accounts: {}", root);
-
-			for (address, account) in self.genesis_state.get().iter() {
-				db.note_non_null_account(address);
-				account.insert_additional(
-					&mut *factories.accountdb.create(db.as_hashdb_mut(), address.sha3()),
-					&factories.trie
-				);
-			}
-
-			println!("root after writing storage: {}", root);
+		for (address, account) in self.genesis_state.get().iter() {
+			db.note_non_null_account(address);
+			account.insert_additional(
+				&mut *factories.accountdb.create(db.as_hashdb_mut(), address.sha3()),
+				&factories.trie
+			);
 		}
 
 		let start_nonce = self.engine.account_start_nonce();
@@ -262,7 +259,6 @@ impl Spec {
 			state.drop()
 		};
 
-		println!("root after executing constructors: {}", root);
 		*self.state_root_memo.write() = root;
 		Ok(db)
 	}
@@ -352,8 +348,6 @@ impl Spec {
 
 	/// Ensure that the given state DB has the trie nodes in for the genesis state.
 	pub fn ensure_db_good(&self, db: StateDB, factories: &Factories) -> Result<StateDB, Error> {
-		println!("calling ensure_db_good");
-
 		if db.as_hashdb().contains(&self.state_root()) {
 			return Ok(db)
 		}

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -354,8 +354,6 @@ impl Spec {
 
 		// TODO: could optimize so we don't re-run, but `ensure_db_good` is barely ever
 		// called anyway.
-		//
-		// call with boxed_clone so things don't stick around in cache forever.
 		let db = self.run_constructors(factories, db)?;
 
 		Ok(db)

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -133,7 +133,7 @@ fn load_from(s: ethjson::spec::Spec) -> Result<Spec, Error> {
 	let GenericSeal(seal_rlp) = g.seal.into();
 	let params = CommonParams::from(s.params);
 
-	let s = Spec {
+	let mut s = Spec {
 		name: s.name.clone().into(),
 		params: params.clone(),
 		engine: Spec::engine(s.engine, params, builtins),
@@ -154,7 +154,11 @@ fn load_from(s: ethjson::spec::Spec) -> Result<Spec, Error> {
 		genesis_state: s.accounts.into(),
 	};
 
-	let _ = s.run_constructors(&Default::default(), BasicBackend(MemoryDB::new()))?;
+	// use memoized state root if provided.
+	match g.state_root {
+		Some(root) => *s.state_root_memo.get_mut() = root,
+		None => { let _ = s.run_constructors(&Default::default(), BasicBackend(MemoryDB::new()))?; },
+	}
 
 	Ok(s)
 }

--- a/ethcore/src/state/backend.rs
+++ b/ethcore/src/state/backend.rs
@@ -206,7 +206,8 @@ impl<H: AsHashDB> Proving<H> {
 		}
 	}
 
-	/// Consume the backend, extracting the gathered proof.
+	/// Consume the backend, extracting the gathered proof in lexicographical order
+	/// by value.
 	pub fn extract_proof(self) -> Vec<DBValue> {
 		self.proof.into_inner().into_iter().collect()
 	}
@@ -220,4 +221,34 @@ impl<H: AsHashDB + Clone> Clone for Proving<H> {
 			proof: Mutex::new(self.proof.lock().clone()),
 		}
 	}
+}
+
+/// A basic backend. Just wraps the given database, directly inserting into and deleting from
+/// it. Doesn't cache anything.
+pub struct Basic<H>(pub H);
+
+impl<H: AsHashDB + Send + Sync> Backend for Basic<H> {
+	fn as_hashdb(&self) -> &HashDB {
+		self.0.as_hashdb()
+	}
+
+	fn as_hashdb_mut(&mut self) -> &mut HashDB {
+		self.0.as_hashdb_mut()
+	}
+
+	fn add_to_account_cache(&mut self, _: Address, _: Option<Account>, _: bool) { }
+
+	fn cache_code(&self, _: H256, _: Arc<Vec<u8>>) { }
+
+	fn get_cached_account(&self, _: &Address) -> Option<Option<Account>> { None }
+
+	fn get_cached<F, U>(&self, _: &Address, _: F) -> Option<U>
+		where F: FnOnce(Option<&mut Account>) -> U
+	{
+		None
+	}
+
+	fn get_cached_code(&self, _: &H256) -> Option<Arc<Vec<u8>>> { None }
+	fn note_non_null_account(&self, _: &Address) { }
+	fn is_known_null(&self, _: &Address) -> bool { false }
 }

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -448,7 +448,9 @@ impl state::Backend for StateDB {
 	fn is_known_null(&self, address: &Address) -> bool {
 		trace!(target: "account_bloom", "Check account bloom: {:?}", address);
 		let bloom = self.account_bloom.lock();
-		!bloom.check(&*address.sha3())
+		let is_null = !bloom.check(&*address.sha3());
+		println!("is known null? {}", is_null);
+		is_null
 	}
 }
 

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -449,7 +449,6 @@ impl state::Backend for StateDB {
 		trace!(target: "account_bloom", "Check account bloom: {:?}", address);
 		let bloom = self.account_bloom.lock();
 		let is_null = !bloom.check(&*address.sha3());
-		println!("is known null? {}", is_null);
 		is_null
 	}
 }

--- a/rpc/src/v1/tests/eth.rs
+++ b/rpc/src/v1/tests/eth.rs
@@ -83,7 +83,7 @@ fn make_spec(chain: &BlockChain) -> Spec {
 	let genesis = Genesis::from(chain.genesis());
 	let mut spec = ethereum::new_frontier_test();
 	let state = chain.pre_state.clone().into();
-	spec.set_genesis_state(state);
+	spec.set_genesis_state(state).expect("unable to set genesis state");
 	spec.overwrite_genesis_params(genesis);
 	assert!(spec.is_state_root_valid());
 	spec


### PR DESCRIPTION
...fixes the issue described in https://github.com/paritytech/parity/pull/5488#issuecomment-297440063

Also uncovered a trie bug in the process. I just worked around for now, but I'll look into fixing it ASAP.