### PR TITLE
Only keep a single rocksdb debug log file

### DIFF
--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -493,6 +493,7 @@ impl Database {
 		}
 		opts.set_parsed_options(&format!("max_total_wal_size={}", 64 * 1024 * 1024))?;
 		opts.set_parsed_options("verify_checksums_in_compaction=0")?;
+		opts.set_parsed_options("keep_log_file_num=1")?;
 		opts.set_max_open_files(config.max_open_files);
 		opts.create_if_missing(true);
 		opts.set_use_fsync(false);


### PR DESCRIPTION
Closes #1100 

Before:

```
db $ ls -l LOG*
-rw-r--r-- 1 user users 19001 Aug 21 15:31 LOG.old.1503322205093659
-rw-r--r-- 1 user users 85319 Aug 21 15:30 LOG.old.1503322205071345
-rw-r--r-- 1 user users 88637 Aug 21 15:29 LOG.old.1503322116371839
-rw-r--r-- 1 user users 32292 Aug 21 15:27 LOG.old.1503321102269360
-rw-r--r-- 1 user users 69247 Aug 21 15:32 LOG
```

After:

```
db $ ls -l LOG*
-rw-r--r-- 1 user users 67999 Aug 21 15:32 LOG
```

Rationale:

- There is no documented way to disable the debug/info logging of rocksdb. 
- Setting the number of logs to 1 is the cleanest and simplest way to get close to disabling the logs.
- 0 log files is not allowed (out of range error).
- alternatives would involve hacky solutions like piping the logs to /dev/null
- KISS, because we consider replacing rocksdb in the long run