### PR TITLE
Do not convert to Dates twice

### DIFF
--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -96,6 +96,12 @@ export function outDate (date) {
     return date;
   }
 
+  try {
+    if (typeof date === 'string' && (new Date(date)).toISOString() === date) {
+      return new Date(date);
+    }
+  } catch (error) {}
+
   return new Date(outNumber(date).toNumber() * 1000);
 }
 

--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -92,6 +92,10 @@ export function outChainStatus (status) {
 }
 
 export function outDate (date) {
+  if (typeof date.toISOString === 'function') {
+    return date;
+  }
+
   return new Date(outNumber(date).toNumber() * 1000);
 }
 


### PR DESCRIPTION
In API > outputFormat > outDate ; take into account input dates that are not numbers.