### PR TITLE
Unroll loops in light_compute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crunchy"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -365,7 +365,7 @@ dependencies = [
 name = "ethash"
 version = "1.7.0"
 dependencies = [
- "crunchy 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2949,7 +2949,7 @@ dependencies = [
 "checksum core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "20a6d0448d3a99d977ae4a2aa5a98d886a923e863e81ad9ff814645b6feb3bbd"
 "checksum core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05eed248dc504a5391c63794fe4fb64f46f071280afaa1b73308f3c0ce4574c5"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
-"checksum crunchy 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b56bdac907d4b64254aed43964b11dd334bc46e0826a0e3add75caddfaf90175"
+"checksum crunchy 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "803315676d3fc09db67636977586262e7d1a6c5bdb291810efd5ceb48a0d5d58"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
 "checksum daemonize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "271ec51b7e0bee92f0d04601422c73eb76ececf197026711c97ad25038a010cf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crunchy"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -365,7 +365,7 @@ dependencies = [
 name = "ethash"
 version = "1.7.0"
 dependencies = [
- "crunchy 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2949,7 +2949,7 @@ dependencies = [
 "checksum core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "20a6d0448d3a99d977ae4a2aa5a98d886a923e863e81ad9ff814645b6feb3bbd"
 "checksum core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05eed248dc504a5391c63794fe4fb64f46f071280afaa1b73308f3c0ce4574c5"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
-"checksum crunchy 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "803315676d3fc09db67636977586262e7d1a6c5bdb291810efd5ceb48a0d5d58"
+"checksum crunchy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6aa9cb5f2d7bffc4eecfaf924fe450549dc4f0c3a6502298dc24f968b1eabbe"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
 "checksum daemonize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "271ec51b7e0bee92f0d04601422c73eb76ececf197026711c97ad25038a010cf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,11 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crunchy"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crypt32-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +365,7 @@ dependencies = [
 name = "ethash"
 version = "1.7.0"
 dependencies = [
+ "crunchy 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2943,6 +2949,7 @@ dependencies = [
 "checksum core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "20a6d0448d3a99d977ae4a2aa5a98d886a923e863e81ad9ff814645b6feb3bbd"
 "checksum core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05eed248dc504a5391c63794fe4fb64f46f071280afaa1b73308f3c0ce4574c5"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
+"checksum crunchy 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b56bdac907d4b64254aed43964b11dd334bc46e0826a0e3add75caddfaf90175"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
 "checksum daemonize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "271ec51b7e0bee92f0d04601422c73eb76ececf197026711c97ad25038a010cf"

--- a/ethash/Cargo.toml
+++ b/ethash/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.3"
 sha3 = { path = "../util/sha3" }
 primal = "0.2.3"
 parking_lot = "0.4"
+crunchy = "0.1.0"
 
 [features]
 benches = []

--- a/ethash/Cargo.toml
+++ b/ethash/Cargo.toml
@@ -10,3 +10,6 @@ log = "0.3"
 sha3 = { path = "../util/sha3" }
 primal = "0.2.3"
 parking_lot = "0.4"
+
+[features]
+benches = []

--- a/ethash/src/compute.rs
+++ b/ethash/src/compute.rs
@@ -397,8 +397,12 @@ fn light_new(block_number: u64) -> Light {
 			for i in 0..num_nodes {
 				let idx = *nodes.get_unchecked_mut(i).as_words().get_unchecked(0) as usize % num_nodes;
 				let mut data = nodes.get_unchecked((num_nodes - 1 + i) % num_nodes).clone();
-				for w in 0..NODE_WORDS {
-					*data.as_words_mut().get_unchecked_mut(w) ^= *nodes.get_unchecked(idx).as_words().get_unchecked(w);
+
+				debug_assert_eq!(NODE_WORDS, 16);
+				unroll! {
+					for w in 0..16 {
+						*data.as_words_mut().get_unchecked_mut(w) ^= *nodes.get_unchecked(idx).as_words().get_unchecked(w);
+					}
 				}
 				sha3_512(&data.bytes, &mut nodes.get_unchecked_mut(i).bytes);
 			}

--- a/ethash/src/compute.rs
+++ b/ethash/src/compute.rs
@@ -287,12 +287,39 @@ fn hash_compute(light: &Light, full_size: usize, header_hash: &H256, nonce: u64)
 		let num_full_pages = (full_size / page_size) as u32;
 		let cache: &[Node] = &light.cache;  // deref once for better performance
 
-		for i in 0..(ETHASH_ACCESSES as u32) {
-			let index = fnv_hash(f_mix.get_unchecked(0).as_words().get_unchecked(0) ^ i, *mix.get_unchecked(0).as_words().get_unchecked((i as usize) % MIX_WORDS)) % num_full_pages;
-			for n in 0..MIX_NODES {
-				let tmp_node = calculate_dag_item(index * MIX_NODES as u32 + n as u32, cache);
-				for w in 0..NODE_WORDS {
-					*mix.get_unchecked_mut(n).as_words_mut().get_unchecked_mut(w) = fnv_hash(*mix.get_unchecked(n).as_words().get_unchecked(w), *tmp_node.as_words().get_unchecked(w));
+		debug_assert_eq!(ETHASH_ACCESSES, 64);
+		debug_assert_eq!(MIX_NODES, 2);
+		debug_assert_eq!(NODE_WORDS, 16);
+
+		unroll! {
+			// ETHASH_ACCESSES
+			for i_usize in 0..64 {
+				let i = i_usize as u32;
+
+				let index = fnv_hash(
+					f_mix.get_unchecked(0).as_words().get_unchecked(0) ^ i,
+					*mix.get_unchecked(0).as_words().get_unchecked(i_usize % MIX_WORDS)
+				) % num_full_pages;
+
+				unroll! {
+					// MIX_NODES
+					for n in 0..2 {
+						let tmp_node = calculate_dag_item(
+							index * MIX_NODES as u32 + n as u32,
+							cache,
+						);
+
+						unroll! {
+							// NODE_WORDS
+							for w in 0..16 {
+								*mix.get_unchecked_mut(n).as_words_mut().get_unchecked_mut(w) =
+									fnv_hash(
+										*mix.get_unchecked(n).as_words().get_unchecked(w),
+										*tmp_node.as_words().get_unchecked(w),
+									);
+							}
+						}
+					}
 				}
 			}
 		}

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -23,6 +23,8 @@ extern crate sha3;
 extern crate parking_lot;
 
 #[macro_use]
+extern crate crunchy;
+#[macro_use]
 extern crate log;
 mod compute;
 

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "benches", feature(test))]
+
 // Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
@@ -124,4 +126,29 @@ fn test_lru() {
 	ethash.compute_light(70000, &hash, 1);
 	assert_eq!(ethash.cache.lock().recent_epoch.unwrap(), 2);
 	assert_eq!(ethash.cache.lock().prev_epoch.unwrap(), 0);
+}
+
+#[cfg(feature = "benches")]
+mod benchmarks {
+	extern crate test;
+
+	use compute::{Light, light_compute, SeedHashCompute};
+	use self::test::Bencher;
+
+	#[bench]
+	fn bench_light_compute(b: &mut Bencher) {
+		let hash = [0xf5, 0x7e, 0x6f, 0x3a, 0xcf, 0xc0, 0xdd, 0x4b, 0x5b, 0xf2, 0xbe, 0xe4, 0x0a, 0xb3, 0x35, 0x8a, 0xa6, 0x87, 0x73, 0xa8, 0xd0, 0x9f, 0x5e, 0x59, 0x5e, 0xab, 0x55, 0x94, 0x05, 0x52, 0x7d, 0x72];
+		let nonce = 0xd7b3ac70a301a249;
+		let light = Light::new(486382);
+
+		b.iter(|| light_compute(&light, &hash, nonce));
+	}
+
+	#[bench]
+	fn bench_seedhash(b: &mut Bencher) {
+		let seed_compute = SeedHashCompute::new();
+		let hash = [241, 175, 44, 134, 39, 121, 245, 239, 228, 236, 43, 160, 195, 152, 46, 7, 199, 5, 253, 147, 241, 206, 98, 43, 3, 104, 17, 40, 192, 79, 106, 162];
+
+		b.iter(|| seed_compute.get_seedhash(486382));
+	}
 }

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "benches", feature(test))]
-
 // Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
@@ -15,6 +13,8 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(feature = "benches", feature(test))]
 
 //! Ethash implementation
 //! See https://github.com/ethereum/wiki/wiki/Ethash

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -147,7 +147,6 @@ mod benchmarks {
 	#[bench]
 	fn bench_seedhash(b: &mut Bencher) {
 		let seed_compute = SeedHashCompute::new();
-		let hash = [241, 175, 44, 134, 39, 121, 245, 239, 228, 236, 43, 160, 195, 152, 46, 7, 199, 5, 253, 147, 241, 206, 98, 43, 3, 104, 17, 40, 192, 79, 106, 162];
 
 		b.iter(|| seed_compute.get_seedhash(486382));
 	}

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg_attr(feature = "benches", feature(test))]
-
 //! Ethash implementation
 //! See https://github.com/ethereum/wiki/wiki/Ethash
+
+#![cfg_attr(feature = "benches", feature(test))]
+
 extern crate primal;
 extern crate sha3;
 extern crate parking_lot;


### PR DESCRIPTION
Godbolt was showing that this loop (or rather, a representative facsimile of this loop) was not being unrolled, so I used an unrolling macro to force the unrolling to happen. This allows better const-folding and avoids jumps (also, since we make a bunch of function calls that stomp on the registers it avoids having to load from the stack). This is a micro-optimization but benchmarks show almost a 10% improvement.