### PR TITLE
Implement health API endpoint

### DIFF
--- a/dapps/src/api/response.rs
+++ b/dapps/src/api/response.rs
@@ -23,6 +23,12 @@ pub fn empty() -> Box<Handler> {
 	Box::new(ContentHandler::ok("".into(), mime!(Text/Plain)))
 }
 
+pub fn as_json<T: Serialize>(val: &T) -> Box<Handler> {
+	let json = serde_json::to_string(val)
+		.expect("serialization to string is infallible; qed");
+	Box::new(ContentHandler::ok(json, mime!(Application/Json)))
+}
+
 pub fn as_json_error<T: Serialize>(val: &T) -> Box<Handler> {
 	let json = serde_json::to_string(val)
 		.expect("serialization to string is infallible; qed");

--- a/dapps/src/tests/api.rs
+++ b/dapps/src/tests/api.rs
@@ -62,6 +62,28 @@ fn should_handle_ping() {
 	assert_security_headers(&response.headers);
 }
 
+#[test]
+fn should_handle_health() {
+	// given
+	let server = serve();
+
+	// when
+	let response = request(server,
+						   "\
+		POST /api/health HTTP/1.1\r\n\
+		Host: home.parity\r\n\
+		Connection: close\r\n\
+		\r\n\
+		{}
+		"
+	);
+
+	// then
+	response.assert_status("HTTP/1.1 200 OK");
+	response.assert_header("Content-Type", "application/json");
+	assert_eq!(response.body, format!("1A\n{}\n0\n\n", r#"{"synced":true,"peers":42}"#));
+	assert_security_headers(&response.headers);
+}
 
 #[test]
 fn should_try_to_resolve_dapp() {

--- a/dapps/src/tests/helpers/mod.rs
+++ b/dapps/src/tests/helpers/mod.rs
@@ -28,7 +28,7 @@ use hash_fetch::urlhint::ContractClient;
 use fetch::{Fetch, Client as FetchClient};
 use parity_reactor::Remote;
 
-use {Middleware, SyncStatus, WebProxyTokens};
+use {Middleware, PeerCount, SyncStatus, WebProxyTokens};
 
 mod registrar;
 mod fetch;
@@ -135,6 +135,7 @@ pub struct ServerBuilder<T: Fetch = FetchClient> {
 	dapps_path: PathBuf,
 	registrar: Arc<ContractClient>,
 	sync_status: Arc<SyncStatus>,
+	peer_count: Arc<PeerCount>,
 	web_proxy_tokens: Arc<WebProxyTokens>,
 	signer_address: Option<(String, u16)>,
 	allowed_hosts: DomainsValidation<Host>,
@@ -149,6 +150,7 @@ impl ServerBuilder {
 			dapps_path: dapps_path.as_ref().to_owned(),
 			registrar: registrar,
 			sync_status: Arc::new(|| false),
+			peer_count: Arc::new(|| 42),
 			web_proxy_tokens: Arc::new(|_| None),
 			signer_address: None,
 			allowed_hosts: DomainsValidation::Disabled,
@@ -165,6 +167,7 @@ impl<T: Fetch> ServerBuilder<T> {
 			dapps_path: self.dapps_path,
 			registrar: self.registrar,
 			sync_status: self.sync_status,
+			peer_count: self.peer_count,
 			web_proxy_tokens: self.web_proxy_tokens,
 			signer_address: self.signer_address,
 			allowed_hosts: self.allowed_hosts,
@@ -212,6 +215,7 @@ impl<T: Fetch> ServerBuilder<T> {
 			vec![],
 			self.registrar,
 			self.sync_status,
+			self.peer_count,
 			self.web_proxy_tokens,
 			self.remote,
 			fetch,
@@ -243,6 +247,7 @@ impl Server {
 		extra_dapps: Vec<PathBuf>,
 		registrar: Arc<ContractClient>,
 		sync_status: Arc<SyncStatus>,
+		peer_count: Arc<PeerCount>,
 		web_proxy_tokens: Arc<WebProxyTokens>,
 		remote: Remote,
 		fetch: F,
@@ -255,6 +260,7 @@ impl Server {
 			DAPPS_DOMAIN.into(),
 			registrar,
 			sync_status,
+			peer_count,
 			web_proxy_tokens,
 			fetch,
 		);
@@ -290,4 +296,3 @@ impl Drop for Server {
 		self.server.take().unwrap().close()
 	}
 }
-

--- a/parity/dapps.rs
+++ b/parity/dapps.rs
@@ -138,6 +138,7 @@ impl ContractClient for LightRegistrar {
 #[derive(Clone)]
 pub struct Dependencies {
 	pub sync_status: Arc<SyncStatus>,
+	pub peer_count: Arc<PeerCount>,
 	pub contract_client: Arc<ContractClient>,
 	pub remote: parity_reactor::TokioRemote,
 	pub fetch: FetchClient,
@@ -169,7 +170,7 @@ pub fn new_ui(enabled: bool, deps: Dependencies) -> Result<Option<Middleware>, S
 	).map(Some)
 }
 
-pub use self::server::{SyncStatus, Middleware, service};
+pub use self::server::{SyncStatus, Middleware, PeerCount, service};
 
 #[cfg(not(feature = "dapps"))]
 mod server {
@@ -180,6 +181,7 @@ mod server {
 	use rpc_apis;
 
 	pub type SyncStatus = Fn() -> bool;
+	pub type PeerCount = Fn() -> usize;
 
 	pub struct Middleware;
 	impl RequestMiddleware for Middleware {
@@ -222,6 +224,7 @@ mod server {
 	use parity_reactor;
 
 	pub use parity_dapps::Middleware;
+	pub use parity_dapps::PeerCount;
 	pub use parity_dapps::SyncStatus;
 
 	pub fn dapps_middleware(
@@ -242,6 +245,7 @@ mod server {
 			dapps_domain,
 			deps.contract_client,
 			deps.sync_status,
+			deps.peer_count,
 			web_proxy_tokens,
 			deps.fetch,
 		))
@@ -256,6 +260,7 @@ mod server {
 			parity_remote,
 			deps.contract_client,
 			deps.sync_status,
+			deps.peer_count,
 			deps.fetch,
 			dapps_domain,
 		))


### PR DESCRIPTION
Initial implementation of health API endpoint, exposed on `/api/health` and returning whether the node is synced and the number of peers.

```
❯ curl http://localhost:8180/api/health
{"synced":false,"peers":50}
```

Fixes #4801.