### PR TITLE
Prioritize accounts over address book

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -59,7 +59,7 @@ extern crate stats;
 
 #[macro_use]
 extern crate log;
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate ethcore_util as util;
 #[macro_use]
 extern crate jsonrpc_macros;

--- a/rpc/src/v1/traits/parity_accounts.rs
+++ b/rpc/src/v1/traits/parity_accounts.rs
@@ -19,14 +19,14 @@ use std::collections::BTreeMap;
 
 use jsonrpc_core::Error;
 use ethstore::KeyFile;
-use v1::types::{H160, H256, H520, DappId, DeriveHash, DeriveHierarchical};
+use v1::types::{H160, H256, H520, DappId, DeriveHash, DeriveHierarchical, ExtAccountInfo};
 
 build_rpc_trait! {
 	/// Personal Parity rpc interface.
 	pub trait ParityAccounts {
 		/// Returns accounts information.
 		#[rpc(name = "parity_allAccountsInfo")]
-		fn all_accounts_info(&self) -> Result<BTreeMap<H160, BTreeMap<String, String>>, Error>;
+		fn all_accounts_info(&self) -> Result<BTreeMap<H160, ExtAccountInfo>, Error>;
 
 		/// Creates new account from the given phrase using standard brainwallet mechanism.
 		/// Second parameter is password for the new account.

--- a/rpc/src/v1/types/account_info.rs
+++ b/rpc/src/v1/types/account_info.rs
@@ -21,6 +21,18 @@ pub struct AccountInfo {
 	pub name: String,
 }
 
+/// Extended account information (used by `parity_allAccountInfo`).
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+pub struct ExtAccountInfo {
+	/// Account name
+	pub name: String,
+	/// Account meta JSON
+	pub meta: String,
+	/// Account UUID (`None` for address book entries)
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub uuid: Option<String>,
+}
+
 /// Hardware wallet information.
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
 pub struct HwAccountInfo {
@@ -29,3 +41,4 @@ pub struct HwAccountInfo {
 	/// Device manufacturer.
 	pub manufacturer: String,
 }
+

--- a/rpc/src/v1/types/mod.rs
+++ b/rpc/src/v1/types/mod.rs
@@ -46,7 +46,7 @@ mod work;
 
 pub mod pubsub;
 
-pub use self::account_info::{AccountInfo, HwAccountInfo};
+pub use self::account_info::{AccountInfo, ExtAccountInfo, HwAccountInfo};
 pub use self::bytes::Bytes;
 pub use self::block::{RichBlock, Block, BlockTransactions, Header, RichHeader, Rich};
 pub use self::block_number::BlockNumber;


### PR DESCRIPTION
If a user creates an entry in the address book, and later tries to import an account that produces the same address, the account never shows up in the UI, no error is presented.

The account actually does get created, but since `parity_allAccountsInfo` returns a map, and the map is constructed such that the address book can overshadow actual accounts. This is a not-so-elegant solution that guarantees that accounts always take precedence over address book.

Also replaced `BTreeMap<String, String>` with a dedicated struct.