### PR TITLE
update the source for the snapcraft package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,6 @@ apps:
 
 parts:
   parity:
-    source: ..
+    source: .
     plugin: rust
     build-packages: [g++, libudev-dev, libssl-dev, make, pkg-config]


### PR DESCRIPTION
The source attribute of the snapcraft.yaml is relative to the directory where snapcraft is called.
When there's a snap directory in the root of the proyect, snapcraft should be called from the root, and thus we were going back one extra directory.