### PR TITLE
option to disable persistent txqueue

### DIFF
--- a/parity/cli/config.full.toml
+++ b/parity/cli/config.full.toml
@@ -7,6 +7,7 @@ release_track = "current"
 public_node = false
 no_download = false
 no_consensus = false
+no_persistent_txqueue = false
 
 chain = "homestead"
 base_path = "$HOME/.parity"

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -95,6 +95,8 @@ usage! {
 		flag_keys_path: String = "$BASE/keys", or |c: &Config| otry!(c.parity).keys_path.clone(),
 		flag_identity: String = "", or |c: &Config| otry!(c.parity).identity.clone(),
 		flag_light: bool = false, or |c: &Config| otry!(c.parity).light,
+		flag_no_persistent_txqueue: bool = false,
+			or |c: &Config| otry!(c.parity).no_persistent_txqueue,
 
 		// -- Account Options
 		flag_unlock: Option<String> = None,
@@ -345,7 +347,6 @@ usage! {
 		flag_no_color: bool = false,
 			or |c: &Config| otry!(c.misc).color.map(|c| !c).clone(),
 
-
 		// -- Legacy Options supported in configs
 		flag_dapps_port: Option<u16> = None,
 			or |c: &Config| otry!(c.dapps).port.clone().map(Some),
@@ -406,6 +407,7 @@ struct Operating {
 	keys_path: Option<String>,
 	identity: Option<String>,
 	light: Option<bool>,
+	no_persistent_txqueue: Option<bool>,
 }
 
 #[derive(Default, Debug, PartialEq, RustcDecodable)]
@@ -682,6 +684,7 @@ mod tests {
 			flag_keys_path: "$HOME/.parity/keys".into(),
 			flag_identity: "".into(),
 			flag_light: false,
+			flag_no_persistent_txqueue: false,
 
 			// -- Account Options
 			flag_unlock: Some("0xdeadbeefcafe0000000000000000000000000000".into()),
@@ -901,6 +904,7 @@ mod tests {
 				keys_path: None,
 				identity: None,
 				light: None,
+				no_persistent_txqueue: None,
 			}),
 			account: Some(Account {
 				unlock: Some(vec!["0x1".into(), "0x2".into(), "0x3".into()]),

--- a/parity/cli/usage.txt
+++ b/parity/cli/usage.txt
@@ -75,6 +75,9 @@ Operating Options:
                                    data on-demand from the network. Much lower in storage,
                                    potentially higher in bandwidth. Has no effect with
                                    subcommands (default: {flag_light}).
+  --no-persistent-txqueue          Don't save pending local transactions to disk to be
+                                   restored whenever the node restarts.
+                                   (default: {flag_no_persistent_txqueue}).
 
 Account Options:
   --unlock ACCOUNTS                Unlock ACCOUNTS for the duration of the execution.

--- a/parity/cli/usage.txt
+++ b/parity/cli/usage.txt
@@ -75,9 +75,6 @@ Operating Options:
                                    data on-demand from the network. Much lower in storage,
                                    potentially higher in bandwidth. Has no effect with
                                    subcommands (default: {flag_light}).
-  --no-persistent-txqueue          Don't save pending local transactions to disk to be
-                                   restored whenever the node restarts.
-                                   (default: {flag_no_persistent_txqueue}).
 
 Account Options:
   --unlock ACCOUNTS                Unlock ACCOUNTS for the duration of the execution.
@@ -307,6 +304,9 @@ Sealing/Mining Options:
                                    execution time limit. Also number of offending actions
                                    have to reach the threshold within that time.
                                    (default: {flag_tx_queue_ban_time} seconds)
+  --no-persistent-txqueue          Don't save pending local transactions to disk to be
+                                   restored whenever the node restarts.
+                                   (default: {flag_no_persistent_txqueue}).
   --remove-solved                  Move solved blocks from the work package queue
                                    instead of cloning them. This gives a slightly
                                    faster import speed, but means that extra solutions

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -388,6 +388,7 @@ impl Configuration {
 				verifier_settings: verifier_settings,
 				serve_light: !self.args.flag_no_serve_light,
 				light: self.args.flag_light,
+				no_persistent_txqueue: self.args.flag_no_persistent_txqueue,
 			};
 			Cmd::Run(run_cmd)
 		};
@@ -1270,6 +1271,7 @@ mod tests {
 			verifier_settings: Default::default(),
 			serve_light: true,
 			light: false,
+			no_persistent_txqueue: false,
 		};
 		expected.secretstore_conf.enabled = cfg!(feature = "secretstore");
 		assert_eq!(conf.into_command().unwrap().cmd, Cmd::Run(expected));

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -115,6 +115,7 @@ pub struct RunCmd {
 	pub verifier_settings: VerifierSettings,
 	pub serve_light: bool,
 	pub light: bool,
+	pub no_persistent_txqueue: bool,
 }
 
 pub fn open_ui(signer_conf: &signer::Configuration) -> Result<(), String> {
@@ -142,15 +143,20 @@ pub fn open_dapp(dapps_conf: &dapps::Configuration, rpc_conf: &rpc::HttpConfigur
 
 // node info fetcher for the local store.
 struct FullNodeInfo {
-	miner: Arc<Miner>, // TODO: only TXQ needed, just use that after decoupling.
+	miner: Option<Arc<Miner>>, // TODO: only TXQ needed, just use that after decoupling.
 }
 
 impl ::local_store::NodeInfo for FullNodeInfo {
 	fn pending_transactions(&self) -> Vec<::ethcore::transaction::PendingTransaction> {
-		let local_txs = self.miner.local_transactions();
-		self.miner.pending_transactions()
+		let miner = match self.miner.as_ref() {
+			Some(m) => m,
+			None => return Vec::new(),
+		};
+
+		let local_txs = miner.local_transactions();
+		miner.pending_transactions()
 			.into_iter()
-			.chain(self.miner.future_transactions())
+			.chain(miner.future_transactions())
 			.filter(|tx| local_txs.contains_key(&tx.hash()))
 			.collect()
 	}
@@ -515,10 +521,21 @@ pub fn execute(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>) -> R
 	let store = {
 		let db = service.db();
 		let node_info = FullNodeInfo {
-			miner: miner.clone(),
+			miner: match cmd.no_persistent_txqueue {
+				true => None,
+				false => Some(miner.clone()),
+			}
 		};
 
 		let store = ::local_store::create(db, ::ethcore::db::COL_NODE_INFO, node_info);
+
+		if cmd.no_persistent_txqueue {
+			info!("Running without a persistent transaction queue.");
+
+			if let Err(e) = store.clear() {
+				warn!("Error clearing persistent transaction queue: {}", e);
+			}
+		}
 
 		// re-queue pending transactions.
 		match store.pending_transactions() {


### PR DESCRIPTION
Introduces the `--no-persistent-txqueue` flag to both clear the existing persistent transaction queue and prevent local transactions created during the current session from being saved to disk.