### PR TITLE
Add CSP for worker-src

### DIFF
--- a/dapps/src/handlers/mod.rs
+++ b/dapps/src/handlers/mod.rs
@@ -68,6 +68,9 @@ pub fn add_security_headers(headers: &mut header::Headers, embeddable_on: Embedd
 		b"font-src 'self' data: https:;".to_vec(),
 		// Allow inline scripts and scripts eval (webpack/jsconsole)
 		b"script-src 'self' 'unsafe-inline' 'unsafe-eval';".to_vec(),
+		// Same restrictions as script-src (fallback) with additional
+		// blob: that is required for camera access (worker)
+		b"worker-src 'self' 'unsafe-inline' 'unsafe-eval' blob: ;".to_vec(),
 		// Restrict everything else to the same origin.
 		b"default-src 'self';".to_vec(),
 		// Run in sandbox mode (although it's not fully safe since we allow same-origin and script)
@@ -140,4 +143,3 @@ pub fn convert_uri_to_url(uri: &uri::RequestUri, host: Option<&header::Host>) ->
 		_ => None,
 	}
 }
-

--- a/js/package.json
+++ b/js/package.json
@@ -209,7 +209,7 @@
     "react-intl": "2.1.5",
     "react-markdown": "2.4.4",
     "react-portal": "3.0.0",
-    "react-qr-reader": "1.0.3",
+    "react-qr-reader": "1.1.3",
     "react-redux": "4.4.6",
     "react-router": "3.0.0",
     "react-router-redux": "4.0.7",


### PR DESCRIPTION
Add CSP for workers, making react-qr-scan work

- Upgrade react-qr-scan to latest version (ui)
- Add worker-src CSP with blob: to allow embedded worker (node)