### PR TITLE
InstantSeal fix

### DIFF
--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -19,7 +19,7 @@ use util::Address;
 use builtin::Builtin;
 use engines::{Engine, Seal};
 use spec::CommonParams;
-use block::ExecutedBlock;
+use block::{ExecutedBlock, IsBlock};
 
 /// An engine which does not provide any consensus mechanism, just seals blocks internally.
 pub struct InstantSeal {
@@ -56,8 +56,8 @@ impl Engine for InstantSeal {
 
 	fn seals_internally(&self) -> Option<bool> { Some(true) }
 
-	fn generate_seal(&self, _block: &ExecutedBlock) -> Seal {
-		Seal::Regular(Vec::new())
+	fn generate_seal(&self, block: &ExecutedBlock) -> Seal {
+		if block.transactions().is_empty() { Seal::None } else { Seal::Regular(Vec::new()) }
 	}
 }
 


### PR DESCRIPTION
@arkpar 's fix for stackoverflow in `InstantSeal` engine

```
frame #297: 0x00000001024bc874 parity`ethcore::miner::miner::{{impl}}::update_sealing(self=0x0000000109edfa10, chain=&MiningBlockChainClient @ 0x00007000181fae90) + 2196 at miner.rs:1138
    frame #298: 0x00000001024be995 parity`ethcore::miner::miner::{{impl}}::chain_new_blocks(self=0x0000000109edfa10, chain=&MiningBlockChainClient @ 0x00007000181fcc50, imported=&[ethcore_bigint::hash::H256] @ 0x00007000181fcc60, _invalid=&[ethcore_bigint::hash::H256] @ 0x00007000181fcc70, enacted=&[ethcore_bigint::hash::H256] @ 0x00007000181fcc80, retracted=&[ethcore_bigint::hash::H256] @ 0x00007000181fcc90) + 1589 at miner.rs:1236
    frame #299: 0x00000001024489e4 parity`ethcore::client::client::{{impl}}::import_sealed_block(self=0x0000000109e46010, block=SealedBlock @ 0x00007000181fd188) + 1908 at client.rs:1837
    frame #300: 0x00000001024b1f11 parity`ethcore::miner::miner::{{impl}}::seal_and_import_block_internally::{{closure}}(sealed=SealedBlock @ 0x00007000181fe668) + 257 at miner.rs:532
    frame #301: 0x0000000101fe1fa1 parity`core::result::{{impl}}::map<ethcore::block::SealedBlock,ethcore::error::BlockError,bool,closure>(self=Result<ethcore::block::SealedBlock, ethcore::error::BlockError> @ 0x00007000181ff718, op=closure @ 0x00007000181ffbc0) + 417 at result.rs:458
    frame #302: 0x00000001024b1a2f parity`ethcore::miner::miner::{{impl}}::seal_and_import_block_internally(self=0x0000000109edfa10, chain=&MiningBlockChainClient @ 0x0000700018201388, block=ClosedBlock @ 0x0000700018201398) + 2319 at miner.rs:529
    frame #303: 0x00000001024bc874 parity`ethcore::miner::miner::{{impl}}::update_sealing(self=0x0000000109edfa10, chain=&MiningBlockChainClient @ 0x0000700018204b70) + 2196 at miner.rs:1138
    frame #304: 0x00000001024ba3ad parity`ethcore::miner::miner::{{impl}}::import_own_transaction(self=0x0000000109edfa10, chain=&MiningBlockChainClient @ 0x0000700018206a60, pending=PendingTransaction @ 0x0000700018206a70) + 3069 at miner.rs:958
    frame #305: 0x000000010024303b parity`parity_rpc::v1::helpers::dispatch::{{impl}}::dispatch_transaction<ethcore::client::client::Client,ethcore::miner::miner::Miner>(self=0x0000700018208950, signed_transaction=PendingTransaction @ 0x0000700018207e68) + 347 at dispatch.rs:164
```