### PR TITLE
reorg into blocks before minimum history

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -377,7 +377,7 @@ impl Client {
 		let chain = self.chain.read();
 		// Check the block isn't so old we won't be able to enact it.
 		let best_block_number = chain.best_block_number();
-		if best_block_number >= self.history && header.number() <= best_block_number - self.history {
+		if self.pruning_info().earliest_state > header.number() {
 			warn!(target: "client", "Block import failed for #{} ({})\nBlock is ancient (current best block: #{}).", header.number(), header.hash(), best_block_number);
 			return Err(());
 		}
@@ -770,7 +770,7 @@ impl Client {
 			let db = self.state_db.lock().boxed_clone();
 
 			// early exit for pruned blocks
-			if db.is_pruned() && self.chain.read().best_block_number() >= block_number + self.history {
+			if db.is_pruned() && self.pruning_info().earliest_state > block_number {
 				return None;
 			}
 
@@ -871,7 +871,7 @@ impl Client {
 		let best_block_number = self.chain_info().best_block_number;
 		let block_number = self.block_number(at).ok_or(snapshot::Error::InvalidStartingBlock(at))?;
 
-		if best_block_number > self.history + block_number && db.is_pruned() {
+		if db.is_pruned() && self.pruning_info().earliest_state > block_number {
 			return Err(snapshot::Error::OldBlockPrunedDB.into());
 		}
 


### PR DESCRIPTION
by using the dynamic `earliest_state` counter rather than the fixed minimum history size. Also does the same for RPCs and snapshot creation.

Should backport to beta and perhaps stable if memory-based pruning is implemented there.