### PR TITLE
light client fixes

### DIFF
--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -806,6 +806,9 @@ impl LightProtocol {
 		trace!(target: "pip", "Connected peer with chain head {:?}", (status.head_hash, status.head_num));
 
 		if (status.network_id, status.genesis_hash) != (self.network_id, self.genesis_hash) {
+			trace!(target: "pip", "peer {} wrong network: network_id is {} vs our {}, gh is {} vs our {}",
+				peer, status.network_id, self.network_id, status.genesis_hash, self.genesis_hash);
+
 			return Err(Error::WrongNetwork);
 		}
 

--- a/sync/src/light_sync/mod.rs
+++ b/sync/src/light_sync/mod.rs
@@ -503,10 +503,12 @@ impl<L: AsLightClient> LightSync<L> {
 					None
 				}
 			}).collect();
+
 			let mut rng = self.rng.lock();
+			let mut requested_from = HashSet::new();
 
 			// naive request dispatcher: just give to any peer which says it will
-			// give us responses.
+			// give us responses. but only one request per peer per state transition.
 			let dispatcher = move |req: HeadersRequest| {
 				rng.shuffle(&mut peer_ids);
 
@@ -521,9 +523,12 @@ impl<L: AsLightClient> LightSync<L> {
 					builder.build()
 				};
 				for peer in &peer_ids {
+					if requested_from.contains(peer) { continue }
 					match ctx.request_from(*peer, request.clone()) {
 						Ok(id) => {
 							self.pending_reqs.lock().insert(id.clone());
+							requested_from.insert(peer.clone());
+
 							return Some(id)
 						}
 						Err(NetError::NoCredits) => {}

--- a/sync/src/light_sync/mod.rs
+++ b/sync/src/light_sync/mod.rs
@@ -285,6 +285,13 @@ impl<L: AsLightClient + Send + Sync> Handler for LightSync<L> {
 			best.clone()
 		};
 
+		{
+			let mut pending_reqs = self.pending_reqs.lock();
+			for unfulfilled in unfulfilled {
+				pending_reqs.remove(&unfulfilled);
+			}
+		}
+
 		if new_best.is_none() {
 			debug!(target: "sync", "No peers remain. Reverting to idle");
 			*self.state.lock() = SyncState::Idle;


### PR DESCRIPTION
1. only make one request from a peer per each light sync, allowing other threads to get a turn with access to the handlers.
2. make sure genesis header is available by hash
3. fix memory-lru-cache
4. clear unfulfilled requests from pending requests set in `light_sync` on peer disconnect.