### PR TITLE
Make config file optional in systemd

### DIFF
--- a/scripts/parity.service
+++ b/scripts/parity.service
@@ -3,7 +3,7 @@ Description=Parity Daemon
 After=network.target
 
 [Service]
-EnvironmentFile=%h/.parity/parity.conf
+EnvironmentFile=-%h/.parity/parity.conf
 ExecStart=/usr/bin/parity $ARGS
 
 [Install]


### PR DESCRIPTION
Currently the systemd service won't start unless you create a config file, even if you don't need one:
```
Failed to load environment files: No such file or directory
parity.service: Failed to run 'start' task: No such file or directory
Failed to start Parity Daemon.
```
The minus sign makes systemd ignore the file if it does not exist.