### PR TITLE
Ignore errors from dappsUrl when starting UI.

### DIFF
--- a/js/src/secureApi.js
+++ b/js/src/secureApi.js
@@ -325,7 +325,8 @@ export default class SecureApi extends Api {
   _fetchSettings () {
     return Promise
       .all([
-        this._uiApi.parity.dappsUrl(),
+        // ignore dapps disabled errors
+        this._uiApi.parity.dappsUrl().catch(err => null),
         this._uiApi.parity.wsUrl()
       ])
       .then(([dappsUrl, wsUrl]) => {

--- a/js/src/secureApi.js
+++ b/js/src/secureApi.js
@@ -326,7 +326,7 @@ export default class SecureApi extends Api {
     return Promise
       .all([
         // ignore dapps disabled errors
-        this._uiApi.parity.dappsUrl().catch(err => null),
+        this._uiApi.parity.dappsUrl().catch(() => null),
         this._uiApi.parity.wsUrl()
       ])
       .then(([dappsUrl, wsUrl]) => {


### PR DESCRIPTION
Related #6261 

This allows to access the UI even if dapps server is disabled.