### PR TITLE
Fix local transactions without condition.

### DIFF
--- a/js/src/ui/TxList/TxRow/txRow.js
+++ b/js/src/ui/TxList/TxRow/txRow.js
@@ -210,31 +210,36 @@ class TxRow extends Component {
 
     if (!isCancelOpen && !isEditOpen) {
       const pendingStatus = this.getCondition();
+      const isPending = pendingStatus === 'pending';
 
-      if (pendingStatus === 'submitting') {
-        return (
-          <div className={ styles.pending }>
-            <div />
-            <div className={ styles.uppercase }>
-              <FormattedMessage
-                id='ui.txList.txRow.submitting'
-                defaultMessage='Submitting'
-              />
-            </div>
-          </div>
-        );
-      }
       return (
         <div className={ styles.pending }>
-          <span>
-            { pendingStatus }
-          </span>
-          <div className={ styles.uppercase }>
-            <FormattedMessage
-              id='ui.txList.txRow.scheduled'
-              defaultMessage='Scheduled'
-            />
-          </div>
+          {
+            isPending
+            ? (
+              <div className={ styles.pending }>
+                <div />
+                <div className={ styles.uppercase }>
+                  <FormattedMessage
+                    id='ui.txList.txRow.submitting'
+                    defaultMessage='Pending'
+                  />
+                </div>
+              </div>
+            ) : (
+              <div>
+                <span>
+                  { pendingStatus }
+                </span>
+                <div className={ styles.uppercase }>
+                  <FormattedMessage
+                    id='ui.txList.txRow.scheduled'
+                    defaultMessage='Scheduled'
+                  />
+                </div>
+              </div>
+            )
+          }
           <a onClick={ this.setEdit } className={ styles.uppercase }>
             <FormattedMessage
               id='ui.txList.txRow.edit'
@@ -248,6 +253,16 @@ class TxRow extends Component {
               defaultMessage='Cancel'
             />
           </a>
+          { isPending
+            ? (
+              <div>
+                <FormattedMessage
+                  id='ui.txList.txRow.cancelWarning'
+                  defaultMessage='Warning: Editing or Canceling the transaction may not succeed!'
+                />
+              </div>
+            ) : null
+          }
         </div>
       );
     }
@@ -319,11 +334,10 @@ class TxRow extends Component {
 
   getCondition = () => {
     const { blockNumber, tx } = this.props;
-    let { time, block } = tx.condition;
+    let { time, block = 0 } = tx.condition || {};
 
     if (time) {
       if ((time.getTime() - Date.now()) >= 0) {
-        // return `${dateDifference(new Date(), time, { compact: true })} left`;
         return (
           <FormattedMessage
             id='ui.txList.txRow.pendingStatus.time'
@@ -333,14 +347,13 @@ class TxRow extends Component {
             } }
           />
         );
-      } else {
-        return 'submitting';
       }
-    } else if (blockNumber) {
+
+      return 'pending';
+    }
+
+    if (blockNumber) {
       block = blockNumber.minus(block);
-      // return (block.toNumber() < 0)
-      //   ? block.abs().toFormat(0) + ' blocks left'
-      //   : 'submitting';
       if (block.toNumber() < 0) {
         return (
           <FormattedMessage
@@ -351,9 +364,9 @@ class TxRow extends Component {
             } }
           />
         );
-      } else {
-        return 'submitting';
       }
+
+      return 'pending';
     }
   }
 


### PR DESCRIPTION
It was not possible to cancel transaction that didn't have a condition.
In fact no transaction was displayed, cause `TxRow` expected every transaction to always have a condition.

Closes #5715 