### PR TITLE
Fix wrongly called timeouts

### DIFF
--- a/js/src/api/subscriptions/signer.js
+++ b/js/src/api/subscriptions/signer.js
@@ -57,7 +57,7 @@ export default class Signer {
         this._updateSubscriptions('signer_requestsToConfirm', null, requests);
         nextTimeout();
       })
-      .catch(nextTimeout);
+      .catch(() => nextTimeout());
   }
 
   _postTransaction (data) {

--- a/js/src/api/transport/http/http.js
+++ b/js/src/api/transport/http/http.js
@@ -93,8 +93,8 @@ export default class Http extends JsonRpcBase {
 
     this
       .execute('net_listening')
-      .then(nextTimeout)
-      .catch(nextTimeout);
+      .then(() => nextTimeout())
+      .catch(() => nextTimeout());
   }
 
   set url (url) {

--- a/js/src/views/Signer/store.js
+++ b/js/src/views/Signer/store.js
@@ -101,7 +101,7 @@ export default class SignerStore {
 
         this.setLocalHashes(keys);
       })
-      .then(nextTimeout)
-      .catch(nextTimeout);
+      .then(() => nextTimeout())
+      .catch(() => nextTimeout());
   }
 }


### PR DESCRIPTION
Avoid doing `catch(nextTimeout)` since some `nextTimeout` functions have the actual timeout as first argument. Calling this would pass the error as the timeout, which would make it instantaneous:

```js
console.log(Date.now());
setTimeout(() => {
  console.log(Date.now());
}, new Error('This is an error'));
```

The consequences being sending thousands of requests on continuous failure.