### PR TITLE
Fix QR scanner returning null on confirm

### DIFF
--- a/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormConfirm/transactionPendingFormConfirm.js
+++ b/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormConfirm/transactionPendingFormConfirm.js
@@ -407,7 +407,11 @@ export default class TransactionPendingFormConfirm extends Component {
   onScan = (signature) => {
     const { chainId, rlp, tx, data, decrypt } = this.state.qr;
 
-    if (signature && signature.substr(0, 2) !== '0x') {
+    if (!signature) {
+      return;
+    }
+
+    if (signature.substr(0, 2) !== '0x') {
       signature = `0x${signature}`;
     }
 


### PR DESCRIPTION
Related to the react component upgrade, scanner now returns null, not only valid values where QR detected (fix applied for initial reading in #6119)