### PR TITLE
Ethereum Classic Monetary Policy

### DIFF
--- a/ethcore/res/ethereum/classic.json
+++ b/ethcore/res/ethereum/classic.json
@@ -16,6 +16,7 @@
 				"eip160Transition": 3000000,
 				"ecip1010PauseTransition": 3000000,
 				"ecip1010ContinueTransition": 5000000,
+				"ecip1017EraRounds": 5000000,
 
 				"eip161abcTransition": "0x7fffffffffffffff",
 				"eip161dTransition": "0x7fffffffffffffff"

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -276,7 +276,11 @@ impl Engine for Arc<Ethash> {
 		let mut reward = self.ethash_params.block_reward;
 		let fields = block.fields_mut();
 
-		let eras = fields.header.number() / self.ethash_params.ecip1017_era_rounds;
+		let eras = if fields.header.number() != 0 && fields.header.number() % self.ethash_params.ecip1017_era_rounds == 0 {
+			fields.header.number() / self.ethash_params.ecip1017_era_rounds - 1
+		} else {
+			fields.header.number() / self.ethash_params.ecip1017_era_rounds
+		};
 		for _ in 0..eras {
 			reward = reward / U256::from(5) * U256::from(4);
 		}

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -291,11 +291,19 @@ impl Engine for Arc<Ethash> {
 		// Bestow uncle rewards
 		let current_number = fields.header.number();
 		for u in fields.uncles.iter() {
-			fields.state.add_balance(
-				u.author(),
-				&(reward * U256::from(8 + u.number() - current_number) / U256::from(8)),
-				CleanupMode::NoEmpty
-			)?;
+			if eras == 0 {
+				fields.state.add_balance(
+					u.author(),
+					&(reward * U256::from(8 + u.number() - current_number) / U256::from(8)),
+					CleanupMode::NoEmpty
+				)
+			} else {
+				fields.state.add_balance(
+					u.author(),
+					&(reward / U256::from(32)),
+					CleanupMode::NoEmpty
+				)
+			}?;
 		}
 
 		// Commit state so that we can actually figure out the state root.

--- a/ethcore/src/tests/helpers.rs
+++ b/ethcore/src/tests/helpers.rs
@@ -418,6 +418,7 @@ pub fn get_default_ethash_params() -> EthashParams{
 		eip161d_transition: u64::max_value(),
 		ecip1010_pause_transition: u64::max_value(),
 		ecip1010_continue_transition: u64::max_value(),
+		ecip1017_era_rounds: u64::max_value(),
 		max_code_size: u64::max_value(),
 		max_gas_limit_transition: u64::max_value(),
 		max_gas_limit: U256::max_value(),

--- a/json/src/spec/ethash.rs
+++ b/json/src/spec/ethash.rs
@@ -101,6 +101,10 @@ pub struct EthashParams {
 	pub ecip1010_continue_transition: Option<Uint>,
 
 	/// See main EthashParams docs.
+	#[serde(rename="ecip1017EraRounds")]
+	pub ecip1017_era_rounds: Option<Uint>,
+
+	/// See main EthashParams docs.
 	#[serde(rename="maxCodeSize")]
 	pub max_code_size: Option<Uint>,
 


### PR DESCRIPTION
Create a new parameter `ecip1017EraRounds`. When the block number
passes one era rounds, the reward is reduced by 20%.

See https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1017.md