### PR TITLE
Get rid of "TraceDB resync required" error message

### DIFF
--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -531,10 +531,12 @@ pub fn kill_db(cmd: KillBlockchain) -> Result<(), String> {
 	let genesis_hash = spec.genesis_header().hash();
 	let db_dirs = cmd.dirs.database(genesis_hash, None, spec.data_dir);
 	let user_defaults_path = db_dirs.user_defaults_path();
-	let user_defaults = UserDefaults::load(&user_defaults_path)?;
+	let mut user_defaults = UserDefaults::load(&user_defaults_path)?;
 	let algorithm = cmd.pruning.to_algorithm(&user_defaults);
 	let dir = db_dirs.db_path(algorithm);
 	fs::remove_dir_all(&dir).map_err(|e| format!("Error removing database: {:?}", e))?;
+	user_defaults.is_first_launch = true;
+	user_defaults.save(&user_defaults_path)?;
 	info!("Database deleted.");
 	Ok(())
 }

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -754,6 +754,7 @@ pub fn execute(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>) -> R
 	service.register_io_handler(informant.clone()).map_err(|_| "Unable to register informant handler".to_owned())?;
 
 	// save user defaults
+	user_defaults.is_first_launch = false;
 	user_defaults.pruning = algorithm;
 	user_defaults.tracing = tracing;
 	user_defaults.fat_db = fat_db;

--- a/parity/user_defaults.rs
+++ b/parity/user_defaults.rs
@@ -41,6 +41,7 @@ impl Serialize for UserDefaults {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {
 		let mut map: BTreeMap<String, Value> = BTreeMap::new();
+		map.insert("is_first_launch".into(), Value::Bool(self.is_first_launch));
 		map.insert("pruning".into(), Value::String(self.pruning.as_str().into()));
 		map.insert("tracing".into(), Value::Bool(self.tracing));
 		map.insert("fat_db".into(), Value::Bool(self.fat_db));


### PR DESCRIPTION
- `User_defaults` now contains serialization for `is_first_launch` parameter
- Solved the _TraceDB resync required_ error message when trying to use _--tracing on_ option just after a DB kill operation

