### PR TITLE
Clean up function naming in RPC error module

### DIFF
--- a/rpc/src/v1/helpers/dispatch.rs
+++ b/rpc/src/v1/helpers/dispatch.rs
@@ -162,7 +162,7 @@ impl<C: MiningBlockChainClient, M: MinerService> Dispatcher for FullDispatcher<C
 		let hash = signed_transaction.transaction.hash();
 
 		self.miner.import_own_transaction(&*self.client, signed_transaction)
-			.map_err(errors::from_transaction_error)
+			.map_err(errors::transaction)
 			.map(|_| hash)
 	}
 }
@@ -400,7 +400,7 @@ impl Dispatcher for LightDispatcher {
 
 		self.transaction_queue.write().import(signed_transaction)
 			.map_err(Into::into)
-			.map_err(errors::from_transaction_error)
+			.map_err(errors::transaction)
 			.map(|_| hash)
 	}
 }
@@ -538,8 +538,8 @@ fn signature(accounts: &AccountProvider, address: Address, hash: H256, password:
 		SignWith::Password(pass) => accounts.sign(address, Some(pass), hash).map(WithToken::No),
 		SignWith::Token(token) => accounts.sign_with_token(address, token, hash).map(Into::into),
 	}.map_err(|e| match password {
-		SignWith::Nothing => errors::from_signing_error(e),
-		_ => errors::from_password_error(e),
+		SignWith::Nothing => errors::signing(e),
+		_ => errors::password(e),
 	})
 }
 
@@ -570,8 +570,8 @@ fn decrypt(accounts: &AccountProvider, address: Address, msg: Bytes, password: S
 		SignWith::Password(pass) => accounts.decrypt(address, Some(pass), &DEFAULT_MAC, &msg).map(WithToken::No),
 		SignWith::Token(token) => accounts.decrypt_with_token(address, token, &DEFAULT_MAC, &msg).map(Into::into),
 	}.map_err(|e| match password {
-		SignWith::Nothing => errors::from_signing_error(e),
-		_ => errors::from_password_error(e),
+		SignWith::Nothing => errors::signing(e),
+		_ => errors::password(e),
 	})
 }
 

--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -221,7 +221,7 @@ pub fn network_disabled() -> Error {
 	}
 }
 
-pub fn encryption_error<T: fmt::Debug>(error: T) -> Error {
+pub fn encryption<T: fmt::Debug>(error: T) -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::ENCRYPTION_ERROR),
 		message: "Encryption error.".into(),
@@ -229,7 +229,7 @@ pub fn encryption_error<T: fmt::Debug>(error: T) -> Error {
 	}
 }
 
-pub fn encoding_error<T: fmt::Debug>(error: T) -> Error {
+pub fn encoding<T: fmt::Debug>(error: T) -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::ENCODING_ERROR),
 		message: "Encoding error.".into(),
@@ -237,7 +237,7 @@ pub fn encoding_error<T: fmt::Debug>(error: T) -> Error {
 	}
 }
 
-pub fn database_error<T: fmt::Debug>(error: T) -> Error {
+pub fn database<T: fmt::Debug>(error: T) -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::DATABASE_ERROR),
 		message: "Database error.".into(),
@@ -245,7 +245,7 @@ pub fn database_error<T: fmt::Debug>(error: T) -> Error {
 	}
 }
 
-pub fn from_fetch_error<T: fmt::Debug>(error: T) -> Error {
+pub fn fetch<T: fmt::Debug>(error: T) -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::FETCH_ERROR),
 		message: "Error while fetching content.".into(),
@@ -253,7 +253,7 @@ pub fn from_fetch_error<T: fmt::Debug>(error: T) -> Error {
 	}
 }
 
-pub fn from_signing_error(error: AccountError) -> Error {
+pub fn signing(error: AccountError) -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::ACCOUNT_LOCKED),
 		message: "Your account is locked. Unlock the account via CLI, personal_unlockAccount or use Trusted Signer.".into(),
@@ -261,7 +261,7 @@ pub fn from_signing_error(error: AccountError) -> Error {
 	}
 }
 
-pub fn from_password_error(error: AccountError) -> Error {
+pub fn password(error: AccountError) -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::PASSWORD_INVALID),
 		message: "Account password is invalid or account does not exist.".into(),
@@ -301,7 +301,7 @@ pub fn transaction_message(error: TransactionError) -> String {
 	}
 }
 
-pub fn from_transaction_error(error: EthcoreError) -> Error {
+pub fn transaction(error: EthcoreError) -> Error {
 
 	if let EthcoreError::Transaction(e) = error {
 		Error {
@@ -318,7 +318,7 @@ pub fn from_transaction_error(error: EthcoreError) -> Error {
 	}
 }
 
-pub fn from_rlp_error(error: DecoderError) -> Error {
+pub fn rlp(error: DecoderError) -> Error {
 	Error {
 		code: ErrorCode::InvalidParams,
 		message: "Invalid RLP.".into(),
@@ -326,7 +326,7 @@ pub fn from_rlp_error(error: DecoderError) -> Error {
 	}
 }
 
-pub fn from_call_error(error: CallError) -> Error {
+pub fn call(error: CallError) -> Error {
 	match error {
 		CallError::StatePruned => state_pruned(),
 		CallError::StateCorrupt => state_corrupt(),

--- a/rpc/src/v1/helpers/ipfs.rs
+++ b/rpc/src/v1/helpers/ipfs.rs
@@ -32,7 +32,7 @@ pub fn cid(content: Bytes) -> Result<String, Error> {
 	let mut buf = Vec::with_capacity(len);
 	buf.resize(len, 0);
 	hasher.result(&mut buf);
-	let mh = multihash::encode(multihash::Hash::SHA2256, &buf).map_err(errors::encoding_error)?;
+	let mh = multihash::encode(multihash::Hash::SHA2256, &buf).map_err(errors::encoding)?;
 	let cid = Cid::new(Codec::DagProtobuf, Version::V0, &mh);
 	Ok(cid.to_string().into())
 }

--- a/rpc/src/v1/helpers/secretstore.rs
+++ b/rpc/src/v1/helpers/secretstore.rs
@@ -86,13 +86,13 @@ fn decrypt_with_shadow_coefficients(mut decrypted_shadow: Public, mut common_sha
 	let mut shadow_coefficients_sum = shadow_coefficients[0].clone();
 	for shadow_coefficient in shadow_coefficients.iter().skip(1) {
 		shadow_coefficients_sum.add(shadow_coefficient)
-			.map_err(errors::encryption_error)?;
+			.map_err(errors::encryption)?;
 	}
 
 	math::public_mul_secret(&mut common_shadow_point, &shadow_coefficients_sum)
-		.map_err(errors::encryption_error)?;
+		.map_err(errors::encryption)?;
 	math::public_add(&mut decrypted_shadow, &common_shadow_point)
-		.map_err(errors::encryption_error)?;
+		.map_err(errors::encryption)?;
 	Ok(decrypted_shadow)
 }
 

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -363,18 +363,18 @@ impl Eth for EthClient {
 		let best_header = self.client.best_block_header().decode();
 
 		UntrustedRlp::new(&raw.into_vec()).as_val()
-			.map_err(errors::from_rlp_error)
+			.map_err(errors::rlp)
 			.and_then(|tx| {
 				self.client.engine().verify_transaction_basic(&tx, &best_header)
-					.map_err(errors::from_transaction_error)?;
+					.map_err(errors::transaction)?;
 
-				let signed = SignedTransaction::new(tx).map_err(errors::from_transaction_error)?;
+				let signed = SignedTransaction::new(tx).map_err(errors::transaction)?;
 				let hash = signed.hash();
 
 				self.transaction_queue.write().import(signed.into())
 					.map(|_| hash)
 					.map_err(Into::into)
-					.map_err(errors::from_transaction_error)
+					.map_err(errors::transaction)
 			})
 			.map(Into::into)
 	}

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -241,7 +241,7 @@ impl Parity for ParityClient {
 
 	fn encrypt_message(&self, key: H512, phrase: Bytes) -> Result<Bytes, Error> {
 		ecies::encrypt(&key.into(), &DEFAULT_MAC, &phrase.0)
-			.map_err(errors::encryption_error)
+			.map_err(errors::encryption)
 			.map(Into::into)
 	}
 

--- a/rpc/src/v1/impls/light/parity_set.rs
+++ b/rpc/src/v1/impls/light/parity_set.rs
@@ -127,9 +127,9 @@ impl<F: Fetch> ParitySet for ParitySetClient<F> {
 	fn hash_content(&self, url: String) -> BoxFuture<H256, Error> {
 		self.fetch.process(self.fetch.fetch(&url).then(move |result| {
 			result
-				.map_err(errors::from_fetch_error)
+				.map_err(errors::fetch)
 				.and_then(|response| {
-					sha3(&mut io::BufReader::new(response)).map_err(errors::from_fetch_error)
+					sha3(&mut io::BufReader::new(response)).map_err(errors::fetch)
 				})
 				.map(Into::into)
 		}))

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -284,7 +284,7 @@ impl<C, M, S: ?Sized, U> Parity for ParityClient<C, M, S, U> where
 
 	fn encrypt_message(&self, key: H512, phrase: Bytes) -> Result<Bytes, Error> {
 		ecies::encrypt(&key.into(), &DEFAULT_MAC, &phrase.0)
-			.map_err(errors::encryption_error)
+			.map_err(errors::encryption)
 			.map(Into::into)
 	}
 

--- a/rpc/src/v1/impls/parity_set.rs
+++ b/rpc/src/v1/impls/parity_set.rs
@@ -101,7 +101,7 @@ impl<C, M, U, F> ParitySet for ParitySetClient<C, M, U, F> where
 	}
 
 	fn set_engine_signer(&self, address: H160, password: String) -> Result<bool, Error> {
-		self.miner.set_engine_signer(address.into(), password).map_err(Into::into).map_err(errors::from_password_error)?;
+		self.miner.set_engine_signer(address.into(), password).map_err(Into::into).map_err(errors::password)?;
 		Ok(true)
 	}
 
@@ -168,9 +168,9 @@ impl<C, M, U, F> ParitySet for ParitySetClient<C, M, U, F> where
 	fn hash_content(&self, url: String) -> BoxFuture<H256, Error> {
 		self.fetch.process(self.fetch.fetch(&url).then(move |result| {
 			result
-				.map_err(errors::from_fetch_error)
+				.map_err(errors::fetch)
 				.and_then(|response| {
-					sha3(&mut io::BufReader::new(response)).map_err(errors::from_fetch_error)
+					sha3(&mut io::BufReader::new(response)).map_err(errors::fetch)
 				})
 				.map(Into::into)
 		}))

--- a/rpc/src/v1/impls/signer.rs
+++ b/rpc/src/v1/impls/signer.rs
@@ -133,7 +133,7 @@ impl<D: Dispatcher + 'static> SignerClient<D> {
 	fn verify_transaction<F>(bytes: Bytes, request: FilledTransactionRequest, process: F) -> Result<ConfirmationResponse, Error> where
 		F: FnOnce(PendingTransaction) -> Result<ConfirmationResponse, Error>,
 	{
-		let signed_transaction = UntrustedRlp::new(&bytes.0).as_val().map_err(errors::from_rlp_error)?;
+		let signed_transaction = UntrustedRlp::new(&bytes.0).as_val().map_err(errors::rlp)?;
 		let signed_transaction = SignedTransaction::new(signed_transaction).map_err(|e| errors::invalid_params("Invalid signature.", e))?;
 		let sender = signed_transaction.sender();
 

--- a/rpc/src/v1/impls/traces.rs
+++ b/rpc/src/v1/impls/traces.rs
@@ -87,23 +87,23 @@ impl<C, M> Traces for TracesClient<C, M> where C: MiningBlockChainClient + 'stat
 
 		self.client.call(&signed, block.into(), to_call_analytics(flags))
 			.map(TraceResults::from)
-			.map_err(errors::from_call_error)
+			.map_err(errors::call)
 	}
 
 	fn raw_transaction(&self, raw_transaction: Bytes, flags: Vec<String>, block: Trailing<BlockNumber>) -> Result<TraceResults, Error> {
 		let block = block.unwrap_or_default();
 
 		let tx = UntrustedRlp::new(&raw_transaction.into_vec()).as_val().map_err(|e| errors::invalid_params("Transaction is not valid RLP", e))?;
-		let signed = SignedTransaction::new(tx).map_err(errors::from_transaction_error)?;
+		let signed = SignedTransaction::new(tx).map_err(errors::transaction)?;
 
 		self.client.call(&signed, block.into(), to_call_analytics(flags))
 			.map(TraceResults::from)
-			.map_err(errors::from_call_error)
+			.map_err(errors::call)
 	}
 
 	fn replay_transaction(&self, transaction_hash: H256, flags: Vec<String>) -> Result<TraceResults, Error> {
 		self.client.replay(TransactionId::Hash(transaction_hash.into()), to_call_analytics(flags))
 			.map(TraceResults::from)
-			.map_err(errors::from_call_error)
+			.map_err(errors::call)
 	}
 }


### PR DESCRIPTION
I'm glad to have found somewhere to start :P 

Closes #3204 ; here are the changes to the function names:
```
errors::encryption_error => errors::encryption
errors::encoding_error => errors::encoding
errors::database_error => errors::database
errors::from_fetch_error => errors::fetch
errors::from_signing_error => errors::signing
errors::from_password_error => errors::password
errors::from_transaction_error => errors::transaction
errors::from_call_error => errors::call
```

Let me know if you have better ideas for some names or if there are other things to be done!