### PR TITLE
Don't display an overlay in case the time sync check fails.

### DIFF
--- a/dapps/src/api/time.rs
+++ b/dapps/src/api/time.rs
@@ -100,6 +100,10 @@ impl SimpleNtp {
 impl Ntp for SimpleNtp {
 	fn drift(&self) -> BoxFuture<Duration, Error> {
 		let address = self.address.clone();
+		if &*address == "none" {
+			return futures::future::err(Error::Ntp("NTP server is not provided.".into())).boxed();
+		}
+
 		self.pool.spawn_fn(move || {
 			let packet = ntp::request(&*address)?;
 			let dest_time = ::time::now_utc().to_timespec();
@@ -227,7 +231,7 @@ mod tests {
 
 	fn time_checker() -> TimeChecker<FakeNtp> {
 		let last_result = Arc::new(RwLock::new(
-			(Instant::now(), vec![Err(Error::Ntp("NTP server unavailable.".into()))].into())
+			(Instant::now(), vec![Err(Error::Ntp("NTP server unavailable".into()))].into())
 		));
 
 		TimeChecker {

--- a/dapps/src/api/time.rs
+++ b/dapps/src/api/time.rs
@@ -114,7 +114,9 @@ impl Ntp for SimpleNtp {
 	}
 }
 
-const MAX_RESULTS: usize = 4;
+// NOTE In a positive scenario first results will be seen after:
+// MAX_RESULTS * UPDATE_TIMEOUT_OK_SECS seconds.
+const MAX_RESULTS: usize = 7;
 const UPDATE_TIMEOUT_OK_SECS: u64 = 30;
 const UPDATE_TIMEOUT_ERR_SECS: u64 = 2;
 

--- a/js/src/redux/providers/status.js
+++ b/js/src/redux/providers/status.js
@@ -228,9 +228,10 @@ export default class Status {
 
   _overallStatus = (health) => {
     const all = [health.peers, health.sync, health.time].filter(x => x);
+    const allNoTime = [health.peers, health.sync].filter(x => x);
     const statuses = all.map(x => x.status);
     const bad = statuses.find(x => x === STATUS_BAD);
-    const needsAttention = statuses.find(x => x === STATUS_WARN);
+    const needsAttention = allNoTime.map(x => x.status).find(x => x === STATUS_WARN);
     const message = all.map(x => x.message).filter(x => x);
 
     if (all.length) {

--- a/js/src/redux/providers/statusReducer.js
+++ b/js/src/redux/providers/statusReducer.js
@@ -35,7 +35,7 @@ const initialState = {
       status: DEFAULT_STATUS
     },
     overall: {
-      isReady: false,
+      isNotReady: true,
       status: DEFAULT_STATUS,
       message: []
     }

--- a/js/src/views/SyncWarning/syncWarning.js
+++ b/js/src/views/SyncWarning/syncWarning.js
@@ -116,7 +116,7 @@ class SyncWarning extends Component {
 
 function mapStateToProps (state) {
   const { health } = state.nodeStatus;
-  const isNotAvailableYet = health.overall.isReady;
+  const isNotAvailableYet = health.overall.isNotReady;
   const isOk = isNotAvailableYet || health.overall.status === 'ok';
 
   return {

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -359,7 +359,7 @@ usage! {
 			or |c: &Config| otry!(c.vm).jit.clone(),
 
 		// -- Miscellaneous Options
-		flag_ntp_server: String = "pool.ntp.org:123",
+		flag_ntp_server: String = "none",
 			or |c: &Config| otry!(c.misc).ntp_server.clone(),
 		flag_logging: Option<String> = None,
 			or |c: &Config| otry!(c.misc).logging.clone().map(Some),
@@ -919,7 +919,7 @@ mod tests {
 			flag_dapps_apis_all: None,
 
 			// -- Miscellaneous Options
-			flag_ntp_server: "pool.ntp.org:123".into(),
+			flag_ntp_server: "none".into(),
 			flag_version: false,
 			flag_logging: Some("own_tx=trace".into()),
 			flag_log_file: Some("/var/log/parity.log".into()),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1277,7 +1277,7 @@ mod tests {
 			support_token_api: true
 		}, UiConfiguration {
 			enabled: true,
-			ntp_server: "pool.ntp.org:123".into(),
+			ntp_server: "none".into(),
 			interface: "127.0.0.1".into(),
 			port: 8180,
 			hosts: Some(vec![]),
@@ -1519,7 +1519,7 @@ mod tests {
 		assert_eq!(conf0.directories().signer, "signer".to_owned());
 		assert_eq!(conf0.ui_config(), UiConfiguration {
 			enabled: true,
-			ntp_server: "pool.ntp.org:123".into(),
+			ntp_server: "none".into(),
 			interface: "127.0.0.1".into(),
 			port: 8180,
 			hosts: Some(vec![]),
@@ -1528,7 +1528,7 @@ mod tests {
 		assert_eq!(conf1.directories().signer, "signer".to_owned());
 		assert_eq!(conf1.ui_config(), UiConfiguration {
 			enabled: true,
-			ntp_server: "pool.ntp.org:123".into(),
+			ntp_server: "none".into(),
 			interface: "127.0.0.1".into(),
 			port: 8180,
 			hosts: Some(vec![]),
@@ -1538,7 +1538,7 @@ mod tests {
 		assert_eq!(conf2.directories().signer, "signer".to_owned());
 		assert_eq!(conf2.ui_config(), UiConfiguration {
 			enabled: true,
-			ntp_server: "pool.ntp.org:123".into(),
+			ntp_server: "none".into(),
 			interface: "127.0.0.1".into(),
 			port: 3123,
 			hosts: Some(vec![]),
@@ -1547,7 +1547,7 @@ mod tests {
 		assert_eq!(conf3.directories().signer, "signer".to_owned());
 		assert_eq!(conf3.ui_config(), UiConfiguration {
 			enabled: true,
-			ntp_server: "pool.ntp.org:123".into(),
+			ntp_server: "none".into(),
 			interface: "test".into(),
 			port: 8180,
 			hosts: Some(vec![]),

--- a/parity/dapps.rs
+++ b/parity/dapps.rs
@@ -47,7 +47,7 @@ impl Default for Configuration {
 		let data_dir = default_data_path();
 		Configuration {
 			enabled: true,
-			ntp_server: "pool.ntp.org:123".into(),
+			ntp_server: "none".into(),
 			dapps_path: replace_home(&data_dir, "$BASE/dapps").into(),
 			extra_dapps: vec![],
 			extra_embed_on: vec![],

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -107,7 +107,7 @@ impl Default for UiConfiguration {
 	fn default() -> Self {
 		UiConfiguration {
 			enabled: true && cfg!(feature = "ui-enabled"),
-			ntp_server: "pool.ntp.org:123".into(),
+			ntp_server: "none".into(),
 			port: 8180,
 			interface: "127.0.0.1".into(),
 			hosts: Some(vec![]),


### PR DESCRIPTION
- Warning status of time does not contribute to overall status
- Fix displaying overlay before first query of health API.