### PR TITLE
EIP #198 and Issue #185: added bn_128_add benchmark

### DIFF
--- a/ethcore/benches/evm.rs
+++ b/ethcore/benches/evm.rs
@@ -48,6 +48,19 @@ fn bn_128_pairing(b: &mut Bencher) {
 }
 
 #[bench]
+fn bn_128_add(b: &mut Bencher) {
+	use bn::{AffineG1, G1, Group};
+
+	let mut rng = StdRng::new().unwrap();
+	let p1: G1 = G1::random(&mut rng);
+	let p2: G1 = G1::random(&mut rng);
+
+	b.iter(|| {
+		let _ = AffineG1::from_jacobian(p1 + p2);
+	});
+}
+
+#[bench]
 fn bn_128_mul(b: &mut Bencher) {
 	use bn::{AffineG1, G1, Fr, Group};
 


### PR DESCRIPTION
Hi Parity Team, 

This pull request adds a benchmark for ethereum builtins bn_128_add for [EIP#198](https://github.com/ethereum/EIPs/pull/198) and [Issue#185](https://github.com/ethereum/tests/issues/185) on the metropolis-update branch.

I'm am new to this project, so I'm not yet acquainted with the formalities around ensuring that all the tests pass etc., however I'm enthusiastic about contributing. So if someone would be interested in helping me enhance the quality of this pull request, I would love to speak with you~

Thank you =)

Tim (@tcsiwula) 