### PR TITLE
use NULL_RLP, remove NULL_RLP_STATIC

### DIFF
--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -18,8 +18,6 @@
 use util::*;
 use rlp::NULL_RLP;
 
-static NULL_RLP_STATIC: [u8; 1] = [0x80; 1];
-
 // combines a key with an address hash to ensure uniqueness.
 // leaves the first 96 bits untouched in order to support partial key lookup.
 #[inline]
@@ -99,7 +97,7 @@ impl<'db> HashDB for AccountDB<'db>{
 
 	fn get(&self, key: &H256) -> Option<DBValue> {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP_STATIC));
+			return Some(DBValue::from_slice(&NULL_RLP));
 		}
 		self.db.get(&combine_key(&self.address_hash, key))
 	}
@@ -158,7 +156,7 @@ impl<'db> HashDB for AccountDBMut<'db>{
 
 	fn get(&self, key: &H256) -> Option<DBValue> {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP_STATIC));
+			return Some(DBValue::from_slice(&NULL_RLP));
 		}
 		self.db.get(&combine_key(&self.address_hash, key))
 	}
@@ -206,7 +204,7 @@ impl<'db> HashDB for Wrapping<'db> {
 
 	fn get(&self, key: &H256) -> Option<DBValue> {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP_STATIC));
+			return Some(DBValue::from_slice(&NULL_RLP));
 		}
 		self.0.get(key)
 	}
@@ -240,7 +238,7 @@ impl<'db> HashDB for WrappingMut<'db>{
 
 	fn get(&self, key: &H256) -> Option<DBValue> {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP_STATIC));
+			return Some(DBValue::from_slice(&NULL_RLP));
 		}
 		self.0.get(key)
 	}

--- a/util/src/memorydb.rs
+++ b/util/src/memorydb.rs
@@ -122,7 +122,7 @@ impl MemoryDB {
 	/// when the refs > 0.
 	pub fn raw(&self, key: &H256) -> Option<(DBValue, i32)> {
 		if key == &SHA3_NULL_RLP {
-			return Some((DBValue::from_slice(&NULL_RLP_STATIC), 1));
+			return Some((DBValue::from_slice(&NULL_RLP), 1));
 		}
 		self.data.get(key).cloned()
 	}
@@ -172,12 +172,10 @@ impl MemoryDB {
 	}
 }
 
-static NULL_RLP_STATIC: [u8; 1] = [0x80; 1];
-
 impl HashDB for MemoryDB {
 	fn get(&self, key: &H256) -> Option<DBValue> {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP_STATIC));
+			return Some(DBValue::from_slice(&NULL_RLP));
 		}
 
 		match self.data.get(key) {


### PR DESCRIPTION
I thought `NULL_RLP_STATIC` was created for a reason, but I can't think of the specific reason, even the Rust book suggests we should prefer `const`. So this PR, but maybe it has other reasons, then feel free to close this PR.

`cargo build` and `cargo test` both seem ok.