### PR TITLE
[WIP] Add get_with method to KeyValueDB and HashDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "ethcore-logger 1.7.0",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -95,9 +95,9 @@ impl<'db> HashDB for AccountDB<'db>{
 		unimplemented!()
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
 		if key == &SHA3_NULL_RLP {
-			f(&DBValue::from_slice(&NULL_RLP));
+			f(&NULL_RLP);
 			return;
 		}
 
@@ -156,9 +156,9 @@ impl<'db> HashDB for AccountDBMut<'db>{
 		unimplemented!()
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
 		if key == &SHA3_NULL_RLP {
-			f(&DBValue::from_slice(&NULL_RLP));
+			f(&NULL_RLP);
 			return;
 		}
 
@@ -206,9 +206,9 @@ impl<'db> HashDB for Wrapping<'db> {
 		unimplemented!()
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
 		if key == &SHA3_NULL_RLP {
-			f(&DBValue::from_slice(&NULL_RLP));
+			f(&NULL_RLP);
 			return;
 		}
 
@@ -242,9 +242,9 @@ impl<'db> HashDB for WrappingMut<'db>{
 		unimplemented!()
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
 		if key == &SHA3_NULL_RLP {
-			f(&DBValue::from_slice(&NULL_RLP));
+			f(&NULL_RLP);
 			return;
 		}
 

--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -95,10 +95,10 @@ impl<'db> HashDB for AccountDB<'db>{
 		unimplemented!()
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8]),
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8]),
 	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);
@@ -160,10 +160,10 @@ impl<'db> HashDB for AccountDBMut<'db>{
 		unimplemented!()
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8])
 	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);
@@ -214,10 +214,10 @@ impl<'db> HashDB for Wrapping<'db> {
 		unimplemented!()
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8])
 	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);

--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -95,11 +95,13 @@ impl<'db> HashDB for AccountDB<'db>{
 		unimplemented!()
 	}
 
-	fn get(&self, key: &H256) -> Option<DBValue> {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP));
+			f(&DBValue::from_slice(&NULL_RLP));
+			return;
 		}
-		self.db.get(&combine_key(&self.address_hash, key))
+
+		self.db.get_exec(&combine_key(&self.address_hash, key), f);
 	}
 
 	fn contains(&self, key: &H256) -> bool {
@@ -154,11 +156,13 @@ impl<'db> HashDB for AccountDBMut<'db>{
 		unimplemented!()
 	}
 
-	fn get(&self, key: &H256) -> Option<DBValue> {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP));
+			f(&DBValue::from_slice(&NULL_RLP));
+			return;
 		}
-		self.db.get(&combine_key(&self.address_hash, key))
+
+		self.db.get_exec(&combine_key(&self.address_hash, key), f);
 	}
 
 	fn contains(&self, key: &H256) -> bool {
@@ -202,11 +206,13 @@ impl<'db> HashDB for Wrapping<'db> {
 		unimplemented!()
 	}
 
-	fn get(&self, key: &H256) -> Option<DBValue> {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP));
+			f(&DBValue::from_slice(&NULL_RLP));
+			return;
 		}
-		self.0.get(key)
+
+		self.0.get_exec(key, f);
 	}
 
 	fn contains(&self, key: &H256) -> bool {
@@ -236,11 +242,13 @@ impl<'db> HashDB for WrappingMut<'db>{
 		unimplemented!()
 	}
 
-	fn get(&self, key: &H256) -> Option<DBValue> {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
 		if key == &SHA3_NULL_RLP {
-			return Some(DBValue::from_slice(&NULL_RLP));
+			f(&DBValue::from_slice(&NULL_RLP));
+			return;
 		}
-		self.0.get(key)
+
+		self.0.get_exec(key, f);
 	}
 
 	fn contains(&self, key: &H256) -> bool {

--- a/ethcore/src/account_db.rs
+++ b/ethcore/src/account_db.rs
@@ -95,7 +95,11 @@ impl<'db> HashDB for AccountDB<'db>{
 		unimplemented!()
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		f: &'this mut for<'a: 'this> FnMut(&'a [u8]),
+	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);
 			return;
@@ -156,7 +160,11 @@ impl<'db> HashDB for AccountDBMut<'db>{
 		unimplemented!()
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);
 			return;
@@ -206,7 +214,11 @@ impl<'db> HashDB for Wrapping<'db> {
 		unimplemented!()
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);
 			return;

--- a/ethcore/src/evm/benches/mod.rs
+++ b/ethcore/src/evm/benches/mod.rs
@@ -40,13 +40,13 @@ fn simple_loop_log0_u256(b: &mut Bencher) {
 }
 
 fn simple_loop_log0(gas: U256, b: &mut Bencher) {
-	let mut vm = Factory::new(VMType::Interpreter).create(gas);
+	let mut vm = Factory::new(VMType::Interpreter, None).create(gas);
 	let mut ext = FakeExt::new();
 
 	let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
-	let code = black_box(
+	let code: Arc<_> = black_box(
 		"62ffffff5b600190036000600fa0600357".from_hex().unwrap()
-	);
+	).into();
 
 	b.iter(|| {
 		let mut params = ActionParams::default();
@@ -69,16 +69,15 @@ fn mem_gas_calculation_same_u256(b: &mut Bencher) {
 }
 
 fn mem_gas_calculation_same(gas: U256, b: &mut Bencher) {
-	let mut vm = Factory::new(VMType::Interpreter).create(gas);
+	let mut vm = Factory::new(VMType::Interpreter, None).create(gas);
 	let mut ext = FakeExt::new();
 
 	let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
+	let code: Arc<_> = black_box(
+		"6110006001556001546000555b610fff805560016000540380600055600c57".from_hex().unwrap()
+	).into();
 
 	b.iter(|| {
-		let code = black_box(
-			"6110006001556001546000555b610fff805560016000540380600055600c57".from_hex().unwrap()
-		);
-
 		let mut params = ActionParams::default();
 		params.address = address.clone();
 		params.gas = gas;
@@ -99,16 +98,15 @@ fn mem_gas_calculation_increasing_u256(b: &mut Bencher) {
 }
 
 fn mem_gas_calculation_increasing(gas: U256, b: &mut Bencher) {
-	let mut vm = Factory::new(VMType::Interpreter).create(gas);
+	let mut vm = Factory::new(VMType::Interpreter, None).create(gas);
 	let mut ext = FakeExt::new();
 
 	let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
+	let code: Arc<_> = black_box(
+		"6110006001556001546000555b610fff60005401805560016000540380600055600c57".from_hex().unwrap()
+	).into();
 
 	b.iter(|| {
-		let code = black_box(
-			"6110006001556001546000555b610fff60005401805560016000540380600055600c57".from_hex().unwrap()
-		);
-
 		let mut params = ActionParams::default();
 		params.address = address.clone();
 		params.gas = gas;
@@ -121,7 +119,7 @@ fn mem_gas_calculation_increasing(gas: U256, b: &mut Bencher) {
 fn result(r: evm::Result<evm::GasLeft>) -> U256 {
 	match r {
 		Ok(evm::GasLeft::Known(v)) => v,
-		Ok(evm::GasLeft::NeedsReturn(v, _)) => v,
+		Ok(evm::GasLeft::NeedsReturn { gas_left, .. }) => gas_left,
 		_ => U256::zero(),
 	}
 }

--- a/ethcore/src/evm/factory.rs
+++ b/ethcore/src/evm/factory.rs
@@ -61,7 +61,10 @@ impl Factory {
 
 	/// Create new instance of specific `VMType` factory, with a size in bytes
 	/// for caching jump destinations.
-	pub fn new(evm: VMType, cache_size: usize) -> Self {
+	pub fn new<T: Into<Option<usize>>>(evm: VMType, maybe_cache_size: T) -> Self {
+		const DEFAULT_CACHE_SIZE: usize = 1024 * 32;
+		let cache_size = maybe_cache_size.into().unwrap_or(DEFAULT_CACHE_SIZE);
+
 		Factory {
 			evm: evm,
 			evm_cache: Arc::new(SharedCache::new(cache_size)),
@@ -106,18 +109,18 @@ macro_rules! evm_test(
 		#[ignore]
 		#[cfg(feature = "jit")]
 		fn $name_jit() {
-			$name_test(Factory::new(VMType::Jit, 1024 * 32));
+			$name_test(Factory::new(VMType::Jit, None));
 		}
 		#[test]
 		fn $name_int() {
-			$name_test(Factory::new(VMType::Interpreter, 1024 * 32));
+			$name_test(Factory::new(VMType::Interpreter, None));
 		}
 	};
 	($name_test: ident: $name_jit: ident, $name_int: ident) => {
 		#[test]
 		#[cfg(feature = "jit")]
 		fn $name_jit() {
-			$name_test(Factory::new(VMType::Jit, 1024 * 32));
+			$name_test(Factory::new(VMType::Jit, None));
 		}
 		#[test]
 		fn $name_int() {
@@ -135,13 +138,13 @@ macro_rules! evm_test_ignore(
 		#[cfg(feature = "jit")]
 		#[cfg(feature = "ignored-tests")]
 		fn $name_jit() {
-			$name_test(Factory::new(VMType::Jit, 1024 * 32));
+			$name_test(Factory::new(VMType::Jit, None));
 		}
 		#[test]
 		#[ignore]
 		#[cfg(feature = "ignored-tests")]
 		fn $name_int() {
-			$name_test(Factory::new(VMType::Interpreter, 1024 * 32));
+			$name_test(Factory::new(VMType::Interpreter, None));
 		}
 	}
 );

--- a/ethcore/src/evm/tests.rs
+++ b/ethcore/src/evm/tests.rs
@@ -895,7 +895,7 @@ fn test_signextend(factory: super::Factory) {
 
 #[test] // JIT just returns out of gas
 fn test_badinstruction_int() {
-	let factory = super::Factory::new(VMType::Interpreter, 1024 * 32);
+	let factory = super::Factory::new(VMType::Interpreter, None);
 	let code = "af".from_hex().unwrap();
 
 	let mut params = ActionParams::default();

--- a/ethcore/src/evm/tests.rs
+++ b/ethcore/src/evm/tests.rs
@@ -222,7 +222,7 @@ fn test_stack_underflow() {
 
 evm_test!{test_add: test_add_jit, test_add_int}
 fn test_add(factory: super::Factory) {
-  let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
+	let address = Address::from_str("0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6").unwrap();
 	let code = "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055".from_hex().unwrap();
 
 	let mut params = ActionParams::default();

--- a/ethcore/src/migrations/state/v7.rs
+++ b/ethcore/src/migrations/state/v7.rs
@@ -17,16 +17,14 @@
 //! This migration migrates the state db to use an accountdb which ensures uniqueness
 //! using an address' hash as opposed to the address itself.
 
+use rlp::{decode, Rlp, RlpStream};
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use util::Bytes;
-use util::{Address, H256};
+use util::{Bytes, KeyValueDB, Address, H256};
 use util::kvdb::Database;
 use util::migration::{Batch, Config, Error, Migration, SimpleMigration, Progress};
 use util::sha3::Hashable;
-use std::sync::Arc;
-
-use rlp::{decode, Rlp, RlpStream};
 
 // attempt to migrate a key, value pair. None if migration not possible.
 fn attempt_migrate(mut key_h: H256, val: &[u8]) -> Option<H256> {

--- a/ethcore/src/migrations/state/v7.rs
+++ b/ethcore/src/migrations/state/v7.rs
@@ -21,7 +21,7 @@ use rlp::{decode, Rlp, RlpStream};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use util::{Bytes, KeyValueDB, Address, H256};
+use util::{Bytes, Address, H256};
 use util::kvdb::Database;
 use util::migration::{Batch, Config, Error, Migration, SimpleMigration, Progress};
 use util::sha3::Hashable;

--- a/ethcore/src/migrations/v10.rs
+++ b/ethcore/src/migrations/v10.rs
@@ -20,7 +20,7 @@ use bloom_journal::Bloom;
 use db::{COL_EXTRA, COL_HEADERS, COL_STATE};
 use state_db::{ACCOUNT_BLOOM_SPACE, DEFAULT_ACCOUNT_PRESET, StateDB};
 use std::sync::Arc;
-use util::{journaldb, H256, Trie, KeyValueDB, Database, DBTransaction};
+use util::{journaldb, H256, Trie, Database, DBTransaction};
 use util::migration::{Error, Migration, Progress, Batch, Config};
 use util::trie::TrieDB;
 use views::HeaderView;

--- a/ethcore/src/migrations/v10.rs
+++ b/ethcore/src/migrations/v10.rs
@@ -16,16 +16,14 @@
 
 //! Bloom upgrade
 
-use std::sync::Arc;
+use bloom_journal::Bloom;
 use db::{COL_EXTRA, COL_HEADERS, COL_STATE};
 use state_db::{ACCOUNT_BLOOM_SPACE, DEFAULT_ACCOUNT_PRESET, StateDB};
+use std::sync::Arc;
+use util::{journaldb, H256, Trie, KeyValueDB, Database, DBTransaction};
+use util::migration::{Error, Migration, Progress, Batch, Config};
 use util::trie::TrieDB;
 use views::HeaderView;
-use bloom_journal::Bloom;
-use util::migration::{Error, Migration, Progress, Batch, Config};
-use util::journaldb;
-use util::{H256, Trie};
-use util::{Database, DBTransaction};
 
 /// Account bloom upgrade routine. If bloom already present, does nothing.
 /// If database empty (no best block), does nothing.

--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -34,7 +34,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use util::{KeyValueDB, Bytes, H256, Mutex, RwLock, RwLockReadGuard, UtilError};
+use util::{Bytes, H256, Mutex, RwLock, RwLockReadGuard, UtilError};
 use util::journaldb::Algorithm;
 use util::kvdb::{Database, DatabaseConfig};
 use util::snappy;

--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -16,13 +16,6 @@
 
 //! Snapshot network service implementation.
 
-use std::collections::HashSet;
-use std::io::ErrorKind;
-use std::fs;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
 use super::{ManifestData, StateRebuilder, Rebuilder, RestorationStatus, SnapshotService};
 use super::io::{SnapshotReader, LooseReader, SnapshotWriter, LooseWriter};
 
@@ -31,11 +24,17 @@ use client::{BlockChainClient, Client};
 use engines::Engine;
 use error::Error;
 use ids::BlockId;
-use service::ClientIoMessage;
 
 use io::IoChannel;
+use service::ClientIoMessage;
+use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use util::{Bytes, H256, Mutex, RwLock, RwLockReadGuard, UtilError};
+use util::{KeyValueDB, Bytes, H256, Mutex, RwLock, RwLockReadGuard, UtilError};
 use util::journaldb::Algorithm;
 use util::kvdb::{Database, DatabaseConfig};
 use util::snappy;

--- a/ethcore/src/state/backend.rs
+++ b/ethcore/src/state/backend.rs
@@ -90,7 +90,11 @@ impl HashDB for ProofCheck {
 		self.0.get(key)
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
 		self.0.get_exec(key, f);
 	}
 
@@ -143,7 +147,11 @@ impl<H: AsHashDB + Send + Sync> HashDB for Proving<H> {
 		keys
 	}
 
-	fn get_exec(&self, key: &H256, mut f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
 		let mut called = false;
 
 		{

--- a/ethcore/src/state/backend.rs
+++ b/ethcore/src/state/backend.rs
@@ -90,7 +90,7 @@ impl HashDB for ProofCheck {
 		self.0.get(key)
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
 		self.0.get_exec(key, f);
 	}
 
@@ -143,14 +143,14 @@ impl<H: AsHashDB + Send + Sync> HashDB for Proving<H> {
 		keys
 	}
 
-	fn get_exec(&self, key: &H256, mut f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, mut f: &mut FnMut(&[u8])) {
 		let mut called = false;
 
 		{
 			let mut optional_f = Some(&mut f);
-			let mut wrapper = |val: &DBValue| {
+			let mut wrapper = |val: &[u8]| {
 				called = true;
-				self.proof.lock().insert(val.clone());
+				self.proof.lock().insert(DBValue::from_slice(val));
 
 				if let Some(f) = optional_f.take() {
 					f(val);

--- a/ethcore/src/state/backend.rs
+++ b/ethcore/src/state/backend.rs
@@ -90,10 +90,10 @@ impl HashDB for ProofCheck {
 		self.0.get(key)
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8])
 	) {
 		self.0.get_exec(key, f);
 	}
@@ -147,10 +147,10 @@ impl<H: AsHashDB + Send + Sync> HashDB for Proving<H> {
 		keys
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		mut f: &mut FnMut(&[u8])
 	) {
 		let mut called = false;
 

--- a/secret_store/src/key_storage.rs
+++ b/secret_store/src/key_storage.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use std::collections::BTreeMap;
 use serde_json;
 use ethkey::{Secret, Public};
-use util::Database;
+use util::{Database, KeyValueDBExt};
 use types::all::{Error, ServiceConfiguration, DocumentAddress, NodeId};
 use serialization::{SerializablePublic, SerializableSecret};
 
@@ -97,7 +97,7 @@ impl KeyStorage for PersistentKeyStorage {
 				.map_err(|e| Error::Database(e.to_string()))
 		)
 			.map_err(Error::Database)?
-			.ok_or(Error::DocumentNotFound)
+			.ok_or(Error::DocumentNotFound)?
 			.map(Into::into)
 	}
 

--- a/secret_store/src/key_storage.rs
+++ b/secret_store/src/key_storage.rs
@@ -90,11 +90,14 @@ impl KeyStorage for PersistentKeyStorage {
 	}
 
 	fn get(&self, document: &DocumentAddress) -> Result<DocumentKeyShare, Error> {
-		self.db.get(None, document)
+		self.db.get_with(
+			None,
+			document,
+			|key| serde_json::from_slice::<SerializableDocumentKeyShare>(key)
+				.map_err(|e| Error::Database(e.to_string()))
+		)
 			.map_err(Error::Database)?
 			.ok_or(Error::DocumentNotFound)
-			.map(|key| key.to_vec())
-			.and_then(|key| serde_json::from_slice::<SerializableDocumentKeyShare>(&key).map_err(|e| Error::Database(e.to_string())))
 			.map(Into::into)
 	}
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -36,6 +36,7 @@ ethcore-bloom-journal = { path = "bloom" }
 regex = "0.2"
 lru-cache = "0.1.0"
 ethcore-logger = { path = "../logger" }
+lazy_static = "0.2.8"
 
 [features]
 default = []

--- a/util/src/hashdb.rs
+++ b/util/src/hashdb.rs
@@ -30,7 +30,7 @@ pub trait HashDBExt {
 
 macro_rules! get_with_fn_def {
 	() => {
-		fn get_with<Out, F: FnOnce(&[u8]) -> Out>(
+		fn get_with<Out, F: for<'a> FnOnce(&'a [u8]) -> Out>(
 			&self,
 			key: &H256,
 			f: F,
@@ -113,7 +113,11 @@ pub trait HashDB: AsHashDB + Send + Sync {
 	/// default implementation of `get_with` will panic if `f` is called more than
 	/// once and in general there is no sensible behavior if `f` is called more
 	/// than once.
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8]));
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	);
 
 	/// Check for the existance of a hash-key.
 	///

--- a/util/src/hashdb.rs
+++ b/util/src/hashdb.rs
@@ -23,8 +23,10 @@ use std::collections::HashMap;
 /// `HashDB` value type.
 pub type DBValue = ElasticArray128<u8>;
 
-// TODO: Should this include a generic version of `HashDB::insert`?
+/// Supplemental trait to `HashDB` supplying generic methods for trait objects, internally
+/// calling monomorphic forms of these methods.
 pub trait HashDBExt {
+	/// Get a reference, transform it, and return the result (prevents cloning).
 	fn get_with<Out, F: FnOnce(&[u8]) -> Out>(&self, _: &H256, _: F) -> Option<Out>;
 }
 
@@ -40,6 +42,8 @@ macro_rules! get_with_fn_def {
 
 			{
 				let mut wrapper = |key: &[u8]| {
+					// Unwrap here because `get_exec` is required to call the closure no more than
+					// once.
 					output = Some((o_func.take().unwrap())(key));
 				};
 

--- a/util/src/hashdb.rs
+++ b/util/src/hashdb.rs
@@ -42,9 +42,13 @@ macro_rules! get_with_fn_def {
 
 			{
 				let mut wrapper = |key: &[u8]| {
-					// Unwrap here because `get_exec` is required to call the closure no more than
-					// once.
-					output = Some((o_func.take().unwrap())(key));
+					output = Some(
+						(
+							o_func.take().expect(
+								"The implementation of `get_exec` called its argument twice - this \
+								 is a bug!"
+							)
+						)(key));
 				};
 
 				self.get_exec(key, &mut wrapper);

--- a/util/src/hashdb.rs
+++ b/util/src/hashdb.rs
@@ -112,10 +112,10 @@ pub trait HashDB: AsHashDB + Send + Sync {
 	/// default implementation of `get_with` will panic if `f` is called more than
 	/// once and in general there is no sensible behavior if `f` is called more
 	/// than once.
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8])
 	);
 
 	/// Check for the existance of a hash-key.

--- a/util/src/hashdb.rs
+++ b/util/src/hashdb.rs
@@ -96,11 +96,10 @@ pub trait HashDB: AsHashDB + Send + Sync {
 	/// }
 	/// ```
 	fn get(&self, key: &H256) -> Option<DBValue> {
-		let mut o_func = Some(DBValue::from_slice);
 		let mut output = None;
 
 		{
-			let mut wrapper = |key: &[u8]| { output = Some((o_func.take().unwrap())(key)); };
+			let mut wrapper = |key: &[u8]| { output = Some(DBValue::from_slice(key)); };
 
 			self.get_exec(key, &mut wrapper);
 		}

--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -86,7 +86,11 @@ impl HashDB for ArchiveDB {
 		ret
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
 		let k = self.overlay.raw_ref(key);
 
 		if let Some((d, rc)) = k {

--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -57,17 +57,10 @@ impl ArchiveDB {
 		Self::new(backing, None)
 	}
 
-	fn payload(&self, key: &H256) -> Option<DBValue> {
-		self.backing.get(self.column, key).expect(
+	fn payload_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+		self.backing.get_exec(self.column, key, f).expect(
 			"Low-level database error. Some issue with your hard disk?"
 		)
-	}
-
-	fn payload_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
-		// TODO: Fix this once `KeyValueDB` has a `get_exec` method
-		if let Some(val) = self.payload(key) {
-			f(&val);
-		}
 	}
 }
 

--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -59,15 +59,15 @@ impl ArchiveDB {
 
 	fn payload(&self, key: &H256) -> Option<DBValue> {
 		self.backing.get(self.column, key).expect(
-      "Low-level database error. Some issue with your hard disk?"
-    )
+			"Low-level database error. Some issue with your hard disk?"
+		)
 	}
 
 	fn payload_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
-    // TODO: Fix this once `KeyValueDB` has a `get_exec` method
+		// TODO: Fix this once `KeyValueDB` has a `get_exec` method
 		if let Some(val) = self.payload(key) {
-      f(&val);
-    }
+			f(&val);
+		}
 	}
 }
 
@@ -96,6 +96,7 @@ impl HashDB for ArchiveDB {
 		if let Some((d, rc)) = k {
 			if rc > 0 {
 				f(d.as_ref());
+				return;
 			}
 		}
 

--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -86,10 +86,10 @@ impl HashDB for ArchiveDB {
 		ret
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		mut f: &mut FnMut(&[u8])
 	) {
 		let k = self.overlay.raw_ref(key);
 

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -331,10 +331,10 @@ impl HashDB for EarlyMergeDB {
 		ret
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		mut f: &mut FnMut(&[u8])
 	) {
 		let k = self.overlay.raw_ref(key);
 

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -340,9 +340,9 @@ impl HashDB for EarlyMergeDB {
 
 		if let Some((d, rc)) = k {
 			if rc > 0 {
-        f(d.as_ref());
-        return;
-      }
+				f(d.as_ref());
+				return;
+			}
 		}
 
 		self.payload_exec(key, f);

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -280,10 +280,10 @@ impl EarlyMergeDB {
 	}
 
 	fn payload_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
-    // TODO: Fix this once `KeyValueDB` has a `get_exec` method
+		// TODO: Fix this once `KeyValueDB` has a `get_exec` method
 		if let Some(val) = self.payload(key) {
-      f(&val);
-    }
+			f(&val);
+		}
 	}
 
 	fn read_refs(db: &KeyValueDB, col: Option<u32>) -> (Option<u64>, HashMap<H256, RefInfo>) {
@@ -331,7 +331,11 @@ impl HashDB for EarlyMergeDB {
 		ret
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
 		let k = self.overlay.raw_ref(key);
 
 		if let Some((d, rc)) = k {

--- a/util/src/journaldb/overlayrecentdb.rs
+++ b/util/src/journaldb/overlayrecentdb.rs
@@ -424,11 +424,12 @@ impl HashDB for OverlayRecentDB {
 
 		let journal_overlay = self.journal_overlay.read();
 		let short_key = to_short_key(key);
-		// This weird `&mut &mut FnMut(&[u8])` trick is necessary because the borrow checker
-		// complains that `f` has been moved into `get_with`. I don't know why right now and it's
-		// too hot for me to figure it out.
+
 		let backing_overlay_has_key =
-			journal_overlay.backing_overlay.get_with(&short_key, &mut f).is_some();
+			journal_overlay.backing_overlay.get_with(
+				&short_key,
+				|_| ()
+			).is_some();
 
 		if backing_overlay_has_key {
 			return;

--- a/util/src/journaldb/overlayrecentdb.rs
+++ b/util/src/journaldb/overlayrecentdb.rs
@@ -460,12 +460,12 @@ impl HashDB for OverlayRecentDB {
 		};
 
 		let journal_overlay = self.journal_overlay.read();
-		let key = to_short_key(key);
+		let short_key = to_short_key(key);
 
-		journal_overlay.backing_overlay.get_exec(&key, &mut wrapper);
+		journal_overlay.backing_overlay.get_exec(&short_key, &mut wrapper);
 
 		if !was_called.get() {
-			if let Some(hash_val) = journal_overlay.pending_overlay.get(&key) {
+			if let Some(hash_val) = journal_overlay.pending_overlay.get(&short_key) {
 				wrapper(hash_val);
 			}
 		}

--- a/util/src/journaldb/overlayrecentdb.rs
+++ b/util/src/journaldb/overlayrecentdb.rs
@@ -434,10 +434,10 @@ impl HashDB for OverlayRecentDB {
 		v.or_else(|| self.payload(key))
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8]),
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8]),
 	) {
 		use ::std::cell::Cell;
 

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -81,10 +81,15 @@ impl RefCountedDB {
 
 impl HashDB for RefCountedDB {
 	fn keys(&self) -> HashMap<H256, i32> { self.forward.keys() }
-  fn get(&self, key: &H256) -> Option<DBValue> { self.forward.get(key) }
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
-    self.forward.get_exec(key, f);
-  }
+	fn get(&self, key: &H256) -> Option<DBValue> { self.forward.get(key) }
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
+		self.forward.get_exec(key, f);
+	}
+
 	fn contains(&self, key: &H256) -> bool { self.forward.contains(key) }
 	fn insert(&mut self, value: &[u8]) -> H256 { let r = self.forward.insert(value); self.inserts.push(r.clone()); r }
 	fn emplace(&mut self, key: H256, value: DBValue) { self.inserts.push(key.clone()); self.forward.emplace(key, value); }

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -82,10 +82,10 @@ impl RefCountedDB {
 impl HashDB for RefCountedDB {
 	fn keys(&self) -> HashMap<H256, i32> { self.forward.keys() }
 	fn get(&self, key: &H256) -> Option<DBValue> { self.forward.get(key) }
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		mut f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		mut f: &mut FnMut(&[u8])
 	) {
 		self.forward.get_exec(key, f);
 	}

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -82,7 +82,7 @@ impl RefCountedDB {
 impl HashDB for RefCountedDB {
 	fn keys(&self) -> HashMap<H256, i32> { self.forward.keys() }
   fn get(&self, key: &H256) -> Option<DBValue> { self.forward.get(key) }
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
     self.forward.get_exec(key, f);
   }
 	fn contains(&self, key: &H256) -> bool { self.forward.contains(key) }

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -81,7 +81,10 @@ impl RefCountedDB {
 
 impl HashDB for RefCountedDB {
 	fn keys(&self) -> HashMap<H256, i32> { self.forward.keys() }
-	fn get(&self, key: &H256) -> Option<DBValue> { self.forward.get(key) }
+  fn get(&self, key: &H256) -> Option<DBValue> { self.forward.get(key) }
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+    self.forward.get_exec(key, f);
+  }
 	fn contains(&self, key: &H256) -> bool { self.forward.contains(key) }
 	fn insert(&mut self, value: &[u8]) -> H256 { let r = self.forward.insert(value); self.inserts.push(r.clone()); r }
 	fn emplace(&mut self, key: H256, value: DBValue) { self.inserts.push(key.clone()); self.forward.emplace(key, value); }

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -198,11 +198,10 @@ pub trait KeyValueDB: Sync + Send {
 
 	/// Get a value by key.
 	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>, String> {
-		let mut o_func = Some(DBValue::from_slice);
 		let mut output = None;
 
 		{
-			let mut wrapper = |key: &[u8]| { output = Some((o_func.take().unwrap())(key)); };
+			let mut wrapper = |key: &[u8]| { output = Some(DBValue::from_slice(key)); };
 
 			if let Err(err) = self.get_exec(col, key, &mut wrapper) {
 				return Err(err);

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -128,7 +128,10 @@ enum KeyState {
 	Delete,
 }
 
+/// Supplemental trait to `KeyValueDB` supplying generic methods for trait objects, internally
+/// calling monomorphic forms of these methods.
 pub trait KeyValueDBExt: KeyValueDB {
+	/// Get a reference, transform it, and return the result (prevents cloning).
 	fn get_with<Out, F: FnOnce(&[u8]) -> Out>(
 		&self,
 		col: Option<u32>,
@@ -211,8 +214,11 @@ pub trait KeyValueDB: Sync + Send {
 		Ok(output)
 	}
 
-	// We explicitly write out the lifetime here since we don't need the `FnMut` to be able to take
-	// a slice of any lifetime.
+	/// Any implementation of this function should call `f` zero times if a value
+	/// for `key` is not found, and precisely once if a value is found. The
+	/// default implementation of `get_with` will panic if `f` is called more than
+	/// once and in general there is no sensible behavior if `f` is called more
+	/// than once.
 	fn get_exec(
 		&self,
 		col: Option<u32>,

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -150,7 +150,12 @@ macro_rules! get_with_fn_def {
 
 			{
 				let mut wrapper = |key: &[u8]| {
-					output = Some((o_func.take().unwrap())(key));
+					output = Some(
+						(
+							o_func.take()
+								.expect("Broken `get_exec` implementation - see stack trace")
+						)(key)
+					);
 				};
 
 				self.get_exec(col, key, &mut wrapper)?;
@@ -494,7 +499,7 @@ pub struct DatabaseIterator<'a> {
 impl<'a> Iterator for DatabaseIterator<'a> {
 	type Item = (Box<[u8]>, Box<[u8]>);
 
-    fn next(&mut self) -> Option<Self::Item> {
+	fn next(&mut self) -> Option<Self::Item> {
 		self.iter.next()
 	}
 }

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -128,6 +128,63 @@ enum KeyState {
 	Delete,
 }
 
+pub trait KeyValueDBExt {
+	fn get_with<Out, F: FnOnce(&DBValue) -> Out>(
+		&self,
+		col: Option<u32>,
+		key: &[u8],
+		f: F,
+	) -> Option<Out>;
+}
+
+macro_rules! get_with_fn_def {
+	() => {
+		fn get_with<Out, F: FnOnce(&DBValue) -> Out>(
+			&self,
+			col: Option<u32>,
+			key: &[u8],
+			f: F,
+		) -> Option<Out> {
+			let mut o_func: Option<F>   = Some(f);
+			let mut output: Option<Out> = None;
+
+			{
+				let mut wrapper = |key: &DBValue| {
+					output = Some((o_func.take().unwrap())(key));
+				};
+
+				self.get_exec(col, key, &mut wrapper);
+			}
+
+			output
+		}
+	}
+}
+
+impl<T: KeyValueDB> KeyValueDBExt for T {
+	get_with_fn_def!{}
+}
+
+impl KeyValueDBExt for Box<KeyValueDB> {
+	get_with_fn_def!{}
+}
+
+impl<'any> KeyValueDBExt for &'any KeyValueDB {
+	get_with_fn_def!{}
+}
+
+impl<'any> KeyValueDBExt for &'any mut KeyValueDB {
+	get_with_fn_def!{}
+}
+
+impl KeyValueDBExt for ::std::rc::Rc<KeyValueDB> {
+	get_with_fn_def!{}
+}
+
+impl KeyValueDBExt for ::std::sync::Arc<KeyValueDB> {
+	get_with_fn_def!{}
+}
+
 /// Generic key-value database.
 ///
 /// This makes a distinction between "buffered" and "flushed" values. Values which have been
@@ -151,7 +208,27 @@ pub trait KeyValueDB: Sync + Send {
 	fn transaction(&self) -> DBTransaction { DBTransaction::new() }
 
 	/// Get a value by key.
-	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>, String>;
+	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>, String> {
+		let mut o_func = Some(Clone::clone);
+		let mut output = None;
+
+		{
+			let mut wrapper = |key: &DBValue| { output = Some((o_func.take().unwrap())(key)); };
+
+			if let Err(err) = self.get_exec(col, key, &mut wrapper) {
+				return Err(err);
+			}
+		}
+
+		Ok(output)
+	}
+
+	fn get_exec(
+		&self,
+		col: Option<u32>,
+		key: &[u8],
+		f: &mut FnMut(&DBValue),
+	) -> Result<(), String>;
 
 	/// Get a value by partial key. Only works for flushed data.
 	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>>;
@@ -195,17 +272,26 @@ pub fn in_memory(num_cols: u32) -> InMemory {
 		cols.insert(Some(idx), BTreeMap::new());
 	}
 
-	InMemory {
-		columns: RwLock::new(cols)
-	}
+	InMemory { columns: RwLock::new(cols) }
 }
 
 impl KeyValueDB for InMemory {
-	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>, String> {
+	fn get_exec(
+		&self,
+		col: Option<u32>,
+		key: &[u8],
+		f: &mut FnMut(&DBValue),
+	) -> Result<(), String> {
 		let columns = self.columns.read();
 		match columns.get(&col) {
 			None => Err(format!("No such column family: {:?}", col)),
-			Some(map) => Ok(map.get(key).cloned()),
+			Some(map) => {
+				if let Some(val) = map.get(key) {
+					f(val);
+				}
+
+				Ok(())
+			}
 		}
 	}
 
@@ -571,33 +657,11 @@ impl Database {
 		DBTransaction::new()
 	}
 
-
 	fn to_overlay_column(col: Option<u32>) -> usize {
 		col.map_or(0, |c| (c + 1) as usize)
 	}
 
 	/// Commit transaction to database.
-	pub fn write_buffered(&self, tr: DBTransaction) {
-		let mut overlay = self.overlay.write();
-		let ops = tr.ops;
-		for op in ops {
-			match op {
-				DBOp::Insert { col, key, value } => {
-					let c = Self::to_overlay_column(col);
-					overlay[c].insert(key, KeyState::Insert(value));
-				},
-				DBOp::InsertCompressed { col, key, value } => {
-					let c = Self::to_overlay_column(col);
-					overlay[c].insert(key, KeyState::InsertCompressed(value));
-				},
-				DBOp::Delete { col, key } => {
-					let c = Self::to_overlay_column(col);
-					overlay[c].insert(key, KeyState::Delete);
-				},
-			}
-		};
-	}
-
 	/// Commit buffered changes to database. Must be called under `flush_lock`
 	fn write_flushing_with_lock(&self, _lock: &mut MutexGuard<bool>) -> Result<(), String> {
 		match *self.db.read() {
@@ -767,47 +831,6 @@ impl Database {
 		self.flushing.write().clear();
 	}
 
-	/// Restore the database from a copy at given path.
-	pub fn restore(&self, new_db: &str) -> Result<(), UtilError> {
-		self.close();
-
-		let mut backup_db = PathBuf::from(&self.path);
-		backup_db.pop();
-		backup_db.push("backup_db");
-
-		let existed = match fs::rename(&self.path, &backup_db) {
-			Ok(_) => true,
-			Err(e) => if let ErrorKind::NotFound = e.kind() {
-				false
-			} else {
-				return Err(e.into());
-			}
-		};
-
-		match fs::rename(&new_db, &self.path) {
-			Ok(_) => {
-				// clean up the backup.
-				if existed {
-					fs::remove_dir_all(&backup_db)?;
-				}
-			}
-			Err(e) => {
-				// restore the backup.
-				if existed {
-					fs::rename(&backup_db, &self.path)?;
-				}
-				return Err(e.into())
-			}
-		}
-
-		// reopen the database and steal handles into self
-		let db = Self::open(&self.config, &self.path)?;
-		*self.db.write() = mem::replace(&mut *db.db.write(), None);
-		*self.overlay.write() = mem::replace(&mut *db.overlay.write(), Vec::new());
-		*self.flushing.write() = mem::replace(&mut *db.flushing.write(), Vec::new());
-		Ok(())
-	}
-
 	/// The number of non-default column families.
 	pub fn num_columns(&self) -> u32 {
 		self.db.read().as_ref()
@@ -848,40 +871,211 @@ impl Database {
 // duplicate declaration of methods here to avoid trait import in certain existing cases
 // at time of addition.
 impl KeyValueDB for Database {
-	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>, String> {
-		Database::get(self, col, key)
+	/// Get value by key.
+	fn get_exec(
+		&self,
+		col: Option<u32>,
+		key: &[u8],
+		f: &mut FnMut(&DBValue),
+	) -> Result<(), String> {
+		match *self.db.read() {
+			Some(DBAndColumns { ref db, ref cfs }) => {
+				let overlay = &self.overlay.read()[Self::to_overlay_column(col)];
+				match overlay.get(key) {
+					Some(&KeyState::Insert(ref value)) |
+					Some(&KeyState::InsertCompressed(ref value)) => {
+						f(value);
+
+						Ok(())
+					}
+					Some(&KeyState::Delete) => Ok(()),
+					None => {
+						let flushing = &self.flushing.read()[Self::to_overlay_column(col)];
+						match flushing.get(key) {
+							Some(&KeyState::Insert(ref value)) |
+							Some(&KeyState::InsertCompressed(ref value)) => {
+								f(value);
+
+								Ok(())
+							}
+							Some(&KeyState::Delete) => Ok(()),
+							None => {
+								// We don't use `map_or_else` here because it would require two
+								// seperate closures owning `f`
+								col.map(
+										|c| {
+											db.get_cf_opt(cfs[c as usize], key, &self.read_opts)
+												.map(
+													|r| if let Some(val) = r {
+														f(&DBValue::from_slice(&val));
+													},
+												)
+										},
+									)
+									.unwrap_or_else(
+										|| {
+											db.get_opt(key, &self.read_opts)
+												.map(
+													|r| if let Some(val) = r {
+														f(&DBValue::from_slice(&val));
+													},
+												)
+										},
+									)
+							}
+						}
+					}
+				}
+			}
+			None => Ok(()),
+		}
 	}
 
+	/// Get value by partial key. Prefix size should match configured prefix size. Only searches
+	/// flushed values.
+	// TODO: support prefix seek for unflushed data
 	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>> {
-		Database::get_by_prefix(self, col, prefix)
+		self.iter_from_prefix(col, prefix)
+			.and_then(
+				|mut iter| {
+					match iter.next() {
+						// TODO: use prefix_same_as_start read option (not availabele in C API
+						// currently)
+						Some((k, v)) => if k[0..prefix.len()] == prefix[..] {
+							Some(v)
+						} else {
+							None
+						},
+						_ => None,
+					}
+				},
+			)
 	}
 
-	fn write_buffered(&self, transaction: DBTransaction) {
-		Database::write_buffered(self, transaction)
+	fn write_buffered(&self, tr: DBTransaction) {
+		let mut overlay = self.overlay.write();
+		let ops = tr.ops;
+		for op in ops {
+			match op {
+				DBOp::Insert { col, key, value } => {
+					let c = Self::to_overlay_column(col);
+					overlay[c].insert(key, KeyState::Insert(value));
+				}
+				DBOp::InsertCompressed { col, key, value } => {
+					let c = Self::to_overlay_column(col);
+					overlay[c].insert(key, KeyState::InsertCompressed(value));
+				}
+				DBOp::Delete { col, key } => {
+					let c = Self::to_overlay_column(col);
+					overlay[c].insert(key, KeyState::Delete);
+				}
+			}
+		}
 	}
 
-	fn write(&self, transaction: DBTransaction) -> Result<(), String> {
-		Database::write(self, transaction)
-	}
-
+	/// Commit buffered changes to database.
 	fn flush(&self) -> Result<(), String> {
-		Database::flush(self)
+		let mut lock = self.flushing_lock.lock();
+		// If RocksDB batch allocation fails the thread gets terminated and the lock is released.
+		// The value inside the lock is used to detect that.
+		if *lock {
+			// This can only happen if another flushing thread is terminated unexpectedly.
+			return Err("Database write failure. Running low on memory perhaps?".to_owned());
+		}
+		*lock = true;
+		let result = self.write_flushing_with_lock(&mut lock);
+		*lock = false;
+		result
 	}
 
-	fn iter<'a>(&'a self, col: Option<u32>) -> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a> {
+	/// Commit transaction to database.
+	fn write(&self, tr: DBTransaction) -> Result<(), String> {
+		match *self.db.read() {
+			Some(DBAndColumns { ref db, ref cfs }) => {
+				let batch = WriteBatch::new();
+				let ops = tr.ops;
+				for op in ops {
+					match op {
+						DBOp::Insert { col, key, value } => {
+							col.map_or_else(
+									|| batch.put(&key, &value),
+									|c| batch.put_cf(cfs[c as usize], &key, &value),
+								)?
+						}
+						DBOp::InsertCompressed { col, key, value } => {
+							let compressed = UntrustedRlp::new(&value).compress(RlpType::Blocks);
+							col.map_or_else(
+									|| batch.put(&key, &compressed),
+									|c| batch.put_cf(cfs[c as usize], &key, &compressed),
+								)?
+						}
+						DBOp::Delete { col, key } => {
+							col.map_or_else(
+									|| batch.delete(&key),
+									|c| batch.delete_cf(cfs[c as usize], &key),
+								)?
+						}
+					}
+				}
+				db.write_opt(batch, &self.write_opts)
+			}
+			None => Err("Database is closed".to_owned()),
+		}
+	}
+
+	fn iter<'a>(&'a self, col: Option<u32>) -> Box<Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
 		let unboxed = Database::iter(self, col);
 		Box::new(unboxed.into_iter().flat_map(|inner| inner))
 	}
 
-	fn iter_from_prefix<'a>(&'a self, col: Option<u32>, prefix: &'a [u8])
-		-> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a>
-	{
+	fn iter_from_prefix<'a>(
+		&'a self,
+		col: Option<u32>,
+		prefix: &'a [u8],
+	) -> Box<Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
 		let unboxed = Database::iter_from_prefix(self, col, prefix);
 		Box::new(unboxed.into_iter().flat_map(|inner| inner))
 	}
 
+	/// Restore the database from a copy at given path.
 	fn restore(&self, new_db: &str) -> Result<(), UtilError> {
-		Database::restore(self, new_db)
+		self.close();
+
+		let mut backup_db = PathBuf::from(&self.path);
+		backup_db.pop();
+		backup_db.push("backup_db");
+
+		let existed = match fs::rename(&self.path, &backup_db) {
+			Ok(_) => true,
+			Err(e) => if let ErrorKind::NotFound = e.kind() {
+				false
+			} else {
+				return Err(e.into());
+			},
+		};
+
+		match fs::rename(&new_db, &self.path) {
+			Ok(_) => {
+				// clean up the backup.
+				if existed {
+					fs::remove_dir_all(&backup_db)?;
+				}
+			}
+			Err(e) => {
+				// restore the backup.
+				if existed {
+					fs::rename(&backup_db, &self.path)?;
+				}
+				return Err(e.into());
+			}
+		}
+
+		// reopen the database and steal handles into self
+		let db = Self::open(&self.config, &self.path)?;
+		*self.db.write() = mem::replace(&mut *db.db.write(), None);
+		*self.overlay.write() = mem::replace(&mut *db.overlay.write(), Vec::new());
+		*self.flushing.write() = mem::replace(&mut *db.flushing.write(), Vec::new());
+		Ok(())
 	}
 }
 

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -213,11 +213,11 @@ pub trait KeyValueDB: Sync + Send {
 
 	// We explicitly write out the lifetime here since we don't need the `FnMut` to be able to take
 	// a slice of any lifetime.
-	fn get_exec<'this>(
-		&'this self,
+	fn get_exec(
+		&self,
 		col: Option<u32>,
-		key: &'this [u8],
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8]),
+		key: &[u8],
+		f: &mut FnMut(&[u8]),
 	) -> Result<(), String>;
 
 	/// Get a value by partial key. Only works for flushed data.

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -110,6 +110,9 @@ extern crate itertools;
 extern crate ethcore_logger;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 extern crate log as rlog;
 
 pub extern crate using_queue;

--- a/util/src/memorydb.rs
+++ b/util/src/memorydb.rs
@@ -186,7 +186,11 @@ impl HashDB for MemoryDB {
 		self.get_with(key, DBValue::from_slice)
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
+	fn get_exec<'this>(
+		&'this self,
+		key: &'this H256,
+		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);
 			return;

--- a/util/src/memorydb.rs
+++ b/util/src/memorydb.rs
@@ -82,6 +82,8 @@ impl MemoryDB {
 		}
 	}
 
+	/// Get a raw value by reference, ignoring refcounts. Returns `None` if the key has never been
+	/// added to the database. The data is not guaranteed to be useful if the refcount is 0.
 	pub fn raw_ref(&self, key: &H256) -> Option<(Cow<DBValue>, i32)> {
 		if key == &SHA3_NULL_RLP {
 			return Some(

--- a/util/src/memorydb.rs
+++ b/util/src/memorydb.rs
@@ -82,20 +82,20 @@ impl MemoryDB {
 		}
 	}
 
-  pub fn raw_ref(&self, key: &H256) -> Option<(Cow<DBValue>, i32)> {
+	pub fn raw_ref(&self, key: &H256) -> Option<(Cow<DBValue>, i32)> {
 		if key == &SHA3_NULL_RLP {
 			return Some(
-        (
-          Cow::Owned(DBValue::from_slice(&NULL_RLP)),
-          1,
-        )
-      );
+				(
+					Cow::Owned(DBValue::from_slice(&NULL_RLP)),
+					1,
+				)
+			);
 		}
 
 		self.data.get(key).map(
-      |&(ref val, refcount)| (Cow::Borrowed(val), refcount)
-    )
-  }
+			|&(ref val, refcount)| (Cow::Borrowed(val), refcount)
+		)
+	}
 
 	/// Clear all data from the database.
 	///
@@ -133,7 +133,7 @@ impl MemoryDB {
 	/// Even when Some is returned, the data is only guaranteed to be useful
 	/// when the refs > 0.
 	pub fn raw(&self, key: &H256) -> Option<(DBValue, i32)> {
-    self.raw_ref(key).map(|(val, refcount)| (val.into_owned(), refcount))
+		self.raw_ref(key).map(|(val, refcount)| (val.into_owned(), refcount))
 	}
 
 	/// Returns the size of allocated heap memory
@@ -183,13 +183,13 @@ impl MemoryDB {
 
 impl HashDB for MemoryDB {
 	fn get(&self, key: &H256) -> Option<DBValue> {
-    self.get_with(key, Clone::clone)
+		self.get_with(key, DBValue::from_slice)
 	}
 
-	fn get_exec(&self, key: &H256, f: &mut FnMut(&DBValue)) {
+	fn get_exec(&self, key: &H256, f: &mut FnMut(&[u8])) {
 		if key == &SHA3_NULL_RLP {
-			f(&DBValue::from_slice(&NULL_RLP));
-      return;
+			f(&NULL_RLP);
+			return;
 		}
 
 		match self.data.get(key) {

--- a/util/src/memorydb.rs
+++ b/util/src/memorydb.rs
@@ -186,10 +186,10 @@ impl HashDB for MemoryDB {
 		self.get_with(key, DBValue::from_slice)
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8])
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8])
 	) {
 		if key == &SHA3_NULL_RLP {
 			f(&NULL_RLP);

--- a/util/src/migration/mod.rs
+++ b/util/src/migration/mod.rs
@@ -24,7 +24,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use ::kvdb::{CompactionProfile, Database, DatabaseConfig, DBTransaction};
+use ::kvdb::{CompactionProfile, Database, DatabaseConfig, DBTransaction, KeyValueDB};
 
 /// Migration config.
 #[derive(Clone)]

--- a/util/src/migration/mod.rs
+++ b/util/src/migration/mod.rs
@@ -24,7 +24,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use ::kvdb::{CompactionProfile, Database, DatabaseConfig, DBTransaction, KeyValueDB};
+use ::kvdb::{CompactionProfile, Database, DatabaseConfig, DBTransaction};
 
 /// Migration config.
 #[derive(Clone)]

--- a/util/src/overlaydb.rs
+++ b/util/src/overlaydb.rs
@@ -161,6 +161,8 @@ impl HashDB for OverlayDB {
 			0
 		};
 
+		// This type annotation is necessary, the inferred lifetime is too restrictive otherwise.
+		// Possible bug in the Rust compiler.
 		let mut wrapper = |d: &[u8]| {
 			let r = Rlp::new(d);
 			let refcount: u32 = r.at(0).as_val();

--- a/util/src/overlaydb.rs
+++ b/util/src/overlaydb.rs
@@ -141,10 +141,10 @@ impl HashDB for OverlayDB {
 		ret
 	}
 
-	fn get_exec<'this>(
-		&'this self,
-		key: &'this H256,
-		f: &'this mut for<'a: 'this> FnMut(&'a [u8]),
+	fn get_exec(
+		&self,
+		key: &H256,
+		f: &mut FnMut(&[u8]),
 	) {
 		// return ok if positive; if negative, check backing - might be enough
 		// references there to make it positive again.


### PR DESCRIPTION
This adds a `get_with` method to both `KeyValueDB` and `HashDB`, which takes a reference-taking closure and passes the borrowed value to the function (to avoid cloning). I did some quick benchmarking and this actually seems _slower_ than the previous code. I imagine this is because I reimplemented `get` in terms of `get_with` and the extra dynamic dispatch causes this to be slower. There are some places in the code where the cloned value is only ever used as a borrow where the `get_with` method would be an instant win, so it might be better to have both `get` and `get_with` implemented and use the latter only where necessary.