### PR TITLE
SecretStore: add node to existing session poc + discussion

### DIFF
--- a/secret_store/src/key_server_cluster/math.rs
+++ b/secret_store/src/key_server_cluster/math.rs
@@ -93,6 +93,29 @@ pub fn generate_random_polynom(threshold: usize) -> Result<Vec<Secret>, Error> {
 		.collect()
 }
 
+/// Compute absolute term of additional polynom1 when new node is added to the existing generation node set
+#[cfg(test)]
+pub fn compute_additional_polynom1_absolute_term<'a, I>(secret_values: I) -> Result<Secret, Error> where I: Iterator<Item=&'a Secret> {
+	let mut absolute_term = compute_secret_sum(secret_values)?;
+	absolute_term.neg()?;
+	Ok(absolute_term)
+}
+
+/// Add two polynoms together (coeff = coeff1 + coeff2).
+#[cfg(test)]
+pub fn add_polynoms(polynom1: &[Secret], polynom2: &[Secret], is_absolute_term2_zero: bool) -> Result<Vec<Secret>, Error> {
+	polynom1.iter().zip(polynom2.iter())
+		.enumerate()
+		.map(|(i, (c1, c2))| {
+			let mut sum_coeff = c1.clone();
+			if !is_absolute_term2_zero || i != 0 {
+				sum_coeff.add(c2)?;
+			}
+			Ok(sum_coeff)
+		})
+		.collect()
+}
+
 /// Compute value of polynom, using `node_number` as argument
 pub fn compute_polynom(polynom: &[Secret], node_number: &Secret) -> Result<Secret, Error> {
 	debug_assert!(!polynom.is_empty());
@@ -150,6 +173,28 @@ pub fn keys_verification(threshold: usize, derived_point: &Public, number_id: &S
 
 	math::public_add(&mut multiplication1, &multiplication2)?;
 	let left = multiplication1;
+
+	// calculate right part
+	let mut right = publics[0].clone();
+	for i in 1..threshold + 1 {
+		let mut secret_pow = number_id.clone();
+		secret_pow.pow(i)?;
+
+		let mut public_k = publics[i].clone();
+		math::public_mul_secret(&mut public_k, &secret_pow)?;
+
+		math::public_add(&mut right, &public_k)?;
+	}
+
+	Ok(left == right)
+}
+
+/// Check refreshed keys passed by other participants.
+#[cfg(test)]
+pub fn refreshed_keys_verification(threshold: usize, number_id: &Secret, secret1: &Secret, publics: &[Public]) -> Result<bool, Error> {
+	// calculate left part
+	let mut left = math::generation_point();
+	math::public_mul_secret(&mut left, secret1)?;
 
 	// calculate right part
 	let mut right = publics[0].clone();
@@ -407,6 +452,7 @@ pub mod tests {
 		// === PART1: DKG ===
 
 		// data, gathered during initialization
+		let derived_point = Random.generate().unwrap().public().clone();
 		let id_numbers: Vec<_> = match id_numbers {
 			Some(id_numbers) => id_numbers,
 			None => (0..n).map(|_| generate_random_scalar().unwrap()).collect(),
@@ -415,6 +461,15 @@ pub mod tests {
 		// data, generated during keys dissemination
 		let polynoms1: Vec<_> = (0..n).map(|_| generate_random_polynom(t).unwrap()).collect();
 		let secrets1: Vec<_> = (0..n).map(|i| (0..n).map(|j| compute_polynom(&polynoms1[i], &id_numbers[j]).unwrap()).collect::<Vec<_>>()).collect();
+		// following data is used only on verification step
+		let polynoms2: Vec<_> = (0..n).map(|_| generate_random_polynom(t).unwrap()).collect();
+		let secrets2: Vec<_> = (0..n).map(|i| (0..n).map(|j| compute_polynom(&polynoms2[i], &id_numbers[j]).unwrap()).collect::<Vec<_>>()).collect();
+		let publics: Vec<_> = (0..n).map(|i| public_values_generation(t, &derived_point, &polynoms1[i], &polynoms2[i]).unwrap()).collect();
+
+		// keys verification
+		(0..n).map(|i| (0..n).map(|j| if i != j {
+			assert!(keys_verification(t, &derived_point, &id_numbers[i], &secrets1[j][i], &secrets2[j][i], &publics[j]).unwrap());
+		}).collect::<Vec<_>>()).collect::<Vec<_>>();
 
 		// data, generated during keys generation
 		let public_shares: Vec<_> = (0..n).map(|i| compute_public_share(&polynoms1[i][0]).unwrap()).collect();
@@ -427,6 +482,85 @@ pub mod tests {
 			id_numbers: id_numbers,
 			polynoms1: polynoms1,
 			secrets1: secrets1,
+			public_shares: public_shares,
+			secret_shares: secret_shares,
+			joint_public: joint_public,
+		}
+	}
+
+	fn run_key_share_refreshing(t: usize, n: usize, artifacts: &KeyGenerationArtifacts) -> KeyGenerationArtifacts {
+		// === share refreshing protocol from http://www.wu.ece.ufl.edu/mypapers/msig.pdf
+
+		// key refreshing distribution algorithm (KRD)
+		let refreshed_polynoms1: Vec<_> = (0..n).map(|_| generate_random_polynom(t).unwrap()).collect();
+		let refreshed_polynoms1_sum: Vec<_> = (0..n).map(|i| add_polynoms(&artifacts.polynoms1[i], &refreshed_polynoms1[i], true).unwrap()).collect();
+		let refreshed_secrets1: Vec<_> = (0..n).map(|i| (0..n).map(|j| compute_polynom(&refreshed_polynoms1_sum[i], &artifacts.id_numbers[j]).unwrap()).collect::<Vec<_>>()).collect();
+		let refreshed_publics: Vec<_> = (0..n).map(|i| {
+			(0..t+1).map(|j| compute_public_share(&refreshed_polynoms1_sum[i][j]).unwrap()).collect::<Vec<_>>()
+		}).collect();
+
+		// key refreshing verification algorithm (KRV)
+		(0..n).map(|i| (0..n).map(|j| if i != j {
+			assert!(refreshed_keys_verification(t, &artifacts.id_numbers[i], &refreshed_secrets1[j][i], &refreshed_publics[j]).unwrap())
+		}).collect::<Vec<_>>()).collect::<Vec<_>>();
+
+		// data, generated during keys generation
+		let public_shares: Vec<_> = (0..n).map(|i| compute_public_share(&refreshed_polynoms1_sum[i][0]).unwrap()).collect();
+		let secret_shares: Vec<_> = (0..n).map(|i| compute_secret_share(refreshed_secrets1.iter().map(|s| &s[i])).unwrap()).collect();
+
+		// joint public key, as a result of DKG
+		let joint_public = compute_joint_public(public_shares.iter()).unwrap();
+
+		KeyGenerationArtifacts {
+			id_numbers: artifacts.id_numbers.clone(),
+			polynoms1: refreshed_polynoms1_sum,
+			secrets1: refreshed_secrets1,
+			public_shares: public_shares,
+			secret_shares: secret_shares,
+			joint_public: joint_public,
+		}
+	}
+
+	fn run_key_share_refreshing_and_add_new_node(t: usize, n: usize, artifacts: &KeyGenerationArtifacts) -> KeyGenerationArtifacts {
+		// === share refreshing protocol (with new node addition) from http://www.wu.ece.ufl.edu/mypapers/msig.pdf
+		let mut id_numbers: Vec<_> = artifacts.id_numbers.iter().cloned().collect();
+
+		// key refreshing distribution algorithm (KRD)
+		let refreshed_polynoms1: Vec<_> = (0..n).map(|_| generate_random_polynom(t).unwrap()).collect();
+		let mut refreshed_polynoms1_sum: Vec<_> = (0..n).map(|i| add_polynoms(&artifacts.polynoms1[i], &refreshed_polynoms1[i], false).unwrap()).collect();
+
+		// new node receives private information and generates its own polynom
+		let mut new_polynom1 = generate_random_polynom(t).unwrap();
+		let new_polynom_absolute_term = compute_additional_polynom1_absolute_term(refreshed_polynoms1.iter().map(|polynom1| &polynom1[0])).unwrap();
+		new_polynom1[0] = new_polynom_absolute_term;
+
+		// new nodes sends its own information to all other nodes
+		let n = n + 1;
+		id_numbers.push(Random.generate().unwrap().secret().clone());
+		refreshed_polynoms1_sum.push(new_polynom1);
+
+		// the rest of protocol is the same as without new node
+		let refreshed_secrets1: Vec<_> = (0..n).map(|i| (0..n).map(|j| compute_polynom(&refreshed_polynoms1_sum[i], &id_numbers[j]).unwrap()).collect::<Vec<_>>()).collect();
+		let refreshed_publics: Vec<_> = (0..n).map(|i| {
+			(0..t+1).map(|j| compute_public_share(&refreshed_polynoms1_sum[i][j]).unwrap()).collect::<Vec<_>>()
+		}).collect();
+
+		// key refreshing verification algorithm (KRV)
+		(0..n).map(|i| (0..n).map(|j| if i != j {
+			assert!(refreshed_keys_verification(t, &id_numbers[i], &refreshed_secrets1[j][i], &refreshed_publics[j]).unwrap())
+		}).collect::<Vec<_>>()).collect::<Vec<_>>();
+
+		// data, generated during keys generation
+		let public_shares: Vec<_> = (0..n).map(|i| compute_public_share(&refreshed_polynoms1_sum[i][0]).unwrap()).collect();
+		let secret_shares: Vec<_> = (0..n).map(|i| compute_secret_share(refreshed_secrets1.iter().map(|s| &s[i])).unwrap()).collect();
+
+		// joint public key, as a result of DKG
+		let joint_public = compute_joint_public(public_shares.iter()).unwrap();
+
+		KeyGenerationArtifacts {
+			id_numbers: id_numbers,
+			polynoms1: refreshed_polynoms1_sum,
+			secrets1: refreshed_secrets1,
 			public_shares: public_shares,
 			secret_shares: secret_shares,
 			joint_public: joint_public,
@@ -582,5 +716,38 @@ pub mod tests {
 				assert_eq!(verify_signature(&artifacts.joint_public, signature, &message_hash), Ok(true));
 			}
 		}
+	}
+
+	#[test]
+	fn full_generation_math_session_with_refreshing_shares() {
+		// generate key using 6-of-10 session
+		let (t, n) = (5, 10);
+		let artifacts1 = run_key_generation(t, n, None);
+
+		// let's say we want to refresh existing secret shares
+		// by doing this every T seconds, and assuming that in each T-second period adversary KS is not able to collect t+1 secret shares
+		// we can be sure that the scheme is secure
+		let artifacts2 = run_key_share_refreshing(t, n, &artifacts1);
+		assert_eq!(artifacts1.joint_public, artifacts2.joint_public);
+
+		// refresh again
+		let artifacts3 = run_key_share_refreshing(t, n, &artifacts2);
+		assert_eq!(artifacts1.joint_public, artifacts3.joint_public);
+	}
+
+	#[test]
+	fn full_generation_math_session_with_adding_new_node() {
+		// generate key using 6-of-10 session
+		let (t, n) = (5, 10);
+		let artifacts1 = run_key_generation(t, n, None);
+
+		// let's say we want to include additional server to the set
+		// so that scheme becames 6-of-11
+		let artifacts2 = run_key_share_refreshing_and_add_new_node(t, n, &artifacts1);
+		assert_eq!(artifacts1.joint_public, artifacts2.joint_public);
+
+		// include one more server (6-of-12)
+		let artifacts3 = run_key_share_refreshing_and_add_new_node(t, n + 1, &artifacts2);
+		assert_eq!(artifacts1.joint_public, artifacts3.joint_public);
 	}
 }


### PR DESCRIPTION
The purpose of this PR is mostly to discuss possible SecretStore reactions to KeyServer addition/removal.
Code changes are proof-of-concepts of shares refreshment and adding new nodes to session, without changing shared secret.

### case1: new node is added + session t-of-N exists
We do not risk to loose any secrets in this case, but might want to convert existing sessions: from t-of-N to t-of-N+1.
See `full_generation_math_session_with_adding_new_node` test for implementation details.

My thoughts (labeled to refer later/in comments):
case1-1) no automatical actions should be performed when new node is added to the set
case1-2) there must be a way to extend existing session with new node (i.e. convert from t-of-N to t-of-N+1)

### case2: existing node is removed + session t-of-N exists + number of nodes left is >= t
There's no immediate risk of losing any secrets. Existing session becames t-of-N-1.

My thoughts:
case2-1) no automatical actions should be performed in this case
case2-2) there's 3 reasons (at least those, I can see) of why node is removed:
case2-2-1) node is turned off for maintenance => it **will be** added to the set later
case2-2-2) node is replaced by other node => it is better to run (case1) before (case2) in this case (i.e. convert session to t+N+1 first)
case2-2-3) node is removed permanently (due to failure or smth similar) => SS administrator must add new (empty) server asap && extend existing sessions back to t-of-N
case2-3) to have actual information in db (not required, but desirable), there must be a way to 'shrink' existing session from t-of-N to t-of-N-1 (i.e. mark that removed KS do not hold secret share anymore)

### case3: existing node is removed + session t-of-N exists + number of nodes left is < t
There's no way to recover secret after this happens => this situation must be avoided with all means.

My thoughts:
case3-1) no automatical actions **can** be performed in this case
case3-2) except for case-2-2-3, all possible reasons can be avoided by administrative means
case3-3) case3 when node is removed permanently (case-2-2-3) could only occur when N-t was not enough to react properly

### Administrative API
So there are 2 additional APIs for SS:
1) extend session with new node
2) remove node from existing session
I would like to make these APIs atomic (i.e. 'add single node to single session' or 'remove single node from single session') => there must be also API to list sessions
Another way is to add APIs like: 'add node(s) to all existing sessions' or 'remove node(s) from all existing sessions'.
But these are too complex (both for implemetation and for resolving issues).

There's also bonus API, which could be added (see `full_generation_math_session_with_refreshing_shares`): refresh secret shares.
This could be used externally, or triggered from within the SS.
It is to ensure that even if some KeyServer gains t different shares within T interval **and** there was secret share refreshment within T, it won't be able to recover secret.

I would like to extend existing KS HTTP interface with these methods.

### Bad ideas
bad-1) automatical reactions - will make SS protocols too complex && also gives false confidence that SS can itself solve all problems (it can not if nodes are keep failing or if t/N~1)
bad-2) check if t-of-t sessions exists before removing node and transfer secret share from removing-node to staying-node - t-of-t situations must be avoided, not 'resolved'
