### PR TITLE
Moved attributes under docs

### DIFF
--- a/secret_store/src/key_server.rs
+++ b/secret_store/src/key_server.rs
@@ -51,8 +51,8 @@ impl KeyServerImpl {
 		})
 	}
 
-	#[cfg(test)]
 	/// Get cluster client reference.
+	#[cfg(test)]
 	pub fn cluster(&self) -> Arc<ClusterClient> {
 		self.data.lock().cluster.clone()
 	}

--- a/secret_store/src/key_server_cluster/cluster.rs
+++ b/secret_store/src/key_server_cluster/cluster.rs
@@ -72,14 +72,14 @@ pub trait ClusterClient: Send + Sync {
 	/// Start new signing session.
 	fn new_signing_session(&self, session_id: SessionId, requestor_signature: Signature, message_hash: H256) -> Result<Arc<SigningSession>, Error>;
 
-	#[cfg(test)]
 	/// Ask node to make 'faulty' generation sessions.
+	#[cfg(test)]
 	fn make_faulty_generation_sessions(&self);
-	#[cfg(test)]
 	/// Get active generation session with given id.
-	fn generation_session(&self, session_id: &SessionId) -> Option<Arc<GenerationSessionImpl>>;
 	#[cfg(test)]
+	fn generation_session(&self, session_id: &SessionId) -> Option<Arc<GenerationSessionImpl>>;
 	/// Try connect to disconnected nodes.
+	#[cfg(test)]
 	fn connect(&self);
 }
 
@@ -91,8 +91,8 @@ pub trait Cluster: Send + Sync {
 	fn send(&self, to: &NodeId, message: Message) -> Result<(), Error>;
 }
 
-#[derive(Clone)]
 /// Cluster initialization parameters.
+#[derive(Clone)]
 pub struct ClusterConfiguration {
 	/// Number of threads reserved by cluster.
 	pub threads: usize,
@@ -214,14 +214,14 @@ impl ClusterCore {
 		Arc::new(ClusterClientImpl::new(self.data.clone()))
 	}
 
-	#[cfg(test)]
 	/// Get cluster configuration.
+	#[cfg(test)]
 	pub fn config(&self) -> &ClusterConfiguration {
 		&self.data.config
 	}
 
-	#[cfg(test)]
 	/// Get connection to given node.
+	#[cfg(test)]
 	pub fn connection(&self, node: &NodeId) -> Option<Arc<Connection>> {
 		self.data.connection(node)
 	}

--- a/secret_store/src/key_server_cluster/decryption_session.rs
+++ b/secret_store/src/key_server_cluster/decryption_session.rs
@@ -170,26 +170,26 @@ impl SessionImpl {
 		})
 	}
 
-	#[cfg(test)]
 	/// Get this node id.
+	#[cfg(test)]
 	pub fn node(&self) -> &NodeId {
 		&self.core.meta.self_node_id
 	}
 
-	#[cfg(test)]
 	/// Get this session access key.
+	#[cfg(test)]
 	pub fn access_key(&self) -> &Secret {
 		&self.core.access_key
 	}
 
-	#[cfg(test)]
 	/// Get session state.
+	#[cfg(test)]
 	pub fn state(&self) -> ConsensusSessionState {
 		self.data.lock().consensus_session.state()
 	}
 
-	#[cfg(test)]
 	/// Get decrypted secret
+	#[cfg(test)]
 	pub fn decrypted_secret(&self) -> Option<Result<EncryptedDocumentKeyShadow, Error>> {
 		self.data.lock().result.clone()
 	}

--- a/secret_store/src/key_server_cluster/encryption_session.rs
+++ b/secret_store/src/key_server_cluster/encryption_session.rs
@@ -73,8 +73,8 @@ pub struct SessionParams {
 	pub cluster: Arc<Cluster>,
 }
 
-#[derive(Debug)]
 /// Mutable data of encryption (distributed key generation) session.
+#[derive(Debug)]
 struct SessionData {
 	/// Current state of the session.
 	state: SessionState,
@@ -84,16 +84,16 @@ struct SessionData {
 	result: Option<Result<(), Error>>,
 }
 
-#[derive(Debug, Clone)]
 /// Mutable node-specific data.
+#[derive(Debug, Clone)]
 struct NodeData {
 	// === Values, filled during initialization phase ===
 	/// Flags marking that node has confirmed session initialization.
 	pub initialization_confirmed: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
 /// Encryption (distributed key generation) session state.
+#[derive(Debug, Clone, PartialEq)]
 pub enum SessionState {
 	// === Initialization states ===
 	/// Every node starts in this state.

--- a/secret_store/src/key_server_cluster/generation_session.rs
+++ b/secret_store/src/key_server_cluster/generation_session.rs
@@ -72,8 +72,8 @@ pub struct SessionParams {
 	pub cluster: Arc<Cluster>,
 }
 
-#[derive(Debug)]
 /// Mutable data of distributed key generation session.
+#[derive(Debug)]
 struct SessionData {
 	/// Current state of the session.
 	state: SessionState,
@@ -110,8 +110,8 @@ struct SessionData {
 	joint_public_and_secret: Option<Result<(Public, Secret), Error>>,
 }
 
-#[derive(Debug, Clone)]
 /// Mutable node-specific data.
+#[derive(Debug, Clone)]
 struct NodeData {
 	/// Random unique scalar. Persistent.
 	pub id_number: Secret,
@@ -137,8 +137,8 @@ struct NodeData {
 	pub completion_confirmed: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
 /// Schedule for visiting other nodes of cluster.
+#[derive(Debug, Clone, PartialEq)]
 pub struct EveryOtherNodeVisitor {
 	/// Already visited nodes.
 	visited: BTreeSet<NodeId>,
@@ -148,8 +148,8 @@ pub struct EveryOtherNodeVisitor {
 	in_progress: BTreeSet<NodeId>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
 /// Distributed key generation session state.
+#[derive(Debug, Clone, PartialEq)]
 pub enum SessionState {
 	// === Initialization states ===
 	/// Every node starts in this state.
@@ -209,8 +209,8 @@ impl SessionImpl {
 		&self.self_node_id
 	}
 
-	#[cfg(test)]
 	/// Get derived point.
+	#[cfg(test)]
 	pub fn derived_point(&self) -> Option<Public> {
 		self.data.lock().derived_point.clone()
 	}

--- a/secret_store/src/key_server_cluster/io/deadline.rs
+++ b/secret_store/src/key_server_cluster/io/deadline.rs
@@ -32,8 +32,8 @@ pub fn deadline<F, T>(duration: Duration, handle: &Handle, future: F) -> Result<
 	Ok(deadline)
 }
 
-#[derive(Debug, PartialEq)]
 /// Deadline future completion status.
+#[derive(Debug, PartialEq)]
 pub enum DeadlineStatus<T> {
 	/// Completed a future.
 	Meet(T),

--- a/secret_store/src/key_server_cluster/io/handshake.rs
+++ b/secret_store/src/key_server_cluster/io/handshake.rs
@@ -74,8 +74,8 @@ pub fn accept_handshake<A>(a: A, self_key_pair: Arc<NodeKeyPair>) -> Handshake<A
 	}
 }
 
-#[derive(Debug, PartialEq)]
 /// Result of handshake procedure.
+#[derive(Debug, PartialEq)]
 pub struct HandshakeResult {
 	/// Node id.
 	pub node_id: NodeId,

--- a/secret_store/src/key_server_cluster/io/message.rs
+++ b/secret_store/src/key_server_cluster/io/message.rs
@@ -31,8 +31,8 @@ use key_server_cluster::message::{Message, ClusterMessage, GenerationMessage, En
 /// Size of serialized header.
 pub const MESSAGE_HEADER_SIZE: usize = 4;
 
-#[derive(Debug, PartialEq)]
 /// Message header.
+#[derive(Debug, PartialEq)]
 pub struct MessageHeader {
 	/// Message/Header version.
 	pub version: u8,
@@ -42,8 +42,8 @@ pub struct MessageHeader {
 	pub size: u16,
 }
 
-#[derive(Debug, Clone, PartialEq)]
 /// Serialized message.
+#[derive(Debug, Clone, PartialEq)]
 pub struct SerializedMessage(Vec<u8>);
 
 impl Deref for SerializedMessage {

--- a/secret_store/src/key_server_cluster/jobs/job_session.rs
+++ b/secret_store/src/key_server_cluster/jobs/job_session.rs
@@ -17,8 +17,8 @@
 use std::collections::{BTreeSet, BTreeMap};
 use key_server_cluster::{Error, NodeId, SessionMeta};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
 /// Partial response action.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum JobPartialResponseAction {
 	/// Ignore this response.
 	Ignore,
@@ -28,8 +28,8 @@ pub enum JobPartialResponseAction {
 	Accept,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
 /// Partial request action.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum JobPartialRequestAction<PartialJobResponse> {
 	/// Repond with reject.
 	Reject(PartialJobResponse),
@@ -64,8 +64,8 @@ pub trait JobTransport {
 	fn send_partial_response(&self, node: &NodeId, response: Self::PartialJobResponse) -> Result<(), Error>;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
 /// Current state of job session.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum JobSessionState {
 	/// Session is inactive.
 	Inactive,
@@ -123,8 +123,8 @@ impl<Executor, Transport> JobSession<Executor, Transport> where Executor: JobExe
 		}
 	}
 
-	#[cfg(test)]
 	/// Get transport reference.
+	#[cfg(test)]
 	pub fn transport(&self) -> &Transport {
 		&self.transport
 	}
@@ -134,8 +134,8 @@ impl<Executor, Transport> JobSession<Executor, Transport> where Executor: JobExe
 		self.data.state
 	}
 
-	#[cfg(test)]
 	/// Get rejects.
+	#[cfg(test)]
 	pub fn rejects(&self) -> &BTreeSet<NodeId> {
 		debug_assert!(self.meta.self_node_id == self.meta.master_node_id);
 

--- a/secret_store/src/key_server_cluster/math.rs
+++ b/secret_store/src/key_server_cluster/math.rs
@@ -20,8 +20,8 @@ use bigint::hash::H256;
 use hash::keccak;
 use key_server_cluster::Error;
 
-#[derive(Debug)]
 /// Encryption result.
+#[derive(Debug)]
 pub struct EncryptedSecret {
 	/// Common encryption point.
 	pub common_point: Public,
@@ -183,8 +183,8 @@ pub fn compute_joint_public<'a, I>(public_shares: I) -> Result<Public, Error> wh
 	compute_public_sum(public_shares)
 }
 
-#[cfg(test)]
 /// Compute joint secret key.
+#[cfg(test)]
 pub fn compute_joint_secret<'a, I>(secret_coeffs: I) -> Result<Secret, Error> where I: Iterator<Item=&'a Secret> {
 	compute_secret_sum(secret_coeffs)
 }
@@ -240,8 +240,8 @@ pub fn compute_joint_shadow_point<'a, I>(nodes_shadow_points: I) -> Result<Publi
 	compute_public_sum(nodes_shadow_points)
 }
 
-#[cfg(test)]
 /// Compute joint shadow point (version for tests).
+#[cfg(test)]
 pub fn compute_joint_shadow_point_test<'a, I>(access_key: &Secret, common_point: &Public, nodes_shadows: I) -> Result<Public, Error> where I: Iterator<Item=&'a Secret> {
 	let mut joint_shadow = compute_secret_sum(nodes_shadows)?;
 	joint_shadow.mul(access_key)?;
@@ -279,8 +279,8 @@ pub fn make_common_shadow_point(threshold: usize, mut common_point: Public) -> R
 	}
 }
 
-#[cfg(test)]
 /// Decrypt shadow-encrypted secret.
+#[cfg(test)]
 pub fn decrypt_with_shadow_coefficients(mut decrypted_shadow: Public, mut common_shadow_point: Public, shadow_coefficients: Vec<Secret>) -> Result<Public, Error> {
 	let shadow_coefficients_sum = compute_secret_sum(shadow_coefficients.iter())?;
 	math::public_mul_secret(&mut common_shadow_point, &shadow_coefficients_sum)?;
@@ -288,8 +288,8 @@ pub fn decrypt_with_shadow_coefficients(mut decrypted_shadow: Public, mut common
 	Ok(decrypted_shadow)
 }
 
-#[cfg(test)]
 /// Decrypt data using joint secret (version for tests).
+#[cfg(test)]
 pub fn decrypt_with_joint_secret(encrypted_point: &Public, common_point: &Public, joint_secret: &Secret) -> Result<Public, Error> {
 	let mut common_point_mul = common_point.clone();
 	math::public_mul_secret(&mut common_point_mul, joint_secret)?;
@@ -358,8 +358,8 @@ pub fn compute_signature<'a, I>(signature_shares: I) -> Result<Secret, Error> wh
 	compute_secret_sum(signature_shares)
 }
 
-#[cfg(test)]
 /// Locally compute Schnorr signature as described in https://en.wikipedia.org/wiki/Schnorr_signature#Signing.
+#[cfg(test)]
 pub fn local_compute_signature(nonce: &Secret, secret: &Secret, message_hash: &Secret) -> Result<(Secret, Secret), Error> {
 	let mut nonce_public = math::generation_point();
 	math::public_mul_secret(&mut nonce_public, &nonce).unwrap();
@@ -374,8 +374,8 @@ pub fn local_compute_signature(nonce: &Secret, secret: &Secret, message_hash: &S
 	Ok((combined_hash, sig))
 }
 
-#[cfg(test)]
 /// Verify signature as described in https://en.wikipedia.org/wiki/Schnorr_signature#Verifying.
+#[cfg(test)]
 pub fn verify_signature(public: &Public, signature: &(Secret, Secret), message_hash: &H256) -> Result<bool, Error> {
 	let mut addendum = math::generation_point();
 	math::public_mul_secret(&mut addendum, &signature.1)?;

--- a/secret_store/src/key_server_cluster/message.rs
+++ b/secret_store/src/key_server_cluster/message.rs
@@ -23,8 +23,8 @@ use super::{SerializableH256, SerializablePublic, SerializableSecret, Serializab
 pub type MessageSessionId = SerializableH256;
 pub type MessageNodeId = SerializablePublic;
 
-#[derive(Clone, Debug)]
 /// All possible messages that can be sent during encryption/decryption sessions.
+#[derive(Clone, Debug)]
 pub enum Message {
 	/// Cluster message.
 	Cluster(ClusterMessage),
@@ -38,8 +38,8 @@ pub enum Message {
 	Signing(SigningMessage),
 }
 
-#[derive(Clone, Debug)]
 /// All possible cluster-level messages.
+#[derive(Clone, Debug)]
 pub enum ClusterMessage {
 	/// Introduce node public key.
 	NodePublicKey(NodePublicKey),
@@ -51,8 +51,8 @@ pub enum ClusterMessage {
 	KeepAliveResponse(KeepAliveResponse),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// All possible messages that can be sent during key generation session.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum GenerationMessage {
 	/// Initialize new DKG session.
 	InitializeSession(InitializeSession),
@@ -70,8 +70,8 @@ pub enum GenerationMessage {
 	SessionCompleted(SessionCompleted),
 }
 
-#[derive(Clone, Debug)]
 /// All possible messages that can be sent during encryption session.
+#[derive(Clone, Debug)]
 pub enum EncryptionMessage {
 	/// Initialize encryption session.
 	InitializeEncryptionSession(InitializeEncryptionSession),
@@ -81,8 +81,8 @@ pub enum EncryptionMessage {
 	EncryptionSessionError(EncryptionSessionError),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// All possible messages that can be sent during consensus establishing.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ConsensusMessage {
 	/// Initialize consensus session.
 	InitializeConsensusSession(InitializeConsensusSession),
@@ -90,8 +90,8 @@ pub enum ConsensusMessage {
 	ConfirmConsensusInitialization(ConfirmConsensusInitialization),
 }
 
-#[derive(Clone, Debug)]
 /// All possible messages that can be sent during decryption session.
+#[derive(Clone, Debug)]
 pub enum DecryptionMessage {
 	/// Consensus establishing message.
 	DecryptionConsensusMessage(DecryptionConsensusMessage),
@@ -105,8 +105,8 @@ pub enum DecryptionMessage {
 	DecryptionSessionCompleted(DecryptionSessionCompleted),
 }
 
-#[derive(Clone, Debug)]
 /// All possible messages that can be sent during signing session.
+#[derive(Clone, Debug)]
 pub enum SigningMessage {
 	/// Consensus establishing message.
 	SigningConsensusMessage(SigningConsensusMessage),
@@ -122,8 +122,8 @@ pub enum SigningMessage {
 	SigningSessionCompleted(SigningSessionCompleted),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Introduce node public key.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodePublicKey {
 	/// Node identifier (aka node public key).
 	pub node_id: MessageNodeId,
@@ -131,26 +131,26 @@ pub struct NodePublicKey {
 	pub confirmation_plain: SerializableH256,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Confirm that node owns the private key of previously passed public key (aka node id).
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodePrivateKeySignature {
 	/// Previously passed `confirmation_plain`, signed with node private key.
 	pub confirmation_signed: SerializableSignature,
 }
 
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Ask if the node is still alive.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeepAlive {
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Confirm that the node is still alive.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeepAliveResponse {
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Initialize new DKG session.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InitializeSession {
 	/// Session Id.
 	pub session: MessageSessionId,
@@ -168,8 +168,8 @@ pub struct InitializeSession {
 	pub derived_point: SerializablePublic,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Confirm DKG session initialization.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConfirmInitialization {
 	/// Session Id.
 	pub session: MessageSessionId,
@@ -177,8 +177,8 @@ pub struct ConfirmInitialization {
 	pub derived_point: SerializablePublic,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Broadcast generated point to every other node.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompleteInitialization {
 	/// Session Id.
 	pub session: MessageSessionId,
@@ -186,8 +186,8 @@ pub struct CompleteInitialization {
 	pub derived_point: SerializablePublic,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Generated keys are sent to every node.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeysDissemination {
 	/// Session Id.
 	pub session: MessageSessionId,
@@ -199,8 +199,8 @@ pub struct KeysDissemination {
 	pub publics: Vec<SerializablePublic>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Node is sharing its public key share.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PublicKeyShare {
 	/// Session Id.
 	pub session: MessageSessionId,
@@ -208,8 +208,8 @@ pub struct PublicKeyShare {
 	pub public_share: SerializablePublic,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// When session error has occured.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SessionError {
 	/// Session Id.
 	pub session: MessageSessionId,
@@ -217,15 +217,15 @@ pub struct SessionError {
 	pub error: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// When session is completed.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SessionCompleted {
 	/// Session Id.
 	pub session: MessageSessionId,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Node is requested to prepare for saving encrypted data.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InitializeEncryptionSession {
 	/// Encryption session Id.
 	pub session: MessageSessionId,
@@ -237,15 +237,15 @@ pub struct InitializeEncryptionSession {
 	pub encrypted_point: SerializablePublic,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Node is responding to encryption initialization request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConfirmEncryptionInitialization {
 	/// Encryption session Id.
 	pub session: MessageSessionId,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// When encryption session error has occured.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EncryptionSessionError {
 	/// Encryption session Id.
 	pub session: MessageSessionId,
@@ -253,22 +253,22 @@ pub struct EncryptionSessionError {
 	pub error: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Node is asked to be part of consensus group.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InitializeConsensusSession {
 	/// Requestor signature.
 	pub requestor_signature: SerializableSignature,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Node is responding to consensus initialization request.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConfirmConsensusInitialization {
 	/// Is node confirmed consensus participation.
 	pub is_confirmed: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Consensus-related signing message.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SigningConsensusMessage {
 	/// Generation session Id.
 	pub session: MessageSessionId,
@@ -278,8 +278,8 @@ pub struct SigningConsensusMessage {
 	pub message: ConsensusMessage,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Session key generation message.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SigningGenerationMessage {
 	/// Generation session Id.
 	pub session: MessageSessionId,
@@ -289,8 +289,8 @@ pub struct SigningGenerationMessage {
 	pub message: GenerationMessage,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Request partial signature.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestPartialSignature {
 	/// Generation session Id.
 	pub session: MessageSessionId,
@@ -304,8 +304,8 @@ pub struct RequestPartialSignature {
 	pub nodes: BTreeSet<MessageNodeId>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Partial signature.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PartialSignature {
 	/// Generation session Id.
 	pub session: MessageSessionId,
@@ -317,8 +317,8 @@ pub struct PartialSignature {
 	pub partial_signature: SerializableSecret,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// When signing session error has occured.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SigningSessionError {
 	/// Encryption session Id.
 	pub session: MessageSessionId,
@@ -328,8 +328,8 @@ pub struct SigningSessionError {
 	pub error: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Signing session completed.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SigningSessionCompleted {
 	/// Generation session Id.
 	pub session: MessageSessionId,
@@ -337,8 +337,8 @@ pub struct SigningSessionCompleted {
 	pub sub_session: SerializableSecret,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Consensus-related decryption message.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DecryptionConsensusMessage {
 	/// Generation session Id.
 	pub session: MessageSessionId,
@@ -348,8 +348,8 @@ pub struct DecryptionConsensusMessage {
 	pub message: ConsensusMessage,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Node is requested to do a partial decryption.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RequestPartialDecryption {
 	/// Encryption session Id.
 	pub session: MessageSessionId,
@@ -364,8 +364,8 @@ pub struct RequestPartialDecryption {
 	pub nodes: BTreeSet<MessageNodeId>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Node has partially decrypted the secret.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PartialDecryption {
 	/// Encryption session Id.
 	pub session: MessageSessionId,
@@ -379,8 +379,8 @@ pub struct PartialDecryption {
 	pub decrypt_shadow: Option<Vec<u8>>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// When decryption session error has occured.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DecryptionSessionError {
 	/// Encryption session Id.
 	pub session: MessageSessionId,
@@ -390,8 +390,8 @@ pub struct DecryptionSessionError {
 	pub error: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// When decryption session is completed.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DecryptionSessionCompleted {
 	/// Encryption session Id.
 	pub session: MessageSessionId,

--- a/secret_store/src/key_server_cluster/mod.rs
+++ b/secret_store/src/key_server_cluster/mod.rs
@@ -42,8 +42,8 @@ pub use super::key_server_set::tests::MapKeyServerSet;
 
 pub type SessionId = ServerKeyId;
 
-#[derive(Debug, Clone)]
 /// Session metadata.
+#[derive(Debug, Clone)]
 pub struct SessionMeta {
 	/// Key id.
 	pub id: SessionId,
@@ -55,8 +55,8 @@ pub struct SessionMeta {
 	pub threshold: usize,
 }
 
-#[derive(Clone, Debug, PartialEq)]
 /// Errors which can occur during encryption/decryption session
+#[derive(Clone, Debug, PartialEq)]
 pub enum Error {
 	/// Invalid node address has been passed.
 	InvalidNodeAddress,

--- a/secret_store/src/key_server_cluster/signing_session.rs
+++ b/secret_store/src/key_server_cluster/signing_session.rs
@@ -188,8 +188,8 @@ impl SessionImpl {
 		})
 	}
 
-	#[cfg(test)]
 	/// Get session state.
+	#[cfg(test)]
 	pub fn state(&self) -> SessionState {
 		self.data.lock().state
 	}

--- a/secret_store/src/key_storage.rs
+++ b/secret_store/src/key_storage.rs
@@ -25,8 +25,8 @@ use serialization::{SerializablePublic, SerializableSecret};
 /// Key of version value.
 const DB_META_KEY_VERSION: &'static [u8; 7] = b"version";
 
-#[derive(Debug, Clone, PartialEq)]
 /// Encrypted key share, stored by key storage on the single key server.
+#[derive(Debug, Clone, PartialEq)]
 pub struct DocumentKeyShare {
 	/// Author of the entry.
 	pub author: Public,
@@ -59,8 +59,8 @@ pub struct PersistentKeyStorage {
 	db: Database,
 }
 
-#[derive(Serialize, Deserialize)]
 /// V0 of encrypted key share, as it is stored by key storage on the single key server.
+#[derive(Serialize, Deserialize)]
 struct SerializableDocumentKeyShareV0 {
 	/// Decryption threshold (at least threshold + 1 nodes are required to decrypt data).
 	pub threshold: usize,
@@ -74,8 +74,8 @@ struct SerializableDocumentKeyShareV0 {
 	pub encrypted_point: SerializablePublic,
 }
 
-#[derive(Serialize, Deserialize)]
 /// V1 of encrypted key share, as it is stored by key storage on the single key server.
+#[derive(Serialize, Deserialize)]
 struct SerializableDocumentKeyShareV1 {
 	/// Authore of the entry.
 	pub author: SerializablePublic,
@@ -204,8 +204,8 @@ pub mod tests {
 	use super::{DB_META_KEY_VERSION, KeyStorage, PersistentKeyStorage, DocumentKeyShare,
 		SerializableDocumentKeyShareV0, SerializableDocumentKeyShareV1, upgrade_db};
 
-	#[derive(Default)]
 	/// In-memory document encryption keys storage
+	#[derive(Default)]
 	pub struct DummyKeyStorage {
 		keys: RwLock<HashMap<ServerKeyId, DocumentKeyShare>>,
 	}

--- a/secret_store/src/serialization.rs
+++ b/secret_store/src/serialization.rs
@@ -27,8 +27,8 @@ use util::Bytes;
 /// Serializable message hash.
 pub type SerializableMessageHash = SerializableH256;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Serializable shadow decryption result.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SerializableEncryptedDocumentKeyShadow {
 	/// Decrypted secret point. It is partially decrypted if shadow decrpytion was requested.
 	pub decrypted_secret: SerializablePublic,
@@ -38,8 +38,8 @@ pub struct SerializableEncryptedDocumentKeyShadow {
 	pub decrypt_shadows: Vec<SerializableBytes>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
 /// Serializable Bytes.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SerializableBytes(pub Bytes);
 
 impl<T> From<T> for SerializableBytes where Bytes: From<T> {
@@ -84,8 +84,8 @@ impl<'a> Deserialize<'a> for SerializableBytes {
 	}
 }
 
-#[derive(Clone, Debug)]
 /// Serializable Signature.
+#[derive(Clone, Debug)]
 pub struct SerializableSignature(pub Signature);
 
 impl<T> From<T> for SerializableSignature where Signature: From<T> {
@@ -144,8 +144,8 @@ impl<'a> Deserialize<'a> for SerializableSignature {
 	}
 }
 
-#[derive(Clone, Debug)]
 /// Serializable H256.
+#[derive(Clone, Debug)]
 pub struct SerializableH256(pub H256);
 
 impl<T> From<T> for SerializableH256 where H256: From<T> {
@@ -204,8 +204,8 @@ impl<'a> Deserialize<'a> for SerializableH256 {
 	}
 }
 
-#[derive(Clone, Debug)]
 /// Serializable EC scalar/secret key.
+#[derive(Clone, Debug)]
 pub struct SerializableSecret(pub Secret);
 
 impl<T> From<T> for SerializableSecret where Secret: From<T> {
@@ -264,8 +264,8 @@ impl<'a> Deserialize<'a> for SerializableSecret {
 	}
 }
 
-#[derive(Clone, Debug)]
 /// Serializable EC point/public key.
+#[derive(Clone, Debug)]
 pub struct SerializablePublic(pub Public);
 
 impl<T> From<T> for SerializablePublic where Public: From<T> {

--- a/secret_store/src/traits.rs
+++ b/secret_store/src/traits.rs
@@ -82,7 +82,7 @@ pub trait MessageSigner: ServerKeyGenerator {
 }
 
 
-#[ipc(client_ident="RemoteKeyServer")]
 /// Key server.
+#[ipc(client_ident="RemoteKeyServer")]
 pub trait KeyServer: DocumentKeyServer + MessageSigner + Send + Sync {
 }

--- a/secret_store/src/types/all.rs
+++ b/secret_store/src/types/all.rs
@@ -38,9 +38,9 @@ pub type RequestSignature = ethkey::Signature;
 /// Public key type.
 pub use ethkey::Public;
 
+/// Secret store error
 #[derive(Debug, Clone, PartialEq)]
 #[binary]
-/// Secret store error
 pub enum Error {
 	/// Bad signature is passed
 	BadSignature,
@@ -56,9 +56,9 @@ pub enum Error {
 	Internal(String),
 }
 
+/// Secret store configuration
 #[derive(Debug, Clone)]
 #[binary]
-/// Secret store configuration
 pub struct NodeAddress {
 	/// IP address.
 	pub address: String,
@@ -66,9 +66,9 @@ pub struct NodeAddress {
 	pub port: u16,
 }
 
+/// Secret store configuration
 #[derive(Debug)]
 #[binary]
-/// Secret store configuration
 pub struct ServiceConfiguration {
 	/// HTTP listener address. If None, HTTP API is disabled.
 	pub listener_address: Option<NodeAddress>,
@@ -80,9 +80,9 @@ pub struct ServiceConfiguration {
 	pub cluster_config: ClusterConfiguration,
 }
 
+/// Key server cluster configuration
 #[derive(Debug)]
 #[binary]
-/// Key server cluster configuration
 pub struct ClusterConfiguration {
 	/// Number of threads reserved by cluster.
 	pub threads: usize,
@@ -95,9 +95,9 @@ pub struct ClusterConfiguration {
 	pub allow_connecting_to_higher_nodes: bool,
 }
 
+/// Shadow decryption result.
 #[derive(Clone, Debug, PartialEq)]
 #[binary]
-/// Shadow decryption result.
 pub struct EncryptedDocumentKeyShadow {
 	/// Decrypted secret point. It is partially decrypted if shadow decrpytion was requested.
 	pub decrypted_secret: ethkey::Public,


### PR DESCRIPTION
Finally made a script to fix this unresolved grumble: https://github.com/paritytech/parity/pull/4974#issuecomment-289365952

Checked other mine contributions - looks like everything is already ok there. Although there's other 46 files in Parity with wrong attributes placement - don't know if it is better to fix it, or leave as is (chose the latter).