### PR TITLE
Fix a hash displayed in tooltip when signing arbitrary data

### DIFF
--- a/js/src/api/util/format.js
+++ b/js/src/api/util/format.js
@@ -75,7 +75,10 @@ export function bytesToAscii (bytes) {
 }
 
 export function asciiToHex (string) {
-  return '0x' + string.split('').map((s) => s.charCodeAt(0).toString(16)).join('');
+  return '0x' + string.split('')
+    .map(s => s.charCodeAt(0))
+    .map(s => s < 0x10 ? '0' + s.toString(16) : s.toString(16))
+    .join('');
 }
 
 export function padRight (input, length) {

--- a/js/src/api/util/format.spec.js
+++ b/js/src/api/util/format.spec.js
@@ -67,6 +67,7 @@ describe('api/util/format', () => {
 
     it('correctly converts a non-empty string', () => {
       expect(asciiToHex('abc')).to.equal('0x616263');
+      expect(asciiToHex('a\nb')).to.equal('0x610a62');
     });
   });
 

--- a/js/src/api/util/index.js
+++ b/js/src/api/util/index.js
@@ -17,7 +17,7 @@
 import { isAddress as isAddressValid, toChecksumAddress } from '../../abi/util/address';
 import { abiDecode, decodeCallData, decodeMethodInput, methodToAbi } from './decode';
 import { abiEncode, abiUnencode, abiSignature, encodeMethodCallAbi } from './encode';
-import { bytesToHex, hexToAscii, asciiToHex, cleanupValue } from './format';
+import { bytesToHex, hexToAscii, hexToBytes, asciiToHex, cleanupValue } from './format';
 import { fromWei, toWei } from './wei';
 import { sha3 } from './sha3';
 import { isArray, isFunction, isHex, isInstanceOf, isString } from './types';
@@ -37,6 +37,7 @@ export default {
   isString,
   bytesToHex,
   hexToAscii,
+  hexToBytes,
   asciiToHex,
   createIdentityImg,
   decodeCallData,

--- a/js/src/views/Signer/components/SignRequest/signRequest.js
+++ b/js/src/views/Signer/components/SignRequest/signRequest.js
@@ -18,6 +18,7 @@ import { observer } from 'mobx-react';
 import React, { Component, PropTypes } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
+import ReactTooltip from 'react-tooltip';
 
 import HardwareStore from '~/mobx/hardwareStore';
 
@@ -93,7 +94,6 @@ class SignRequest extends Component {
   }
 
   computeHashToSign (data) {
-    console.log(this.context)
     const { sha3, hexToBytes, asciiToHex } = this.context.api.util;
     const bytes = hexToBytes(data);
     const message = hexToBytes(asciiToHex(`\x19Ethereum Signed Message:\n${bytes.length}`));
@@ -146,6 +146,20 @@ class SignRequest extends Component {
       return <div />;
     }
 
+    const tooltip = [
+      <FormattedMessage
+        id='signer.signRequest.tooltip.hash'
+        defaultMessage='Hash to be signed: {hashToSign}'
+        values={ { hashToSign } }
+      />,
+      <br />,
+      <FormattedMessage
+        id='signer.signRequest.tooltip.data'
+        defaultMessage='Data: {data}'
+        values={ { data } }
+      />
+    ];
+
     return (
       <div className={ styles.signDetails }>
         <div className={ styles.address }>
@@ -158,7 +172,16 @@ class SignRequest extends Component {
           />
           <RequestOrigin origin={ origin } />
         </div>
-        <div className={ styles.info } title={ hashToSign }>
+        <ReactTooltip id={ `signRequest-${hashToSign}` }>
+          { tooltip }
+        </ReactTooltip>
+        <div
+          className={ styles.info }
+          data-effect='solid'
+          data-for={ `signRequest-${hashToSign}` }
+          data-place='top'
+          data-tip
+        >
           <p>
             <FormattedMessage
               id='signer.signRequest.request'

--- a/js/src/views/Signer/components/SignRequest/signRequest.spec.js
+++ b/js/src/views/Signer/components/SignRequest/signRequest.spec.js
@@ -53,7 +53,14 @@ function render () {
     <SignRequest signerStore={ signerStore } />,
     {
       context: {
-        store: reduxStore
+        store: reduxStore,
+        api: {
+          util: {
+            sha3: (x) => x,
+            hexToBytes: (x) => x,
+            asciiToHex: (x) => x
+          }
+        }
       }
     }
   ).find('SignRequest').shallow();
@@ -61,7 +68,7 @@ function render () {
   return component;
 }
 
-describe('views/Signer/components/SignRequest', () => {
+describe.only('views/Signer/components/SignRequest', () => {
   beforeEach(() => {
     render();
   });

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -195,7 +195,7 @@ usage! {
 			or |c: &Config| otry!(c.websockets).interface.clone(),
 		flag_ws_apis: String = "web3,eth,pubsub,net,parity,parity_pubsub,traces,rpc,secretstore,shh,shh_pubsub",
 			or |c: &Config| otry!(c.websockets).apis.as_ref().map(|vec| vec.join(",")),
-		flag_ws_origins: String = "chrome-extension://*",
+		flag_ws_origins: String = "chrome-extension://*,moz-extension://*",
 			or |c: &Config| otry!(c.websockets).origins.as_ref().map(|vec| vec.join(",")),
 		flag_ws_hosts: String = "none",
 			or |c: &Config| otry!(c.websockets).hosts.as_ref().map(|vec| vec.join(",")),

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -195,7 +195,7 @@ usage! {
 			or |c: &Config| otry!(c.websockets).interface.clone(),
 		flag_ws_apis: String = "web3,eth,pubsub,net,parity,parity_pubsub,traces,rpc,secretstore,shh,shh_pubsub",
 			or |c: &Config| otry!(c.websockets).apis.as_ref().map(|vec| vec.join(",")),
-		flag_ws_origins: String = "chrome-extension://*,moz-extension://*",
+		flag_ws_origins: String = "chrome-extension://*",
 			or |c: &Config| otry!(c.websockets).origins.as_ref().map(|vec| vec.join(",")),
 		flag_ws_hosts: String = "none",
 			or |c: &Config| otry!(c.websockets).hosts.as_ref().map(|vec| vec.join(",")),


### PR DESCRIPTION
Previously it was displaying `sha3(data)` now it's the data itself and a hash that will be signed.

Closes https://github.com/paritytech/parity-extension/issues/93