### PR TITLE
Generate transition proof on uncommitted state

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -200,7 +200,7 @@ pub trait IsBlock {
 
 /// Trait for a object that has a state database.
 pub trait Drain {
-	/// Drop this object and return the underlieing database.
+	/// Drop this object and return the underlying database.
 	fn drain(self) -> StateDB;
 }
 
@@ -368,6 +368,22 @@ impl<'x> OpenBlock<'x> {
 			}
 			Err(x) => Err(From::from(x))
 		}
+	}
+
+	/// Push transactions onto the block.
+	pub fn push_transactions(&mut self, transactions: &[SignedTransaction]) -> Result<(), Error> {
+		push_transactions(self, transactions)
+	}
+
+	/// Populate self from a header.
+	pub fn populate_from(&mut self, header: &Header) {
+		self.set_difficulty(*header.difficulty());
+		self.set_gas_limit(*header.gas_limit());
+		self.set_timestamp(header.timestamp());
+		self.set_author(header.author().clone());
+		self.set_extra_data(header.extra_data().clone()).unwrap_or_else(|e| warn!("Couldn't set extradata: {}. Ignoring.", e));
+		self.set_uncles_hash(header.uncles_hash().clone());
+		self.set_transactions_root(header.transactions_root().clone());
 	}
 
 	/// Turn this into a `ClosedBlock`.
@@ -579,18 +595,13 @@ pub fn enact(
 		is_epoch_begin,
 	)?;
 
-	b.set_difficulty(*header.difficulty());
-	b.set_gas_limit(*header.gas_limit());
-	b.set_timestamp(header.timestamp());
-	b.set_author(header.author().clone());
-	b.set_extra_data(header.extra_data().clone()).unwrap_or_else(|e| warn!("Couldn't set extradata: {}. Ignoring.", e));
-	b.set_uncles_hash(header.uncles_hash().clone());
-	b.set_transactions_root(header.transactions_root().clone());
+	b.populate_from(header);
+	b.push_transactions(transactions)?;
 
-	push_transactions(&mut b, transactions)?;
 	for u in uncles {
 		b.push_uncle(u.clone())?;
 	}
+
 	Ok(b.close_and_lock())
 }
 
@@ -681,7 +692,36 @@ mod tests {
 		let header = block.header();
 		let transactions: Result<Vec<_>, Error> = block.transactions().into_iter().map(SignedTransaction::new).collect();
 		let transactions = transactions?;
-		enact(&header, &transactions, &block.uncles(), engine, tracing, db, parent, last_hashes, factories, false)
+
+		{
+			if ::log::max_log_level() >= ::log::LogLevel::Trace {
+				let s = State::from_existing(db.boxed_clone(), parent.state_root().clone(), engine.account_start_nonce(parent.number() + 1), factories.clone())?;
+				trace!(target: "enact", "num={}, root={}, author={}, author_balance={}\n",
+					header.number(), s.root(), header.author(), s.balance(&header.author())?);
+			}
+		}
+
+		let mut b = OpenBlock::new(
+			engine,
+			factories,
+			tracing,
+			db,
+			parent,
+			last_hashes,
+			Address::new(),
+			(3141562.into(), 31415620.into()),
+			vec![],
+			false,
+		)?;
+
+		b.populate_from(&header);
+		b.push_transactions(&transactions)?;
+
+		for u in &block.uncles() {
+			b.push_uncle(u.clone())?;
+		}
+
+		Ok(b.close_and_lock())
 	}
 
 	/// Enact the block given by `block_bytes` using `engine` on the database `db` with given `parent` block header. Seal the block aferwards

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -656,7 +656,7 @@ impl Client {
 			&receipts,
 			&state,
 			&chain,
-			&mut batch
+			&mut batch,
 		);
 
 		state.journal_under(&mut batch, number, hash).expect("DB commit failed");
@@ -675,7 +675,6 @@ impl Client {
 		// Final commit to the DB
 		self.db.read().write_buffered(batch);
 		chain.commit();
-
 
 		self.check_epoch_end(&header, &chain);
 

--- a/ethcore/src/engines/authority_round/finality.rs
+++ b/ethcore/src/engines/authority_round/finality.rs
@@ -66,6 +66,7 @@ impl RollingFinality {
 
 				let entry = self.sign_count.entry(signer);
 				if let (true, &Entry::Vacant(_)) = (would_be_finalized, &entry) {
+					trace!(target: "finality", "Encountered already finalized block {}", hash);
 					break
 				}
 
@@ -75,6 +76,7 @@ impl RollingFinality {
 			self.headers.push_front((hash, signer));
 		}
 
+		trace!(target: "finality", "Rolling finality state: {:?}", self.headers);
 		Ok(())
 	}
 
@@ -127,6 +129,8 @@ impl RollingFinality {
 				Entry::Vacant(_) => panic!("all hashes in `header` should have an entry in `sign_count` for their signer; qed"),
 			}
 		}
+
+		trace!(target: "finality", "Blocks finalized by {:?}: {:?}", head, newly_finalized);
 
 		Ok(newly_finalized)
 	}

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -723,6 +723,9 @@ impl Engine for AuthorityRound {
 		if epoch_manager.finality_checker.subchain_head() != Some(*chain_head.parent_hash()) {
 			// build new finality checker from ancestry of chain head,
 			// not including chain head itself yet.
+			trace!(target: "finality", "Building finality up to parent of {} ({})",
+				chain_head.hash(), chain_head.parent_hash());
+
 			let mut hash = chain_head.parent_hash().clone();
 			let epoch_transition_hash = epoch_manager.epoch_transition_hash;
 
@@ -734,6 +737,8 @@ impl Engine for AuthorityRound {
 					if header.number() == 0 { return None }
 
 					let res = (hash, header.author().clone());
+					trace!(target: "finality", "Ancestry iteration: yielding {:?}", res);
+
 					hash = header.parent_hash().clone();
 					Some(res)
 				})
@@ -766,6 +771,7 @@ impl Engine for AuthorityRound {
 						let finality_proof = ::rlp::encode_list(&finality_proof);
 						epoch_manager.note_new_epoch();
 
+						info!(target: "engine", "Applying validator set change signalled at block {}", signal_number);
 						return Some(combine_proofs(signal_number, &pending.proof, &*finality_proof));
 					}
 				}

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -613,12 +613,12 @@ impl Engine for AuthorityRound {
 			self.validators.report_malicious(header.author(), header.number(), header.number(), Default::default());
 			Err(EngineError::DoubleVote(header.author().clone()))?;
 		}
-		// Report skipped primaries.
-		if step > parent_step + 1 {
+		// Report skipped primaries, but only if last step wasn't the genesis.
+		if step > parent_step + 1 && header.number() != 1 {
 			// TODO: use epochmanager to get correct validator set for reporting?
 			// or just rely on the fact that in general these will be the same
 			// and some reports might go missing?
-			trace!(target: "engine", "Author {} built block with step gap. current step: {}, parent step: {}",
+			debug!(target: "engine", "Author {} built block with step gap. current step: {}, parent step: {}",
 				header.author(), step, parent_step);
 
 			for s in parent_step + 1..step {

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -220,7 +220,7 @@ pub struct AuthorityRound {
 	builtins: BTreeMap<Address, Builtin>,
 	transition_service: IoService<()>,
 	step: Arc<Step>,
-	proposed: AtomicBool,
+	can_propose: AtomicBool,
 	client: RwLock<Option<Weak<EngineClient>>>,
 	signer: EngineSigner,
 	validators: Box<ValidatorSet>,
@@ -372,7 +372,7 @@ impl AuthorityRound {
 					calibrate: our_params.start_step.is_none(),
 					duration: our_params.step_duration,
 				}),
-				proposed: AtomicBool::new(false),
+				can_propose: AtomicBool::new(true),
 				client: RwLock::new(None),
 				signer: Default::default(),
 				validators: our_params.validators,
@@ -439,7 +439,7 @@ impl Engine for AuthorityRound {
 
 	fn step(&self) {
 		self.step.increment();
-		self.proposed.store(false, AtomicOrdering::SeqCst);
+		self.can_propose.store(true, AtomicOrdering::SeqCst);
 		if let Some(ref weak) = *self.client.read() {
 			if let Some(c) = weak.upgrade() {
 				c.update_sealing();
@@ -481,7 +481,7 @@ impl Engine for AuthorityRound {
 	fn generate_seal(&self, block: &ExecutedBlock) -> Seal {
 		// first check to avoid generating signature most of the time
 		// (but there's still a race to the `compare_and_swap`)
-		if self.proposed.load(AtomicOrdering::SeqCst) { return Seal::None; }
+		if !self.can_propose.load(AtomicOrdering::SeqCst) { return Seal::None; }
 
 		let header = block.header();
 		let step = self.step.load();
@@ -516,7 +516,7 @@ impl Engine for AuthorityRound {
 				trace!(target: "engine", "generate_seal: Issuing a block for step {}.", step);
 
 				// only issue the seal if we were the first to reach the compare_and_swap.
-				if !self.proposed.compare_and_swap(false, true, AtomicOrdering::SeqCst) {
+				if self.can_propose.compare_and_swap(true, false, AtomicOrdering::SeqCst) {
 					return Seal::Regular(vec![encode(&step).into_vec(), encode(&(&H520::from(signature) as &[u8])).into_vec()]);
 				}
 			} else {
@@ -613,8 +613,8 @@ impl Engine for AuthorityRound {
 			self.validators.report_malicious(header.author(), header.number(), header.number(), Default::default());
 			Err(EngineError::DoubleVote(header.author().clone()))?;
 		}
-		// Report skipped primaries, but only if last step wasn't the genesis.
-		if step > parent_step + 1 && header.number() != 1 {
+		// Report skipped primaries
+		if step > parent_step + 1 {
 			// TODO: use epochmanager to get correct validator set for reporting?
 			// or just rely on the fact that in general these will be the same
 			// and some reports might go missing?
@@ -772,6 +772,15 @@ impl Engine for AuthorityRound {
 						epoch_manager.note_new_epoch();
 
 						info!(target: "engine", "Applying validator set change signalled at block {}", signal_number);
+
+						// We turn off can_propose here because upon validator set change there can
+						// be two valid proposers for a single step: one from the old set and
+						// one from the new.
+						//
+						// This way, upon encountering an epoch change, the proposer from the
+						// new set will be forced to wait until the next step to avoid sealing a
+						// block that breaks the invariant that the parent's step < the block's step.
+						self.can_propose.store(false, Ordering::SeqCst);
 						return Some(combine_proofs(signal_number, &pending.proof, &*finality_proof));
 					}
 				}

--- a/ethcore/src/engines/validator_set/contract.rs
+++ b/ethcore/src/engines/validator_set/contract.rs
@@ -107,14 +107,14 @@ impl ValidatorSet for ValidatorContract {
 	fn report_malicious(&self, address: &Address, _set_block: BlockNumber, block: BlockNumber, proof: Bytes) {
 		match self.provider.report_malicious(&*self.transact(), *address, block.into(), proof).wait() {
 			Ok(_) => warn!(target: "engine", "Reported malicious validator {}", address),
-			Err(s) => warn!(target: "engine", "Validator {} could not be reported {}", address, s),
+			Err(_) => {} // warn!(target: "engine", "Validator {} could not be reported {}", address, s),
 		}
 	}
 
 	fn report_benign(&self, address: &Address, _set_block: BlockNumber, block: BlockNumber) {
 		match self.provider.report_benign(&*self.transact(), *address, block.into()).wait() {
 			Ok(_) => warn!(target: "engine", "Reported benign validator misbehaviour {}", address),
-			Err(s) => warn!(target: "engine", "Validator {} could not be reported {}", address, s),
+			Err(_) => {} //warn!(target: "engine", "Validator {} could not be reported {}", address, s),
 		}
 	}
 

--- a/ethcore/src/engines/validator_set/safe_contract.rs
+++ b/ethcore/src/engines/validator_set/safe_contract.rs
@@ -110,6 +110,9 @@ fn prove_initial(provider: &Provider, header: &Header, caller: &Call) -> Result<
 		trace!(target: "engine", "obtained proof for initial set: {} validators, {} bytes",
 			validators.len(), proof.len());
 
+		info!(target: "engine", "Signal for switch to contract-based validator set.");
+		info!(target: "engine", "Initial contract validators: {:?}", validators);
+
 		proof
 	})
 }
@@ -231,9 +234,7 @@ impl ValidatorSet for ValidatorSafeContract {
 			.map(|out| (out, Vec::new()))) // generate no proofs in general
 	}
 
-	fn on_epoch_begin(&self, first: bool, _header: &Header, caller: &mut SystemCall) -> Result<(), ::error::Error> {
-		if first { return Ok(()) } // only signalled changes need to be noted.
-
+	fn on_epoch_begin(&self, _first: bool, _header: &Header, caller: &mut SystemCall) -> Result<(), ::error::Error> {
 		self.provider.finalize_change(caller)
 			.wait()
 			.map_err(::engines::EngineError::FailedSystemCall)
@@ -271,8 +272,9 @@ impl ValidatorSet for ValidatorSafeContract {
 			None => ::engines::EpochChange::Unsure(::engines::Unsure::NeedsReceipts),
 			Some(receipts) => match self.extract_from_event(bloom, header, receipts) {
 				None => ::engines::EpochChange::No,
-				Some(_) => {
-					debug!(target: "engine", "signalling transition within contract");
+				Some(list) => {
+					info!(target: "engine", "Signal for transition within contract. New list: {:?}",
+						&*list);
 
 					let proof = encode_proof(&header, receipts);
 					::engines::EpochChange::Yes(::engines::Proof::Known(proof))


### PR DESCRIPTION
Sometimes it wasn't possible to generate proofs on state committed immediately prior. This works around that and reduces the amount of DB commits necessary.

Also does a little bit of cleanup in `block.rs`, since I tried to make these changes there earlier.