### PR TITLE
fix panic in parity-evm json tracer

### DIFF
--- a/evmbin/src/display/json.rs
+++ b/evmbin/src/display/json.rs
@@ -116,6 +116,9 @@ impl trace::VMTracer for Informant {
 		self.stack.extend_from_slice(stack_push);
 
 		if let Some((pos, data)) = mem_diff {
+			if self.memory.len() < (pos + data.len()) {
+				self.memory.resize(pos + data.len(), 0);
+			}
 			self.memory[pos..pos + data.len()].copy_from_slice(data);
 		}
 


### PR DESCRIPTION
Before the fix:

```
$ ./target/release/parity-evm --json --gas ffff --code 6060604052
{"pc":0,"op":96,"opName":"PUSH1","gas":"0xffff","gasCost":"0x3","memory":"0x","stack":[],"storage":{},"depth":1}
{"pc":2,"op":96,"opName":"PUSH1","gas":"0xfffc","gasCost":"0x3","memory":"0x","stack":["0x60"],"storage":{},"depth":1}
{"pc":4,"op":82,"opName":"MSTORE","gas":"0xfff9","gasCost":"0xc","memory":"0x","stack":["0x60","0x40"],"storage":{},"depth":1}

====================

stack backtrace:

Thread 'main' panicked at 'index 96 out of range for slice of length 0', src/libcore/slice/mod.rs:735

This is a bug. Please report it at:

    https://github.com/paritytech/parity/issues/new

Abort trap: 6
```


after:
```
$ ./target/release/parity-evm --json --gas ffff --code 6060604052
{"pc":0,"op":96,"opName":"PUSH1","gas":"0xffff","gasCost":"0x3","memory":"0x","stack":[],"storage":{},"depth":1}
{"pc":2,"op":96,"opName":"PUSH1","gas":"0xfffc","gasCost":"0x3","memory":"0x","stack":["0x60"],"storage":{},"depth":1}
{"pc":4,"op":82,"opName":"MSTORE","gas":"0xfff9","gasCost":"0xc","memory":"0x","stack":["0x60","0x40"],"storage":{},"depth":1}
{"pc":4,"op":82,"opName":"MSTORE","gas":"0xffed","gasCost":"0x0","memory":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060","stack":[],"storage":{},"depth":1}
{"output":"0x","gasUsed":"0x12","time":3756}
```