### PR TITLE
Add test for loading the chain specs

### DIFF
--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -99,24 +99,6 @@ mod tests {
 	use views::BlockView;
 
 	#[test]
-	fn load_ethereum_specs() {
-		new_olympic();
-		new_foundation();
-		new_classic();
-		new_expanse();
-		new_kovan();
-		new_frontier_test();
-		new_homestead_test();
-		new_eip150_test();
-		new_eip161_test();
-		new_transition_test();
-		new_mainnet_like();
-		new_metropolis_test();
-		new_ropsten();
-		new_morden();
-	}
-
-	#[test]
 	fn ensure_db_good() {
 		let spec = new_morden(&::std::env::temp_dir());
 		let engine = &spec.engine;

--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -99,6 +99,24 @@ mod tests {
 	use views::BlockView;
 
 	#[test]
+	fn load_ethereum_specs() {
+		new_olympic();
+		new_foundation();
+		new_classic();
+		new_expanse();
+		new_kovan();
+		new_frontier_test();
+		new_homestead_test();
+		new_eip150_test();
+		new_eip161_test();
+		new_transition_test();
+		new_mainnet_like();
+		new_metropolis_test();
+		new_ropsten();
+		new_morden();
+	}
+
+	#[test]
 	fn ensure_db_good() {
 		let spec = new_morden(&::std::env::temp_dir());
 		let engine = &spec.engine;

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -465,6 +465,19 @@ mod tests {
 	}
 
 	#[test]
+	fn load_specs() {
+		Spec::new_test();
+		Spec::new_null();
+		Spec::new_test_constructor();
+		Spec::new_instant();
+		Spec::new_test_round();
+		Spec::new_test_tendermint();
+		Spec::new_validator_safe_contract();
+		Spec::new_validator_contract();
+		Spec::new_validator_multi();
+	}
+
+	#[test]
 	fn test_chain() {
 		let test_spec = Spec::new_test();
 

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -465,7 +465,7 @@ mod tests {
 	}
 
 	#[test]
-	fn load_specs() {
+	fn all_spec_files_valid() {
 		Spec::new_test();
 		Spec::new_null();
 		Spec::new_test_constructor();


### PR DESCRIPTION
Closes #4586 

We talked in #4586 about loading every JSON file in `ethcore/res/` and `ethcore/res/ethereum/` and trying to make `Spec`s out of them, but I think it's better to simply call the functions loading those files in the code, as they are what's actually called when passing the `--chain` parameter, and afaik we're not sure if every JSON file in those directories will always be chain specs.