### PR TITLE
only enable warp sync when engine supports it

### DIFF
--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -296,6 +296,11 @@ pub trait Engine : Sync + Send {
 		None
 	}
 
+	/// Whether this engine supports warp sync.
+	fn supports_warp(&self) -> bool {
+		self.snapshot_components().is_some()
+	}
+
 	/// Returns new contract address generation scheme at given block number.
 	fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
 		if number >= self.params().eip86_transition { CreateContractAddress::FromCodeHash } else { CreateContractAddress::FromSenderAndNonce }

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -427,8 +427,9 @@ pub fn execute(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>) -> R
 	} else {
 		sync_config.subprotocol_name.clone_from_slice(spec.subprotocol_name().as_bytes());
 	}
+
 	sync_config.fork_block = spec.fork_block();
-	sync_config.warp_sync = cmd.warp_sync;
+	sync_config.warp_sync = spec.engine.supports_warp() && cmd.warp_sync;
 	sync_config.download_old_blocks = cmd.download_old_blocks;
 	sync_config.serve_light = cmd.serve_light;
 


### PR DESCRIPTION
Prevents stalled sync and spam of "Failed to initialize snapshot restoration".