### PR TITLE
Implement skeleton for transaction index and epoch transition proof PIP messages

### DIFF
--- a/ethcore/light/src/net/load_timer.rs
+++ b/ethcore/light/src/net/load_timer.rs
@@ -55,6 +55,7 @@ fn hardcoded_serve_time(kind: Kind) -> u64 {
 	match kind {
 		Kind::Headers => 500_000,
 		Kind::HeaderProof => 500_000,
+		Kind::TransactionIndex => 500_000,
 		Kind::Receipts => 1_000_000,
 		Kind::Body => 1_000_000,
 		Kind::Account => 1_500_000,

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -110,6 +110,7 @@ mod timeout {
 
 	// timeouts per request within packet.
 	pub const HEADERS: i64 = 250; // per header?
+	pub const TRANSACTION_INDEX: i64 = 100;
 	pub const BODY: i64 = 50;
 	pub const RECEIPT: i64 = 50;
 	pub const PROOF: i64 = 100; // state proof
@@ -867,6 +868,7 @@ impl LightProtocol {
 			match complete_req {
 				CompleteRequest::Headers(req) => self.provider.block_headers(req).map(Response::Headers),
 				CompleteRequest::HeaderProof(req) => self.provider.header_proof(req).map(Response::HeaderProof),
+				CompleteRequest::TransactionIndex(_) => None, // don't answer these yet, but leave them in protocol.
 				CompleteRequest::Body(req) => self.provider.block_body(req).map(Response::Body),
 				CompleteRequest::Receipts(req) => self.provider.block_receipts(req).map(Response::Receipts),
 				CompleteRequest::Account(req) => self.provider.account_proof(req).map(Response::Account),

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -80,7 +80,7 @@ pub const PROTOCOL_VERSIONS: &'static [u8] = &[1];
 pub const MAX_PROTOCOL_VERSION: u8 = 1;
 
 /// Packet count for PIP.
-pub const PACKET_COUNT: u8 = 5;
+pub const PACKET_COUNT: u8 = 9;
 
 // packet ID definitions.
 mod packet {
@@ -100,6 +100,10 @@ mod packet {
 
 	// relay transactions to peers.
 	pub const SEND_TRANSACTIONS: u8 = 0x06;
+
+	// request and respond with epoch transition proof
+	pub const REQUEST_EPOCH_PROOF: u8 = 0x07;
+	pub const EPOCH_PROOF: u8 = 0x08;
 }
 
 // timeouts for different kinds of requests. all values are in milliseconds.
@@ -523,6 +527,12 @@ impl LightProtocol {
 			packet::ACKNOWLEDGE_UPDATE => self.acknowledge_update(peer, io, rlp),
 
 			packet::SEND_TRANSACTIONS => self.relay_transactions(peer, io, rlp),
+
+			packet::REQUEST_EPOCH_PROOF | packet::EPOCH_PROOF => {
+				// ignore these for now, but leave them specified.
+				debug!(target: "pip", "Ignoring request/response for epoch proof");
+				Ok(())
+			}
 
 			other => {
 				Err(Error::UnrecognizedPacket(other))

--- a/ethcore/light/src/net/request_set.rs
+++ b/ethcore/light/src/net/request_set.rs
@@ -132,6 +132,7 @@ fn compute_timeout(reqs: &Requests) -> Duration {
 		tm + match *req {
 			Request::Headers(_) => timeout::HEADERS,
 			Request::HeaderProof(_) => timeout::HEADER_PROOF,
+			Request::TransactionIndex(_) => timeout::TRANSACTION_INDEX,
 			Request::Receipts(_) => timeout::RECEIPT,
 			Request::Body(_) => timeout::BODY,
 			Request::Account(_) => timeout::PROOF,


### PR DESCRIPTION
This puts the protocol in a situation where we can provide the implementations of these methods (which may be complex to verify on the client side) after 1.7 without breaking protocol compatibility with Parity-1.7 nodes.