### PR TITLE
Use git for the snap version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: parity
-version: master
+version: git
 summary: Fast, light, robust Ethereum implementation
 description: |
   Parity's goal is to be the fastest, lightest, and most secure Ethereum


### PR DESCRIPTION
For commits with an annotated tag, that tag will be the version. For other commits, a git identifier will be used.
This way, there is no need to manually edit the snap version.