### PR TITLE
Fix failing hardware tests

### DIFF
--- a/js/src/mobx/hardwareStore.spec.js
+++ b/js/src/mobx/hardwareStore.spec.js
@@ -39,6 +39,7 @@ function createApi () {
     },
     parity: {
       hardwareAccountsInfo: sinon.stub().resolves({ ADDRESS: WALLET }),
+      lockedHardwareAccountsInfo: sinon.stub().resolves({}),
       setAccountMeta: sinon.stub().resolves(true),
       setAccountName: sinon.stub().resolves(true)
     }


### PR DESCRIPTION
- As picked up in https://github.com/paritytech/parity/pull/6552
- Add missing method stub
- Current master failing, not building `js-precompiled`