### PR TITLE
Block invalid account name creation

### DIFF
--- a/js/src/modals/CreateAccount/createAccount.js
+++ b/js/src/modals/CreateAccount/createAccount.js
@@ -332,12 +332,10 @@ class CreateAccount extends Component {
     return this.createStore
       .createAccount(this.vaultStore)
       .then(() => {
-        this.createStore.setBusy(false);
         this.createStore.nextStage();
         this.props.onUpdate && this.props.onUpdate();
       })
       .catch((error) => {
-        this.createStore.setBusy(false);
         this.props.newError(error);
       });
   }

--- a/js/src/modals/CreateAccount/createAccount.js
+++ b/js/src/modals/CreateAccount/createAccount.js
@@ -329,8 +329,6 @@ class CreateAccount extends Component {
   }
 
   onCreate = () => {
-    this.createStore.setBusy(true);
-
     return this.createStore
       .createAccount(this.vaultStore)
       .then(() => {

--- a/js/src/modals/CreateAccount/createAccount.test.js
+++ b/js/src/modals/CreateAccount/createAccount.test.js
@@ -17,6 +17,7 @@
 import BigNumber from 'bignumber.js';
 import sinon from 'sinon';
 
+import Api from '~/api';
 import Store from './store';
 
 const ADDRESS = '0x00000123456789abcdef123456789abcdef123456789abcdef';
@@ -45,7 +46,8 @@ function createApi () {
       setAccountName: sinon.stub().resolves(),
       listVaults: sinon.stub().resolves([]),
       listOpenedVaults: sinon.stub().resolves([])
-    }
+    },
+    util: Api.util
   };
 }
 

--- a/js/src/modals/CreateAccount/store.js
+++ b/js/src/modals/CreateAccount/store.js
@@ -91,7 +91,7 @@ export default class Store {
   }
 
   @computed get hasAddress () {
-    return this.address.length !== 0;
+    return !!(this.address.length);
   }
 
   @computed get hasPhrase () {

--- a/js/src/modals/CreateAccount/store.js
+++ b/js/src/modals/CreateAccount/store.js
@@ -70,7 +70,7 @@ export default class Store {
         return !(this.nameError || this.walletFileError);
 
       case 'fromNew':
-        return !(this.nameError || this.passwordRepeatError) && this.hasAddress;
+        return !(this.nameError || this.passwordRepeatError) && this.hasAddress && this.hasPhrase;
 
       case 'fromPhrase':
         return !(this.nameError || this.passwordRepeatError || this.passPhraseError);
@@ -92,6 +92,10 @@ export default class Store {
 
   @computed get hasAddress () {
     return !!(this.address);
+  }
+
+  @computed get hasPhrase () {
+    return !!(this.phrase);
   }
 
   @computed get passwordRepeatError () {

--- a/js/src/modals/CreateAccount/store.js
+++ b/js/src/modals/CreateAccount/store.js
@@ -91,7 +91,7 @@ export default class Store {
   }
 
   @computed get hasAddress () {
-    return !!(this.address.length);
+    return !!(this.address);
   }
 
   @computed get hasPhrase () {

--- a/js/src/modals/CreateAccount/store.js
+++ b/js/src/modals/CreateAccount/store.js
@@ -91,11 +91,11 @@ export default class Store {
   }
 
   @computed get hasAddress () {
-    return !!(this.address);
+    return this.address.length !== 0;
   }
 
   @computed get hasPhrase () {
-    return !!(this.phrase);
+    return this.phrase.length !== 0;
   }
 
   @computed get passwordRepeatError () {
@@ -116,7 +116,7 @@ export default class Store {
       this.passwordRepeat = '';
       this.phrase = '';
       this.name = '';
-      this.nameError = null;
+      this.nameError = ERRORS.noName;
       this.qrAddress = null;
       this.rawKey = '';
       this.rawKeyError = null;
@@ -254,6 +254,10 @@ export default class Store {
   }
 
   @action nextStage = () => {
+    if (this.stage === 0) {
+      this.clearErrors();
+    }
+
     this.stage++;
   }
 
@@ -262,6 +266,10 @@ export default class Store {
   }
 
   createAccount = (vaultStore) => {
+    if (!this.canCreate) {
+      return false;
+    }
+
     this.setBusy(true);
 
     return this

--- a/js/src/modals/CreateAccount/store.spec.js
+++ b/js/src/modals/CreateAccount/store.spec.js
@@ -90,7 +90,7 @@ describe('modals/CreateAccount/Store', () => {
         store.clearErrors();
 
         expect(store.name).to.equal('');
-        expect(store.nameError).to.be.null;
+        expect(store.nameError).not.to.be.null;
         expect(store.password).to.equal('');
         expect(store.passwordRepeatError).to.be.null;
         expect(store.qrAddress).to.be.null;
@@ -309,6 +309,7 @@ describe('modals/CreateAccount/Store', () => {
       describe('createType === fromJSON/fromPresale', () => {
         beforeEach(() => {
           store.setCreateType('fromJSON');
+          store.setName('blah');
         });
 
         it('returns true on no errors', () => {
@@ -330,6 +331,8 @@ describe('modals/CreateAccount/Store', () => {
         beforeEach(() => {
           store.setCreateType('fromNew');
           store.setAddress('0x0000000000000000000000000000000000000000');
+          store.setName('blah');
+          store.setPhrase('testing');
         });
 
         it('returns true on no errors', () => {
@@ -338,6 +341,12 @@ describe('modals/CreateAccount/Store', () => {
 
         it('returns false on nameError', () => {
           store.setName('');
+
+          expect(store.canCreate).to.be.false;
+        });
+
+        it('returns false on no phrase', () => {
+          store.setPhrase('');
 
           expect(store.canCreate).to.be.false;
         });
@@ -352,6 +361,7 @@ describe('modals/CreateAccount/Store', () => {
       describe('createType === fromPhrase', () => {
         beforeEach(() => {
           store.setCreateType('fromPhrase');
+          store.setName('name');
         });
 
         it('returns true on no errors', () => {
@@ -372,6 +382,8 @@ describe('modals/CreateAccount/Store', () => {
       describe('createType === fromRaw', () => {
         beforeEach(() => {
           store.setCreateType('fromRaw');
+          store.setName('name');
+          store.setRawKey('0x1000000000000000000000000000000000000000000000000000000000000000');
         });
 
         it('returns true on no errors', () => {
@@ -389,7 +401,7 @@ describe('modals/CreateAccount/Store', () => {
         });
 
         it('returns false on rawKeyError', () => {
-          store.setRawKey('testing');
+          store.setRawKey('0x1');
           expect(store.canCreate).to.be.false;
         });
       });
@@ -459,6 +471,9 @@ describe('modals/CreateAccount/Store', () => {
         createAccountFromQrSpy = sinon.spy(store, 'createAccountFromQr');
         createAccountFromRawSpy = sinon.spy(store, 'createAccountFromRaw');
         busySpy = sinon.spy(store, 'setBusy');
+
+        store.setName('name');
+        store.setPhrase('testing');
       });
 
       afterEach(() => {
@@ -477,6 +492,8 @@ describe('modals/CreateAccount/Store', () => {
 
       it('calls createAccountFromGeth on createType === fromGeth', () => {
         store.setCreateType('fromGeth');
+        store.setGethAccountsAvailable(GETH_ADDRESSES);
+        store.selectGethAccount(GETH_ADDRESSES[0]);
 
         return store.createAccount().then(() => {
           expect(createAccountFromGethSpy).to.have.been.called;
@@ -485,6 +502,8 @@ describe('modals/CreateAccount/Store', () => {
 
       it('calls createAccountFromWallet on createType === fromJSON', () => {
         store.setCreateType('fromJSON');
+        store.setName('name');
+        store.setWalletJson('{}');
 
         return store.createAccount().then(() => {
           expect(createAccountFromWalletSpy).to.have.been.called;
@@ -493,6 +512,9 @@ describe('modals/CreateAccount/Store', () => {
 
       it('calls createAccountFromPhrase on createType === fromNew', () => {
         store.setCreateType('fromNew');
+        store.setName('name');
+        store.setPhrase('phrase');
+        store.setAddress('0x1234567890123456789012345678901234567890');
 
         return store.createAccount().then(() => {
           expect(createAccountFromPhraseSpy).to.have.been.called;
@@ -501,6 +523,9 @@ describe('modals/CreateAccount/Store', () => {
 
       it('calls createAccountFromPhrase on createType === fromPhrase', () => {
         store.setCreateType('fromPhrase');
+        store.setName('name');
+        store.setPhrase('phrase');
+        store.setAddress('0x1234567890123456789012345678901234567890');
 
         return store.createAccount().then(() => {
           expect(createAccountFromPhraseSpy).to.have.been.called;
@@ -509,6 +534,8 @@ describe('modals/CreateAccount/Store', () => {
 
       it('calls createAccountFromWallet on createType === fromPresale', () => {
         store.setCreateType('fromPresale');
+        store.setName('name');
+        store.setWalletJson('{}');
 
         return store.createAccount().then(() => {
           expect(createAccountFromWalletSpy).to.have.been.called;
@@ -517,6 +544,8 @@ describe('modals/CreateAccount/Store', () => {
 
       it('calls createAccountFromQr on createType === fromQr', () => {
         store.setCreateType('fromQr');
+        store.setQrAddress('0x1234567890123456789012345678901234567890');
+        store.setName('name');
 
         return store.createAccount().then(() => {
           expect(createAccountFromQrSpy).to.have.been.called;
@@ -525,6 +554,8 @@ describe('modals/CreateAccount/Store', () => {
 
       it('calls createAccountFromRaw on createType === fromRaw', () => {
         store.setCreateType('fromRaw');
+        store.setName('name');
+        store.setRawKey('0x1000000000000000000000000000000000000000000000000000000000000000');
 
         return store.createAccount().then(() => {
           expect(createAccountFromRawSpy).to.have.been.called;
@@ -534,6 +565,9 @@ describe('modals/CreateAccount/Store', () => {
       it('moves account to vault when vaultName set', () => {
         store.setCreateType('fromNew');
         store.setVaultName('testing');
+        store.setName('name');
+        store.setAddress('0x1234567890123456789012345678901234567890');
+        store.setPhrase('phrase');
 
         return store.createAccount(vaultStore).then(() => {
           expect(vaultStore.moveAccount).to.have.been.calledWith('testing', ADDRESS);
@@ -542,6 +576,9 @@ describe('modals/CreateAccount/Store', () => {
 
       it('sets and rests the busy flag', () => {
         store.setCreateType('fromNew');
+        store.setName('name');
+        store.setAddress('0x1234567890123456789012345678901234567890');
+        store.setPhrase('phrase');
 
         return store.createAccount().then(() => {
           expect(busySpy).to.have.been.calledWith(true);
@@ -634,22 +671,18 @@ describe('modals/CreateAccount/Store', () => {
         beforeEach(() => {
           store.setName('some name');
           store.setDescription('some desc');
-          store.setQrAddress('0x123');
+          store.setQrAddress('0x1234567890123456789012345678901234567890');
+          sinon.spy(store, 'setupMeta');
 
           return store.createAccountFromQr(-1);
         });
 
-        it('sets the accountInfo name', () => {
-          expect(api.parity.setAccountName).to.have.been.calledWith('0x123', 'some name');
+        afterEach(() => {
+          store.setupMeta.restore();
         });
 
-        it('sets the meta (with extrenal flag)', () => {
-          expect(api.parity.setAccountMeta).to.have.been.calledWith('0x123', {
-            description: 'some desc',
-            passwordHint: '',
-            timestamp: -1,
-            external: true
-          });
+        it('sets the meta', () => {
+          expect(store.setupMeta).to.have.been.called;
         });
       });
 

--- a/js/src/ui/Balance/balance.js
+++ b/js/src/ui/Balance/balance.js
@@ -56,7 +56,7 @@ export class Balance extends Component {
 
         const isEthToken = token.native;
         const isFullToken = !showOnlyEth || isEthToken;
-        const hasBalance = balanceValue.gt(0);
+        const hasBalance = (balanceValue instanceof BigNumber) && balanceValue.gt(0);
 
         if (!hasBalance && !isEthToken) {
           return null;


### PR DESCRIPTION
- Sets name error properly on empty name between next/prev
- Fixes clicking rapidly on next that creates invalid accounts in case where name was previously set
- Fixed token balance checks (currently Geth key imports are not working)
- Additional safety checks for empty phrase (fromNew) and canCreate in actual action handler