### PR TITLE
[beta] Bump snap version and tweak importing detection logic (#6079)

### DIFF
--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -558,9 +558,9 @@ impl SnapshotService for Service {
 		self.reader.read().as_ref().map(|r| r.manifest().clone())
 	}
 
-	fn min_supported_version(&self) -> Option<u64> {
+	fn supported_versions(&self) -> Option<(u64, u64)> {
 		self.engine.snapshot_components()
-			.map(|c| c.min_supported_version())
+			.map(|c| (c.min_supported_version(), c.current_version()))
 	}
 
 	fn chunk(&self, hash: H256) -> Option<Bytes> {

--- a/ethcore/src/snapshot/snapshot_service_trait.rs
+++ b/ethcore/src/snapshot/snapshot_service_trait.rs
@@ -27,9 +27,9 @@ pub trait SnapshotService : Sync + Send {
 	/// Query the most recent manifest data.
 	fn manifest(&self) -> Option<ManifestData>;
 
-	/// Get the minimum supported snapshot version number.
+	/// Get the supported range of snapshot version numbers.
 	/// `None` indicates warp sync isn't supported by the consensus engine.
-	fn min_supported_version(&self) -> Option<u64>;
+	fn supported_versions(&self) -> Option<(u64, u64)>;
 
 	/// Get raw chunk for a given hash.
 	fn chunk(&self, hash: H256) -> Option<Bytes>;

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -152,7 +152,7 @@ impl InformantData for FullNodeInformantData {
 					max_peers: status.current_max_peers(net_config.min_peers, net_config.max_peers),
 				}))
 			}
-			_ => (is_major_importing(None, queue_info.clone()), None),
+			_ => (is_major_importing(self.sync.as_ref().map(|s| s.status().state), queue_info.clone()), None),
 		};
 
 		Report {
@@ -254,8 +254,6 @@ impl<T: InformantData> Informant<T> {
 			return;
 		}
 
-		*self.last_tick.write() = Instant::now();
-
 		let (client_report, full_report) = {
 			let mut last_report = self.last_report.lock();
 			let full_report = self.target.report();
@@ -286,6 +284,8 @@ impl<T: InformantData> Informant<T> {
 		if !importing && !snapshot_sync && elapsed < Duration::from_secs(30) {
 			return;
 		}
+
+		*self.last_tick.write() = Instant::now();
 
 		let paint = |c: Style, t: String| match self.with_color && stdout_isatty() {
 			true => format!("{}", c.paint(t)),

--- a/rpc/src/v1/helpers/block_import.rs
+++ b/rpc/src/v1/helpers/block_import.rs
@@ -21,9 +21,10 @@ use ethsync::SyncState;
 
 /// Check if client is during major sync or during block import.
 pub fn is_major_importing(sync_state: Option<SyncState>, queue_info: BlockQueueInfo) -> bool {
-	let is_syncing_state = sync_state.map_or(false, |s|
-		s != SyncState::Idle && s != SyncState::NewBlocks
-	);
+	let is_syncing_state = sync_state.map_or(false, |s| match s {
+		SyncState::Idle | SyncState::NewBlocks | SyncState::WaitingPeers => false,
+		_ => true,
+	});
 	let is_verifying = queue_info.unverified_queue_size + queue_info.verified_queue_size > 3;
 	is_verifying || is_syncing_state
 }

--- a/rpc/src/v1/tests/helpers/snapshot_service.rs
+++ b/rpc/src/v1/tests/helpers/snapshot_service.rs
@@ -41,7 +41,7 @@ impl TestSnapshotService {
 
 impl SnapshotService for TestSnapshotService {
 	fn manifest(&self) -> Option<ManifestData> { None }
-	fn min_supported_version(&self) -> Option<u64> { None }
+	fn supported_versions(&self) -> Option<(u64, u64)> { None }
 	fn chunk(&self, _hash: H256) -> Option<Bytes> { None }
 	fn status(&self) -> RestorationStatus { self.status.lock().clone() }
 	fn begin_restore(&self, _manifest: ManifestData) { }

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -504,7 +504,7 @@ impl ChainSync {
 	}
 
 	fn maybe_start_snapshot_sync(&mut self, io: &mut SyncIo) {
-		if !self.enable_warp_sync || io.snapshot_service().min_supported_version().is_none() {
+		if !self.enable_warp_sync || io.snapshot_service().supported_versions().is_none() {
 			return;
 		}
 		if self.state != SyncState::WaitingPeers && self.state != SyncState::Blocks && self.state != SyncState::Waiting {
@@ -1044,11 +1044,11 @@ impl ChainSync {
 			Ok(manifest) => manifest,
 		};
 
-		let is_supported_version = io.snapshot_service().min_supported_version()
-			.map_or(false, |v| manifest.version >= v);
+		let is_supported_version = io.snapshot_service().supported_versions()
+			.map_or(false, |(l, h)| manifest.version >= l && manifest.version <= h);
 
 		if !is_supported_version {
-			trace!(target: "sync", "{}: Snapshot manifest version too low: {}", peer_id, manifest.version);
+			trace!(target: "sync", "{}: Snapshot manifest version not supported: {}", peer_id, manifest.version);
 			io.disable_peer(peer_id);
 			self.continue_sync(io);
 			return Ok(());

--- a/sync/src/tests/snapshot.rs
+++ b/sync/src/tests/snapshot.rs
@@ -71,8 +71,8 @@ impl SnapshotService for TestSnapshotService {
 		self.manifest.as_ref().cloned()
 	}
 
-	fn min_supported_version(&self) -> Option<u64> {
-		Some(1)
+	fn supported_versions(&self) -> Option<(u64, u64)> {
+		Some((1, 2))
 	}
 
 	fn chunk(&self, hash: H256) -> Option<Bytes> {


### PR DESCRIPTION
* bump last tick just before printing info and restore sync detection

* bump kovan snapshot version

* Fixed sync tests

* Fixed rpc tests