### PR TITLE
Small grammatical error

### DIFF
--- a/js/src/dapps/localtx/Application/application.js
+++ b/js/src/dapps/localtx/Application/application.js
@@ -151,7 +151,7 @@ export default class Application extends Component {
 
     if (!transactions.length) {
       return (
-        <h3>The queue seems is empty.</h3>
+        <h3>The queue seems empty.</h3>
       );
     }
 


### PR DESCRIPTION
Hi,

I've fixed a small typo (_The transaction pool seems empty_ instead of _the transaction pool seems *is* empty_)!

Plz merge