### PR TITLE
Add the command to install the parity snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ cargo install --git https://github.com/paritytech/parity.git parity
 
 ----
 
+## Install from the snap store
+
+In any of the [supported Linux distros](https://snapcraft.io/docs/core/install):
+
+```bash
+sudo snap install parity --edge
+```
+
+(Note that this is an experimental and unstable release, at the moment)
+
+----
+
 ## Build from source
 
 ```bash


### PR DESCRIPTION
Putting the installation instructions for the snap will help getting more testers, and then publish it in the stable channel with more confidence.