### PR TITLE
updated bigint with optimized mul and from_big_indian

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bigint"
-version = "3.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -542,7 +542,7 @@ dependencies = [
 name = "ethcore-bigint"
 version = "0.1.3"
 dependencies = [
- "bigint 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bigint 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2453,7 +2453,7 @@ dependencies = [
 name = "rpc-cli"
 version = "1.4.0"
 dependencies = [
- "bigint 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bigint 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-util 1.8.0",
  "futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-rpc 1.8.0",
@@ -3231,7 +3231,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3a0d842ea781ce92be2bf78a9b38883948542749640b8378b3b2f03d1fd9f1ff"
 "checksum base-x 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f59103b47307f76e03bef1633aec7fa9e29bfb5aa6daf5a334f94233c71f6c1"
 "checksum base32 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b9605ba46d61df0410d8ac686b0007add8172eba90e8e909c347856fe794d8c"
-"checksum bigint 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0673c930652d3d4d6dcd5c45b5db4fa5f8f33994d7323618c43c083b223e8c"
+"checksum bigint 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2b45beaa0727835a98df09295d4250afc52c3f7d375d560997ae942c95b98ceb"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e1e6fb1c9e3d6fcdec57216a74eaa03e41f52a22f13a16438251d8e88b89da"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"

--- a/rpc_cli/Cargo.toml
+++ b/rpc_cli/Cargo.toml
@@ -9,7 +9,7 @@ version = "1.4.0"
 [dependencies]
 futures = "0.1"
 rpassword = "0.3.0"
-bigint = "3.0"
+bigint = "4.0"
 parity-rpc = { path = "../rpc" }
 parity-rpc-client = { path = "../rpc_client" }
 ethcore-util = { path = "../util" }

--- a/util/bigint/Cargo.toml
+++ b/util/bigint/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-bigint = "3.0"
+bigint = "4.0"
 rustc-hex = "1.0"
 rand = "0.3.12"
 libc = "0.2"

--- a/util/rlp/benches/rlp.rs
+++ b/util/rlp/benches/rlp.rs
@@ -15,7 +15,7 @@
 #![feature(test)]
 
 extern crate test;
-extern crate bigint;
+extern crate ethcore_bigint as bigint;
 extern crate rlp;
 
 use test::Bencher;


### PR DESCRIPTION
bigint optimizations from https://github.com/paritytech/bigint/pull/23

reading u256 is now 60% faster

old rlp benches:

```rust
test bench_decode_u256_value         ... bench:         118 ns/iter (+/- 7)
test bench_decode_u64_value          ... bench:          77 ns/iter (+/- 18)
```

new benches:

```rust
test bench_decode_u256_value         ... bench:          73 ns/iter (+/- 5)
test bench_decode_u64_value          ... bench:          80 ns/iter (+/- 32)
```