### PR TITLE
Replace usages of ::std::env::temp_dir with tempdir crate in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "parking_lot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.1.0",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -531,6 +532,7 @@ dependencies = [
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stats 0.1.0",
  "table 0.1.0",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "transient-hashmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "using_queue 0.1.0",
@@ -786,6 +788,7 @@ dependencies = [
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.1.0",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1875,6 +1878,7 @@ dependencies = [
  "serde 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1992,6 +1996,7 @@ dependencies = [
  "serde_derive 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stats 0.1.0",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "transient-hashmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/dapps/Cargo.toml
+++ b/dapps/Cargo.toml
@@ -40,6 +40,9 @@ parity-ui = { path = "./ui" }
 
 clippy = { version = "0.0.103", optional = true}
 
+[dev-dependencies]
+tempdir = "0.3.5"
+
 [features]
 dev = ["clippy", "ethcore-util/dev"]
 

--- a/dapps/src/apps/fetcher/mod.rs
+++ b/dapps/src/apps/fetcher/mod.rs
@@ -259,13 +259,14 @@ impl<R: URLHint + 'static, F: Fetch> Fetcher for ContentFetcher<F, R> {
 
 #[cfg(test)]
 mod tests {
-	use std::env;
+	extern crate tempdir;
 	use std::sync::Arc;
 	use util::Bytes;
 	use fetch::{Fetch, Client};
 	use futures::{future, Future, BoxFuture};
 	use hash_fetch::urlhint::{URLHint, URLHintResult};
 	use parity_reactor::Remote;
+	use self::tempdir::TempDir;
 
 	use apps::cache::ContentStatus;
 	use endpoint::EndpointInfo;
@@ -290,7 +291,7 @@ mod tests {
 	#[test]
 	fn should_true_if_contains_the_app() {
 		// given
-		let path = env::temp_dir();
+		let path = TempDir::new("").unwrap().into_path();
 		let fetcher = ContentFetcher::new(FakeResolver, Arc::new(FakeSync(false)), Remote::new_sync(), Client::new().unwrap())
 			.allow_dapps(true);
 		let handler = LocalPageEndpoint::new(path, EndpointInfo {

--- a/ethash/Cargo.toml
+++ b/ethash/Cargo.toml
@@ -12,5 +12,8 @@ primal = "0.2.3"
 parking_lot = "0.4"
 crunchy = "0.1.0"
 
+[dev-dependencies]
+tempdir = "0.3.5"
+
 [features]
 benches = []

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -118,20 +118,27 @@ impl EthashManager {
 	}
 }
 
-#[test]
-fn test_lru() {
-	let ethash = EthashManager::new(&::std::env::temp_dir());
-	let hash = [0u8; 32];
-	ethash.compute_light(1, &hash, 1);
-	ethash.compute_light(50000, &hash, 1);
-	assert_eq!(ethash.cache.lock().recent_epoch.unwrap(), 1);
-	assert_eq!(ethash.cache.lock().prev_epoch.unwrap(), 0);
-	ethash.compute_light(1, &hash, 1);
-	assert_eq!(ethash.cache.lock().recent_epoch.unwrap(), 0);
-	assert_eq!(ethash.cache.lock().prev_epoch.unwrap(), 1);
-	ethash.compute_light(70000, &hash, 1);
-	assert_eq!(ethash.cache.lock().recent_epoch.unwrap(), 2);
-	assert_eq!(ethash.cache.lock().prev_epoch.unwrap(), 0);
+#[cfg(test)]
+mod test {
+	extern crate tempdir;
+	use self::tempdir::TempDir;
+	use super::EthashManager;
+
+	#[test]
+	fn test_lru() {
+		let ethash = EthashManager::new(&TempDir::new("").unwrap());
+		let hash = [0u8; 32];
+		ethash.compute_light(1, &hash, 1);
+		ethash.compute_light(50000, &hash, 1);
+		assert_eq!(ethash.cache.lock().recent_epoch.unwrap(), 1);
+		assert_eq!(ethash.cache.lock().prev_epoch.unwrap(), 0);
+		ethash.compute_light(1, &hash, 1);
+		assert_eq!(ethash.cache.lock().recent_epoch.unwrap(), 0);
+		assert_eq!(ethash.cache.lock().prev_epoch.unwrap(), 1);
+		ethash.compute_light(70000, &hash, 1);
+		assert_eq!(ethash.cache.lock().recent_epoch.unwrap(), 2);
+		assert_eq!(ethash.cache.lock().prev_epoch.unwrap(), 0);
+	}
 }
 
 #[cfg(feature = "benches")]

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -61,6 +61,7 @@ wasm = { path = "wasm" }
 
 [dev-dependencies]
 native-contracts = { path = "native_contracts", features = ["test_contracts"] }
+tempdir = "0.3.5"
 
 [features]
 jit = ["evm/jit"]

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -251,6 +251,8 @@ impl Engine for BasicAuthority {
 
 #[cfg(test)]
 mod tests {
+	extern crate tempdir;
+	use self::tempdir::TempDir;
 	use std::sync::Arc;
 	use util::*;
 	use block::*;
@@ -264,7 +266,7 @@ mod tests {
 	/// Create a new test chain spec with `BasicAuthority` consensus engine.
 	fn new_test_authority() -> Spec {
 		let bytes: &[u8] = include_bytes!("../../res/basic_authority.json");
-		Spec::load(::std::env::temp_dir(), bytes).expect("invalid chain spec")
+		Spec::load(TempDir::new("").unwrap(), bytes).expect("invalid chain spec")
 	}
 
 	#[test]

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -550,6 +550,7 @@ impl Header {
 
 #[cfg(test)]
 mod tests {
+	extern crate tempdir;
 	use std::str::FromStr;
 	use std::collections::BTreeMap;
 	use std::sync::Arc;
@@ -563,9 +564,10 @@ mod tests {
 	use super::super::{new_morden, new_homestead_test};
 	use super::{Ethash, EthashParams, PARITY_GAS_LIMIT_DETERMINANT, ecip1017_eras_block_reward};
 	use rlp;
+	use self::tempdir::TempDir;
 
 	fn test_spec() -> Spec {
-		new_morden(&::std::env::temp_dir())
+		new_morden(&TempDir::new("").unwrap().path())
 	}
 
 	#[test]
@@ -769,7 +771,7 @@ mod tests {
 	fn difficulty_frontier() {
 		let spec = new_homestead_test();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1000000);
@@ -787,7 +789,7 @@ mod tests {
 	fn difficulty_homestead() {
 		let spec = new_homestead_test();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1500000);
@@ -840,7 +842,7 @@ mod tests {
 			ecip1010_pause_transition: 3000000,
 			..get_default_ethash_params()
 		};
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(3500000);
@@ -874,7 +876,7 @@ mod tests {
 			ecip1010_continue_transition: 5000000,
 			..get_default_ethash_params()
 		};
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(5000102);
@@ -920,7 +922,7 @@ mod tests {
 	fn gas_limit_is_multiple_of_determinant() {
 		let spec = new_homestead_test();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 		let mut parent = Header::new();
 		let mut header = Header::new();
 		header.set_number(1);
@@ -964,7 +966,7 @@ mod tests {
 	fn difficulty_max_timestamp() {
 		let spec = new_homestead_test();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1000000);
@@ -992,7 +994,7 @@ mod tests {
 		header.set_number(parent_header.number() + 1);
 		header.set_gas_limit(100_001.into());
 		header.set_difficulty(ethparams.minimum_difficulty);
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 		assert!(ethash.verify_block_family(&header, &parent_header, None).is_ok());
 
 		parent_header.set_number(9);
@@ -1047,7 +1049,7 @@ mod tests {
 			nonce: U256::zero(),
 		}.sign(keypair.secret(), None).into();
 
-		let ethash = Ethash::new(&::std::env::temp_dir(), spec.params().clone(), ethparams, BTreeMap::new());
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), spec.params().clone(), ethparams, BTreeMap::new());
 		assert!(ethash.verify_transaction_basic(&tx1, &header).is_ok());
 		assert!(ethash.verify_transaction_basic(&tx2, &header).is_ok());
 

--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -92,15 +92,17 @@ pub fn new_metropolis_test() -> Spec { load(None, include_bytes!("../../res/ethe
 
 #[cfg(test)]
 mod tests {
+	extern crate tempdir;
 	use util::*;
 	use state::*;
 	use super::*;
 	use tests::helpers::*;
 	use views::BlockView;
+	use self::tempdir::TempDir;
 
 	#[test]
 	fn ensure_db_good() {
-		let spec = new_morden(&::std::env::temp_dir());
+		let spec = new_morden(&TempDir::new("").unwrap().path());
 		let engine = &spec.engine;
 		let genesis_header = spec.genesis_header();
 		let db = spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
@@ -115,7 +117,7 @@ mod tests {
 
 	#[test]
 	fn morden() {
-		let morden = new_morden(&::std::env::temp_dir());
+		let morden = new_morden(&TempDir::new("").unwrap().path());
 
 		assert_eq!(morden.state_root(), "f3f4696bbf3b3b07775128eb7a3763279a394e382130f27c21e70233e04946a9".into());
 		let genesis = morden.genesis_block();
@@ -126,7 +128,7 @@ mod tests {
 
 	#[test]
 	fn frontier() {
-		let frontier = new_foundation(&::std::env::temp_dir());
+		let frontier = new_foundation(&TempDir::new("").unwrap().path());
 
 		assert_eq!(frontier.state_root(), "d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544".into());
 		let genesis = frontier.genesis_block();

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -516,17 +516,19 @@ impl Spec {
 
 #[cfg(test)]
 mod tests {
+	extern crate tempdir;
 	use std::str::FromStr;
 	use util::*;
 	use views::*;
 	use tests::helpers::get_temp_state_db;
 	use state::State;
 	use super::*;
+	use self::tempdir::TempDir;
 
 	// https://github.com/paritytech/parity/issues/1840
 	#[test]
 	fn test_load_empty() {
-		assert!(Spec::load(::std::env::temp_dir(), &[] as &[u8]).is_err());
+		assert!(Spec::load(TempDir::new("").unwrap(), &[] as &[u8]).is_err());
 	}
 
 	#[test]

--- a/ethstore/Cargo.toml
+++ b/ethstore/Cargo.toml
@@ -23,4 +23,7 @@ smallvec = "0.4"
 parity-wordlist = "1.0"
 tempdir = "0.3"
 
+[dev-dependencies]
+tempdir = "0.3.5"
+
 [lib]

--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -282,7 +282,7 @@ impl KeyFileManager for DiskKeyFileManager {
 mod test {
 	extern crate tempdir;
 
-	use std::{env, fs};
+	use std::fs;
 	use super::RootDiskDirectory;
 	use dir::{KeyDirectory, VaultKey};
 	use account::SafeAccount;
@@ -292,8 +292,8 @@ mod test {
 	#[test]
 	fn should_create_new_account() {
 		// given
-		let mut dir = env::temp_dir();
-		dir.push("ethstore_should_create_new_account");
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join("ethstore_should_create_new_account");
 		let keypair = Random.generate().unwrap();
 		let password = "hello world";
 		let directory = RootDiskDirectory::create(dir.clone()).unwrap();
@@ -313,8 +313,8 @@ mod test {
 	#[test]
 	fn should_manage_vaults() {
 		// given
-		let mut dir = env::temp_dir();
-		dir.push("should_create_new_vault");
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join("should_create_new_vault");
 		let directory = RootDiskDirectory::create(dir.clone()).unwrap();
 		let vault_name = "vault";
 		let password = "password";

--- a/ethstore/tests/util/transient_dir.rs
+++ b/ethstore/tests/util/transient_dir.rs
@@ -14,17 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+extern crate tempdir;
 use std::path::PathBuf;
-use std::{env, fs};
+use std::fs;
 use rand::{Rng, OsRng};
 use ethstore::dir::{KeyDirectory, RootDiskDirectory};
 use ethstore::{Error, SafeAccount};
+use self::tempdir::TempDir;
 
 pub fn random_dir() -> PathBuf {
 	let mut rng = OsRng::new().unwrap();
-	let mut dir = env::temp_dir();
-	dir.push(format!("{:x}-{:x}", rng.next_u64(), rng.next_u64()));
-	dir
+    let temp_path = TempDir::new("").unwrap();
+    temp_path.path().join(format!("{:x}-{:x}", rng.next_u64(), rng.next_u64()))
 }
 
 pub struct TransientDir {

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 time = "0.1"
+tempdir = "0.3.5"
 tokio-timer = "0.1"
 transient-hashmap = "0.4"
 
@@ -55,6 +56,8 @@ stats = { path = "../util/stats" }
 
 clippy = { version = "0.0.103", optional = true}
 pretty_assertions = "0.1"
+
+[dev-dependencies]
 
 [features]
 dev = ["clippy", "ethcore/dev", "ethcore-util/dev", "ethsync/dev"]

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -31,6 +31,7 @@ extern crate rustc_hex;
 extern crate semver;
 extern crate serde;
 extern crate serde_json;
+extern crate tempdir;
 extern crate time;
 extern crate tokio_timer;
 extern crate transient_hashmap;

--- a/rpc/src/v1/tests/eth.rs
+++ b/rpc/src/v1/tests/eth.rs
@@ -29,6 +29,7 @@ use ethcore::miner::{MinerOptions, Banning, GasPricer, MinerService, ExternalMin
 use ethcore::account_provider::AccountProvider;
 use ethjson::blockchain::BlockChain;
 use io::IoChannel;
+use tempdir::TempDir;
 use util::{U256, H256, Address, Hashable};
 
 use jsonrpc_core::IoHandler;
@@ -321,7 +322,7 @@ const POSITIVE_NONCE_SPEC: &'static [u8] = br#"{
 #[test]
 fn eth_transaction_count() {
 	let secret = "8a283037bb19c4fed7b1c569e40c7dcff366165eb869110a1b11532963eb9cb2".parse().unwrap();
-	let tester = EthTester::from_spec(Spec::load(&env::temp_dir(), TRANSACTION_COUNT_SPEC).expect("invalid chain spec"));
+	let tester = EthTester::from_spec(Spec::load(&TempDir::new("").unwrap(), TRANSACTION_COUNT_SPEC).expect("invalid chain spec"));
 	let address = tester.accounts.insert_account(secret, "").unwrap();
 	tester.accounts.unlock_account_permanently(address, "".into()).unwrap();
 
@@ -447,7 +448,7 @@ fn verify_transaction_counts(name: String, chain: BlockChain) {
 
 #[test]
 fn starting_nonce_test() {
-	let tester = EthTester::from_spec(Spec::load(&env::temp_dir(), POSITIVE_NONCE_SPEC).expect("invalid chain spec"));
+	let tester = EthTester::from_spec(Spec::load(&TempDir::new("").unwrap(), POSITIVE_NONCE_SPEC).expect("invalid chain spec"));
 	let address = Address::from(10);
 
 	let sample = tester.handler.handle_request_sync(&(r#"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -35,6 +35,9 @@ regex = "0.2"
 lru-cache = "0.1.0"
 ethcore-logger = { path = "../logger" }
 
+[dev-dependencies]
+tempdir = "0.3.5"
+
 [features]
 default = []
 dev = ["clippy"]

--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -198,12 +198,14 @@ mod tests {
 	#![cfg_attr(feature="dev", allow(blacklisted_name))]
 	#![cfg_attr(feature="dev", allow(similar_names))]
 
+	extern crate tempdir;
 	use std::path::Path;
 	use hashdb::{HashDB, DBValue};
 	use super::*;
 	use journaldb::traits::JournalDB;
 	use kvdb::Database;
 	use {Hashable, H32};
+	use self::tempdir::TempDir;
 
 	#[test]
 	fn insert_same_in_fork() {
@@ -360,8 +362,8 @@ mod tests {
 
 	#[test]
 	fn reopen() {
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 		let bar = H256::random();
 
 		let foo = {
@@ -389,8 +391,8 @@ mod tests {
 
 	#[test]
 	fn reopen_remove() {
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 
 		let foo = {
 			let mut jdb = new_db(&dir);
@@ -419,8 +421,8 @@ mod tests {
 
 	#[test]
 	fn reopen_fork() {
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 		let (foo, _, _) = {
 			let mut jdb = new_db(&dir);
 			// history is 1

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -555,6 +555,7 @@ mod tests {
 	#![cfg_attr(feature="dev", allow(blacklisted_name))]
 	#![cfg_attr(feature="dev", allow(similar_names))]
 
+	extern crate tempdir;
 	use std::path::Path;
 	use hashdb::{HashDB, DBValue};
 	use super::*;
@@ -562,6 +563,7 @@ mod tests {
 	use ethcore_logger::init_log;
 	use kvdb::{DatabaseConfig};
 	use {Hashable, H32};
+	use self::tempdir::TempDir;
 
 	#[test]
 	fn insert_same_in_fork() {
@@ -826,8 +828,8 @@ mod tests {
 
 	#[test]
 	fn reopen() {
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 		let bar = H256::random();
 
 		let foo = {
@@ -997,8 +999,8 @@ mod tests {
 	fn reopen_remove_three() {
 		init_log();
 
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 
 		let foo = b"foo".sha3();
 
@@ -1052,8 +1054,8 @@ mod tests {
 
 	#[test]
 	fn reopen_fork() {
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 		let (foo, bar, baz) = {
 			let mut jdb = new_db(&dir);
 			// history is 1

--- a/util/src/journaldb/overlayrecentdb.rs
+++ b/util/src/journaldb/overlayrecentdb.rs
@@ -454,6 +454,7 @@ mod tests {
 	#![cfg_attr(feature="dev", allow(blacklisted_name))]
 	#![cfg_attr(feature="dev", allow(similar_names))]
 
+	extern crate tempdir;
 	use std::path::Path;
 	use super::*;
 	use hashdb::{HashDB, DBValue};
@@ -461,6 +462,7 @@ mod tests {
 	use journaldb::JournalDB;
 	use kvdb::Database;
 	use {H32, Hashable};
+	use self::tempdir::TempDir;
 
 	fn new_db(path: &Path) -> OverlayRecentDB {
 		let backing = Arc::new(Database::open_default(path.to_str().unwrap()).unwrap());
@@ -705,8 +707,8 @@ mod tests {
 
 	#[test]
 	fn reopen() {
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 		let bar = H256::random();
 
 		let foo = {
@@ -873,8 +875,8 @@ mod tests {
 	fn reopen_remove_three() {
 		init_log();
 
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 
 		let foo = b"foo".sha3();
 
@@ -928,8 +930,8 @@ mod tests {
 
 	#[test]
 	fn reopen_fork() {
-		let mut dir = ::std::env::temp_dir();
-		dir.push(H32::random().hex());
+		let temp_path = TempDir::new("").unwrap();
+		let dir = temp_path.path().join(H32::random().hex());
 		let (foo, bar, baz) = {
 			let mut jdb = new_db(&dir);
 			// history is 1


### PR DESCRIPTION
Fix #6147