### PR TITLE
Increase default gas limit for eth_call.

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -157,7 +157,7 @@ impl<'a, B: 'a + StateBackend, E: Engine + ?Sized> Executive<'a, B, E> {
 	pub fn transact_virtual(&'a mut self, t: &SignedTransaction, options: TransactOptions) -> Result<Executed, ExecutionError> {
 		let sender = t.sender();
 		let balance = self.state.balance(&sender)?;
-		let needed_balance = t.value + t.gas * t.gas_price;
+		let needed_balance = t.value.saturating_add(t.gas.saturating_mul(t.gas_price));
 		if balance < needed_balance {
 			// give the sender a sufficient balance
 			self.state.add_balance(&sender, &(needed_balance - balance), CleanupMode::NoEmpty)?;

--- a/rpc/src/v1/helpers/fake_sign.rs
+++ b/rpc/src/v1/helpers/fake_sign.rs
@@ -28,14 +28,22 @@ pub fn sign_call<B: MiningBlockChainClient, M: MinerService>(
 	client: &Arc<B>,
 	miner: &Arc<M>,
 	request: CallRequest,
+	gas_cap: bool,
 ) -> Result<SignedTransaction, Error> {
 	let from = request.from.unwrap_or(0.into());
+	let mut gas = request.gas.unwrap_or(U256::max_value());
+	if gas_cap {
+		let max_gas = 50_000_000.into();
+		if gas > max_gas {
+			warn!("Gas limit capped to {} (from {})", max_gas, gas);
+			gas = max_gas
+		}
+	}
 
 	Ok(Transaction {
 		nonce: request.nonce.unwrap_or_else(|| client.latest_nonce(&from)),
 		action: request.to.map_or(Action::Create, Action::Call),
-		// gas: request.gas.unwrap_or(U256::one() << 100),
-		gas: request.gas.unwrap_or(U256::max_value()),
+		gas,
 		gas_price: request.gas_price.unwrap_or_else(|| default_gas_price(&**client, &**miner)),
 		value: request.value.unwrap_or(0.into()),
 		data: request.data.unwrap_or_default(),

--- a/rpc/src/v1/helpers/fake_sign.rs
+++ b/rpc/src/v1/helpers/fake_sign.rs
@@ -34,6 +34,7 @@ pub fn sign_call<B: MiningBlockChainClient, M: MinerService>(
 	Ok(Transaction {
 		nonce: request.nonce.unwrap_or_else(|| client.latest_nonce(&from)),
 		action: request.to.map_or(Action::Create, Action::Call),
+		// gas: request.gas.unwrap_or(U256::one() << 100),
 		gas: request.gas.unwrap_or(U256::max_value()),
 		gas_price: request.gas_price.unwrap_or_else(|| default_gas_price(&**client, &**miner)),
 		value: request.value.unwrap_or(0.into()),

--- a/rpc/src/v1/helpers/fake_sign.rs
+++ b/rpc/src/v1/helpers/fake_sign.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use ethcore::client::MiningBlockChainClient;
 use ethcore::miner::MinerService;
 use ethcore::transaction::{Transaction, SignedTransaction, Action};
+use util::U256;
 
 use jsonrpc_core::Error;
 use v1::helpers::CallRequest;
@@ -33,7 +34,7 @@ pub fn sign_call<B: MiningBlockChainClient, M: MinerService>(
 	Ok(Transaction {
 		nonce: request.nonce.unwrap_or_else(|| client.latest_nonce(&from)),
 		action: request.to.map_or(Action::Create, Action::Call),
-		gas: request.gas.unwrap_or(50_000_000.into()),
+		gas: request.gas.unwrap_or(U256::max_value()),
 		gas_price: request.gas_price.unwrap_or_else(|| default_gas_price(&**client, &**miner)),
 		value: request.value.unwrap_or(0.into()),
 		data: request.data.unwrap_or_default(),

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -612,9 +612,9 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM> Eth for EthClient<C, SN, S, M, EM> where
 		self.send_raw_transaction(raw)
 	}
 
-	fn call(&self, request: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<Bytes, Error> {
+	fn call(&self, meta: Self::Metadata, request: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<Bytes, Error> {
 		let request = CallRequest::into(request);
-		let signed = match fake_sign::sign_call(&self.client, &self.miner, request) {
+		let signed = match fake_sign::sign_call(&self.client, &self.miner, request, meta.is_dapp()) {
 			Ok(signed) => signed,
 			Err(e) => return future::err(e).boxed(),
 		};
@@ -628,9 +628,9 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM> Eth for EthClient<C, SN, S, M, EM> where
 		).boxed()
 	}
 
-	fn estimate_gas(&self, request: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256, Error> {
+	fn estimate_gas(&self, meta: Self::Metadata, request: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256, Error> {
 		let request = CallRequest::into(request);
-		let signed = match fake_sign::sign_call(&self.client, &self.miner, request) {
+		let signed = match fake_sign::sign_call(&self.client, &self.miner, request, meta.is_dapp()) {
 			Ok(signed) => signed,
 			Err(e) => return future::err(e).boxed(),
 		};

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -383,7 +383,7 @@ impl Eth for EthClient {
 		self.send_raw_transaction(raw)
 	}
 
-	fn call(&self, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<Bytes, Error> {
+	fn call(&self, _meta: Self::Metadata, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<Bytes, Error> {
 		self.fetcher().proved_execution(req, num).and_then(|res| {
 			match res {
 				Ok(exec) => Ok(exec.output.into()),
@@ -392,7 +392,7 @@ impl Eth for EthClient {
 		}).boxed()
 	}
 
-	fn estimate_gas(&self, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256, Error> {
+	fn estimate_gas(&self, _meta: Self::Metadata, req: CallRequest, num: Trailing<BlockNumber>) -> BoxFuture<RpcU256, Error> {
 		// TODO: binary chop for more accurate estimates.
 		self.fetcher().proved_execution(req, num).and_then(|res| {
 			match res {

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -390,7 +390,7 @@ impl Parity for ParityClient {
 		ipfs::cid(content)
 	}
 
-	fn call(&self, _requests: Vec<CallRequest>, _block: Trailing<BlockNumber>) -> BoxFuture<Vec<Bytes>, Error> {
+	fn call(&self, _meta: Self::Metadata, _requests: Vec<CallRequest>, _block: Trailing<BlockNumber>) -> BoxFuture<Vec<Bytes>, Error> {
 		future::err(errors::light_unimplemented(None)).boxed()
 	}
 }

--- a/rpc/src/v1/impls/light/trace.rs
+++ b/rpc/src/v1/impls/light/trace.rs
@@ -17,7 +17,9 @@
 //! Traces api implementation.
 
 use jsonrpc_core::Error;
+use jsonrpc_core::futures::{future, Future, BoxFuture};
 use jsonrpc_macros::Trailing;
+use v1::Metadata;
 use v1::traits::Traces;
 use v1::helpers::errors;
 use v1::types::{TraceFilter, LocalizedTrace, BlockNumber, Index, CallRequest, Bytes, TraceResults, TraceOptions, H256};
@@ -27,6 +29,8 @@ use v1::types::{TraceFilter, LocalizedTrace, BlockNumber, Index, CallRequest, By
 pub struct TracesClient;
 
 impl Traces for TracesClient {
+	type Metadata = Metadata;
+
 	fn filter(&self, _filter: TraceFilter) -> Result<Option<Vec<LocalizedTrace>>, Error> {
 		Err(errors::light_unimplemented(None))
 	}
@@ -43,12 +47,12 @@ impl Traces for TracesClient {
 		Err(errors::light_unimplemented(None))
 	}
 
-	fn call(&self, _request: CallRequest, _flags: TraceOptions, _block: Trailing<BlockNumber>) -> Result<TraceResults, Error> {
-		Err(errors::light_unimplemented(None))
+	fn call(&self, _meta: Self::Metadata, _request: CallRequest, _flags: TraceOptions, _block: Trailing<BlockNumber>) -> BoxFuture<TraceResults, Error> {
+		future::err(errors::light_unimplemented(None)).boxed()
 	}
 
-	fn call_many(&self, _request: Vec<(CallRequest, TraceOptions)>, _block: Trailing<BlockNumber>) -> Result<Vec<TraceResults>, Error> {
-		Err(errors::light_unimplemented(None))
+	fn call_many(&self, _meta: Self::Metadata, _request: Vec<(CallRequest, TraceOptions)>, _block: Trailing<BlockNumber>) -> BoxFuture<Vec<TraceResults>, Error> {
+		future::err(errors::light_unimplemented(None)).boxed()
 	}
 
 	fn raw_transaction(&self, _raw_transaction: Bytes, _flags: TraceOptions, _block: Trailing<BlockNumber>) -> Result<TraceResults, Error> {

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -411,11 +411,11 @@ impl<C, M, S: ?Sized, U> Parity for ParityClient<C, M, S, U> where
 		ipfs::cid(content)
 	}
 
-	fn call(&self, requests: Vec<CallRequest>, block: Trailing<BlockNumber>) -> BoxFuture<Vec<Bytes>, Error> {
+	fn call(&self, meta: Self::Metadata, requests: Vec<CallRequest>, block: Trailing<BlockNumber>) -> BoxFuture<Vec<Bytes>, Error> {
 		let requests: Result<Vec<(SignedTransaction, _)>, Error> = requests
 			.into_iter()
 			.map(|request| Ok((
-				fake_sign::sign_call(&self.client, &self.miner, request.into())?,
+				fake_sign::sign_call(&self.client, &self.miner, request.into(), meta.is_dapp())?,
 				Default::default()
 			)))
 			.collect();

--- a/rpc/src/v1/impls/traces.rs
+++ b/rpc/src/v1/impls/traces.rs
@@ -18,13 +18,15 @@
 
 use std::sync::Arc;
 
-use rlp::UntrustedRlp;
 use ethcore::client::{MiningBlockChainClient, CallAnalytics, TransactionId, TraceId};
 use ethcore::miner::MinerService;
 use ethcore::transaction::SignedTransaction;
+use rlp::UntrustedRlp;
 
 use jsonrpc_core::Error;
+use jsonrpc_core::futures::{self, Future, BoxFuture};
 use jsonrpc_macros::Trailing;
+use v1::Metadata;
 use v1::traits::Traces;
 use v1::helpers::{errors, fake_sign};
 use v1::types::{TraceFilter, LocalizedTrace, BlockNumber, Index, CallRequest, Bytes, TraceResults, TraceOptions, H256};
@@ -54,6 +56,8 @@ impl<C, M> TracesClient<C, M> {
 }
 
 impl<C, M> Traces for TracesClient<C, M> where C: MiningBlockChainClient + 'static, M: MinerService + 'static {
+	type Metadata = Metadata;
+
 	fn filter(&self, filter: TraceFilter) -> Result<Option<Vec<LocalizedTrace>>, Error> {
 		Ok(self.client.filter_traces(filter.into())
 			.map(|traces| traces.into_iter().map(LocalizedTrace::from).collect()))
@@ -79,31 +83,35 @@ impl<C, M> Traces for TracesClient<C, M> where C: MiningBlockChainClient + 'stat
 			.map(LocalizedTrace::from))
 	}
 
-	fn call(&self, request: CallRequest, flags: TraceOptions, block: Trailing<BlockNumber>) -> Result<TraceResults, Error> {
+	fn call(&self, meta: Self::Metadata, request: CallRequest, flags: TraceOptions, block: Trailing<BlockNumber>) -> BoxFuture<TraceResults, Error> {
 		let block = block.unwrap_or_default();
 
 		let request = CallRequest::into(request);
-		let signed = fake_sign::sign_call(&self.client, &self.miner, request)?;
+		let signed = try_bf!(fake_sign::sign_call(&self.client, &self.miner, request, meta.is_dapp()));
 
-		self.client.call(&signed, to_call_analytics(flags), block.into())
+		let res = self.client.call(&signed, to_call_analytics(flags), block.into())
 			.map(TraceResults::from)
-			.map_err(errors::call)
+			.map_err(errors::call);
+
+		futures::done(res).boxed()
 	}
 
-	fn call_many(&self, requests: Vec<(CallRequest, TraceOptions)>, block: Trailing<BlockNumber>) -> Result<Vec<TraceResults>, Error> {
+	fn call_many(&self, meta: Self::Metadata, requests: Vec<(CallRequest, TraceOptions)>, block: Trailing<BlockNumber>) -> BoxFuture<Vec<TraceResults>, Error> {
 		let block = block.unwrap_or_default();
 
-		let requests = requests.into_iter()
+		let requests = try_bf!(requests.into_iter()
 			.map(|(request, flags)| {
 				let request = CallRequest::into(request);
-				let signed = fake_sign::sign_call(&self.client, &self.miner, request)?;
+				let signed = fake_sign::sign_call(&self.client, &self.miner, request, meta.is_dapp())?;
 				Ok((signed, to_call_analytics(flags)))
 			})
-			.collect::<Result<Vec<_>, _>>()?;
+			.collect::<Result<Vec<_>, Error>>());
 
-		self.client.call_many(&requests, block.into())
+		let res = self.client.call_many(&requests, block.into())
 			.map(|results| results.into_iter().map(TraceResults::from).collect())
-			.map_err(errors::call)
+			.map_err(errors::call);
+
+		futures::done(res).boxed()
 	}
 
 	fn raw_transaction(&self, raw_transaction: Bytes, flags: TraceOptions, block: Trailing<BlockNumber>) -> Result<TraceResults, Error> {

--- a/rpc/src/v1/metadata.rs
+++ b/rpc/src/v1/metadata.rs
@@ -42,6 +42,15 @@ impl Metadata {
 			_ => DappId::default(),
 		}
 	}
+
+	/// Returns true if the request originates from a Dapp.
+	pub fn is_dapp(&self) -> bool {
+		if let Origin::Dapps(_) = self.origin {
+			true
+		} else {
+			false
+		}
+	}
 }
 
 impl jsonrpc_core::Metadata for Metadata {}

--- a/rpc/src/v1/tests/mocked/traces.rs
+++ b/rpc/src/v1/tests/mocked/traces.rs
@@ -25,12 +25,12 @@ use vm::CallType;
 
 use jsonrpc_core::IoHandler;
 use v1::tests::helpers::{TestMinerService};
-use v1::{Traces, TracesClient};
+use v1::{Metadata, Traces, TracesClient};
 
 struct Tester {
 	client: Arc<TestBlockChainClient>,
 	_miner: Arc<TestMinerService>,
-	io: IoHandler,
+	io: IoHandler<Metadata>,
 }
 
 fn io() -> Tester {
@@ -67,7 +67,7 @@ fn io() -> Tester {
 	}));
 	let miner = Arc::new(TestMinerService::default());
 	let traces = TracesClient::new(&client, &miner);
-	let mut io = IoHandler::new();
+	let mut io = IoHandler::default();
 	io.extend_with(traces.to_delegate());
 
 	Tester {

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -110,12 +110,12 @@ build_rpc_trait! {
 		fn submit_transaction(&self, Bytes) -> Result<H256, Error>;
 
 		/// Call contract, returning the output data.
-		#[rpc(async, name = "eth_call")]
-		fn call(&self, CallRequest, Trailing<BlockNumber>) -> BoxFuture<Bytes, Error>;
+		#[rpc(meta, name = "eth_call")]
+		fn call(&self, Self::Metadata, CallRequest, Trailing<BlockNumber>) -> BoxFuture<Bytes, Error>;
 
 		/// Estimate gas needed for execution of given contract.
-		#[rpc(async, name = "eth_estimateGas")]
-		fn estimate_gas(&self, CallRequest, Trailing<BlockNumber>) -> BoxFuture<U256, Error>;
+		#[rpc(meta, name = "eth_estimateGas")]
+		fn estimate_gas(&self, Self::Metadata, CallRequest, Trailing<BlockNumber>) -> BoxFuture<U256, Error>;
 
 		/// Get transaction by its hash.
 		#[rpc(name = "eth_getTransactionByHash")]

--- a/rpc/src/v1/traits/parity.rs
+++ b/rpc/src/v1/traits/parity.rs
@@ -205,7 +205,7 @@ build_rpc_trait! {
 		fn ipfs_cid(&self, Bytes) -> Result<String, Error>;
 
 		/// Call contract, returning the output data.
-		#[rpc(async, name = "parity_call")]
-		fn call(&self, Vec<CallRequest>, Trailing<BlockNumber>) -> BoxFuture<Vec<Bytes>, Error>;
+		#[rpc(meta, name = "parity_call")]
+		fn call(&self, Self::Metadata, Vec<CallRequest>, Trailing<BlockNumber>) -> BoxFuture<Vec<Bytes>, Error>;
 	}
 }

--- a/rpc/src/v1/traits/traces.rs
+++ b/rpc/src/v1/traits/traces.rs
@@ -17,12 +17,15 @@
 //! Traces specific rpc interface.
 
 use jsonrpc_core::Error;
+use jsonrpc_core::futures::BoxFuture;
 use jsonrpc_macros::Trailing;
 use v1::types::{TraceFilter, LocalizedTrace, BlockNumber, Index, CallRequest, Bytes, TraceResults, H256, TraceOptions};
 
 build_rpc_trait! {
 	/// Traces specific rpc interface.
 	pub trait Traces {
+		type Metadata;
+
 		/// Returns traces matching given filter.
 		#[rpc(name = "trace_filter")]
 		fn filter(&self, TraceFilter) -> Result<Option<Vec<LocalizedTrace>>, Error>;
@@ -40,12 +43,12 @@ build_rpc_trait! {
 		fn block_traces(&self, BlockNumber) -> Result<Option<Vec<LocalizedTrace>>, Error>;
 
 		/// Executes the given call and returns a number of possible traces for it.
-		#[rpc(name = "trace_call")]
-		fn call(&self, CallRequest, TraceOptions, Trailing<BlockNumber>) -> Result<TraceResults, Error>;
+		#[rpc(meta, name = "trace_call")]
+		fn call(&self, Self::Metadata, CallRequest, TraceOptions, Trailing<BlockNumber>) -> BoxFuture<TraceResults, Error>;
 
 		/// Executes all given calls and returns a number of possible traces for each of it.
-		#[rpc(name = "trace_callMany")]
-		fn call_many(&self, Vec<(CallRequest, TraceOptions)>, Trailing<BlockNumber>) -> Result<Vec<TraceResults>, Error>;
+		#[rpc(meta, name = "trace_callMany")]
+		fn call_many(&self, Self::Metadata, Vec<(CallRequest, TraceOptions)>, Trailing<BlockNumber>) -> BoxFuture<Vec<TraceResults>, Error>;
 
 		/// Executes the given raw transaction and returns a number of possible traces for it.
 		#[rpc(name = "trace_rawTransaction")]


### PR DESCRIPTION
Resolves #6293 

Might be worth considering hard-limitting gas supply for requests coming from dapps to prevent a malicious dapp from generating substantial load on the node.