### PR TITLE
Remove formal verification messages in Dev Contract

### DIFF
--- a/js/src/views/WriteContract/writeContractStore.js
+++ b/js/src/views/WriteContract/writeContractStore.js
@@ -397,11 +397,10 @@ export default class WriteContractStore {
 
     const { errors = [] } = data;
     const errorAnnotations = this.parseErrors(errors);
-    const formalAnnotations = this.parseErrors(data.formal && data.formal.errors, true);
+    // const formalAnnotations = this.parseErrors(data.formal && data.formal.errors, true);
 
     const annotations = [].concat(
-      errorAnnotations,
-      formalAnnotations
+      errorAnnotations
     );
 
     const contractKeys = Object.keys(contracts || {});


### PR DESCRIPTION
It seems that (part of) the formal verification in Solc will be removed soon anyway (ethereum/solidity#2202), those messages are misleading: #5572 

(Keeping a reference if we want the show them in a special panel)