### PR TITLE
Keyethereum fs dependency

### DIFF
--- a/js/src/api/local/index.js
+++ b/js/src/api/local/index.js
@@ -14,4 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+if (process.env.NODE_ENV !=== 'test') {
+  process.browser = true;
+}
+
 export LocalAccountsMiddleware from './localAccountsMiddleware';

--- a/js/src/api/local/index.js
+++ b/js/src/api/local/index.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-if (process.env.NODE_ENV !=== 'test') {
+if (process.env.NODE_ENV !== 'test') {
   process.browser = true;
 }
 

--- a/js/webpack/app.js
+++ b/js/webpack/app.js
@@ -148,6 +148,10 @@ module.exports = {
     unsafeCache: true
   },
 
+  node: {
+    fs: 'empty'
+  },
+
   plugins: (function () {
     const DappsHTMLInjection = DAPPS.filter((dapp) => !dapp.skipBuild).map((dapp) => {
       return new HtmlWebpackPlugin({

--- a/js/webpack/libraries.js
+++ b/js/webpack/libraries.js
@@ -46,6 +46,10 @@ module.exports = {
     }
   },
 
+  node: {
+    fs: 'empty'
+  },
+
   module: {
     rules: [
       {

--- a/js/webpack/npm.js
+++ b/js/webpack/npm.js
@@ -70,7 +70,9 @@ module.exports = {
       }
     ]
   },
-
+  node: {
+    fs: 'empty'
+  },
   resolve: {
     alias: {
       '~': path.resolve(__dirname, '../src'),


### PR DESCRIPTION
- Explicitly set process.browser (used by keyethereum)
- Expose empty fs module