### PR TITLE
use the git version for the parity snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: parity
-version: master
+version: git
 summary: Fast, light, robust Ethereum implementation
 description: |
   Parity's goal is to be the fastest, lightest, and most secure Ethereum


### PR DESCRIPTION
A new feature landed recently in snapcraft that will use information from the git repo to set the snap version.
If the snap is built from a tagged revision, the tag will be used as the version.