### PR TITLE
fix bloom bitvecjournal storage allocation

### DIFF
--- a/util/bloom/src/lib.rs
+++ b/util/bloom/src/lib.rs
@@ -37,9 +37,9 @@ struct BitVecJournal {
 
 impl BitVecJournal {
 	pub fn new(size: usize) -> BitVecJournal {
-		let extra = if size % 8 > 0  { 1 } else { 0 };
+		let extra = if size % 64 > 0  { 1 } else { 0 };
 		BitVecJournal {
-			elems: vec![0u64; size / 8 + extra],
+			elems: vec![0u64; size / 64 + extra],
 			journal: HashSet::new(),
 		}
 	}


### PR DESCRIPTION
Since the type of elem is `u64`, `size/64 + extra` is sufficient for the storage. Correct me if I am wrong or just miss something. Thank you:)

```rust
impl BitVecJournal {
	pub fn new(size: usize) -> BitVecJournal {
		let extra = if size % 8 > 0  { 1 } else { 0 };
		BitVecJournal {
			elems: vec![0u64; size / 8 + extra],
			journal: HashSet::new(),
		}
	}
// ... skip
}
```

