### PR TITLE
Fix #6540

### DIFF
--- a/js/src/api/contract/contract.js
+++ b/js/src/api/contract/contract.js
@@ -133,11 +133,11 @@ export default class Contract {
 
         return this._api.parity
           .postTransaction(encodedOptions)
-          .then((result) => {
-            if (result.length !== 66) {
-              statecb(null, { state: 'checkRequest', result });
-              return this._pollCheckRequest(result);
-            } else { return result; }
+          .then((requestId) => {
+            if (requestId.length !== 66) {
+              statecb(null, { state: 'checkRequest', requestId });
+              return this._pollCheckRequest(requestId);
+            } else { return requestId; }
           })
           .then((txhash) => {
             statecb(null, { state: 'getTransactionReceipt', txhash });

--- a/js/src/api/contract/contract.js
+++ b/js/src/api/contract/contract.js
@@ -133,9 +133,11 @@ export default class Contract {
 
         return this._api.parity
           .postTransaction(encodedOptions)
-          .then((requestId) => {
-            statecb(null, { state: 'checkRequest', requestId });
-            return this._pollCheckRequest(requestId);
+          .then((result) => {
+            if (result.length !== 66) {
+              statecb(null, { state: 'checkRequest', result });
+              return this._pollCheckRequest(result);
+            } else { return result; }
           })
           .then((txhash) => {
             statecb(null, { state: 'getTransactionReceipt', txhash });


### PR DESCRIPTION
Skips the `checkRequest` call if result of `postTransaction` is a tx ID.
If there is a better way to check whether `result` is a tx ID than looking at its length, let's do that.

Made a similar PR over [here](https://github.com/paritytech/parity.js/pull/3), but I can't even get the module installed from that repo, and the latest changes are not as new as those in this repo, so it looks like this one makes more sense to merge to.