### PR TITLE
Fix memory tracing.

### DIFF
--- a/ethcore/evm/src/interpreter/memory.rs
+++ b/ethcore/evm/src/interpreter/memory.rs
@@ -44,7 +44,7 @@ pub trait Memory {
 }
 
 /// Checks whether offset and size is valid memory range
-fn is_valid_range(off: usize, size: usize)  -> bool {
+pub fn is_valid_range(off: usize, size: usize)  -> bool {
 	// When size is zero we haven't actually expanded the memory
 	let overflow = off.overflowing_add(size).1;
 	size > 0 && !overflow

--- a/ethcore/vm/src/tests.rs
+++ b/ethcore/vm/src/tests.rs
@@ -61,6 +61,7 @@ pub struct FakeExt {
 	pub info: EnvInfo,
 	pub schedule: Schedule,
 	pub balances: HashMap<Address, U256>,
+	pub tracing: bool,
 }
 
 // similar to the normal `finalize` function, but ignoring NeedsReturn.
@@ -183,5 +184,9 @@ impl Ext for FakeExt {
 
 	fn inc_sstore_clears(&mut self) {
 		self.sstore_clears += 1;
+	}
+
+	fn trace_next_instruction(&mut self, _pc: usize, _instruction: u8) -> bool {
+		self.tracing
 	}
 }


### PR DESCRIPTION
VM tracing could cause a crash if the memory range was invalid.