### PR TITLE
Use host as ws/dapps url if present.

### DIFF
--- a/js/src/api/local/localAccountsMiddleware.js
+++ b/js/src/api/local/localAccountsMiddleware.js
@@ -188,16 +188,6 @@ export default class LocalAccountsMiddleware extends Middleware {
       return [];
     });
 
-    register('parity_wsUrl', () => {
-      // This is a hack, will be replaced by a `hostname` setting on the node itself
-      return `${window.location.hostname}:8546`;
-    });
-
-    register('parity_dappsUrl', () => {
-      // This is a hack, will be replaced by a `hostname` setting on the node itself
-      return `${window.location.hostname}:8545`;
-    });
-
     register('parity_hashContent', () => {
       throw new Error('Functionality unavailable on a public wallet.');
     });

--- a/js/src/secureApi.js
+++ b/js/src/secureApi.js
@@ -82,7 +82,7 @@ export default class SecureApi extends Api {
 
     return {
       host,
-      port: parseInt(port, 10)
+      port: port ? parseInt(port, 10) : null
     };
   }
 
@@ -93,7 +93,9 @@ export default class SecureApi extends Api {
   get dappsUrl () {
     const { port } = this._dappsAddress;
 
-    return `${this.protocol()}//${this.hostname}:${port}`;
+    return port
+      ? `${this.protocol()}//${this.hostname}:${port}`
+      : `${this.protocol()}//${this.hostname}`;
   }
 
   get hostname () {

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1322,7 +1322,7 @@ mod tests {
 			origins: Some(vec!["chrome-extension://*".into(), "moz-extension://*".into()]),
 			hosts: Some(vec![]),
 			signer_path: expected.into(),
-			ui_address: Some(("127.0.0.1".to_owned(), 8180)),
+			ui_address: Some("127.0.0.1:8180".into()),
 			support_token_api: true
 		}, UiConfiguration {
 			enabled: true,

--- a/parity/dapps.rs
+++ b/parity/dapps.rs
@@ -57,7 +57,7 @@ impl Default for Configuration {
 }
 
 impl Configuration {
-	pub fn address(&self, address: Option<(String, u16)>) -> Option<(String, u16)> {
+	pub fn address(&self, address: Option<::parity_rpc::Host>) -> Option<::parity_rpc::Host> {
 		match self.enabled {
 			true => address,
 			false => None,

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -37,7 +37,7 @@ use node_health::NodeHealth;
 use parity_reactor;
 use parity_rpc::dispatch::{FullDispatcher, LightDispatcher};
 use parity_rpc::informant::{ActivityNotifier, ClientNotifier};
-use parity_rpc::{Metadata, NetworkSettings};
+use parity_rpc::{Metadata, NetworkSettings, Host};
 use updater::Updater;
 use parking_lot::{Mutex, RwLock};
 
@@ -222,8 +222,8 @@ pub struct FullDependencies {
 	pub health: NodeHealth,
 	pub geth_compatibility: bool,
 	pub dapps_service: Option<Arc<DappsService>>,
-	pub dapps_address: Option<(String, u16)>,
-	pub ws_address: Option<(String, u16)>,
+	pub dapps_address: Option<Host>,
+	pub ws_address: Option<Host>,
 	pub fetch: FetchClient,
 	pub remote: parity_reactor::Remote,
 	pub whisper_rpc: Option<::whisper::RpcFactory>,
@@ -412,8 +412,8 @@ pub struct LightDependencies<T> {
 	pub cache: Arc<Mutex<LightDataCache>>,
 	pub transaction_queue: Arc<RwLock<LightTransactionQueue>>,
 	pub dapps_service: Option<Arc<DappsService>>,
-	pub dapps_address: Option<(String, u16)>,
-	pub ws_address: Option<(String, u16)>,
+	pub dapps_address: Option<Host>,
+	pub ws_address: Option<Host>,
 	pub fetch: FetchClient,
 	pub geth_compatibility: bool,
 	pub remote: parity_reactor::Remote,

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -329,7 +329,7 @@ fn execute_light(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>) ->
 			remote: event_loop.raw_remote(),
 			fetch: fetch.clone(),
 			signer: signer_service.clone(),
-			ui_address: cmd.ui_conf.address(),
+			ui_address: cmd.ui_conf.redirection_address(),
 		})
 	};
 
@@ -723,7 +723,7 @@ pub fn execute(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>) -> R
 			remote: event_loop.raw_remote(),
 			fetch: fetch.clone(),
 			signer: signer_service.clone(),
-			ui_address: cmd.ui_conf.address(),
+			ui_address: cmd.ui_conf.redirection_address(),
 		})
 	};
 	let dapps_middleware = dapps::new(cmd.dapps_conf.clone(), dapps_deps.clone())?;

--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -51,6 +51,6 @@ pub use self::signer::SignerService;
 pub use self::subscribers::Subscribers;
 pub use self::subscription_manager::GenericPollManager;
 
-pub fn to_url(address: &Option<(String, u16)>) -> Option<String> {
-	address.as_ref().map(|&(ref iface, ref port)| format!("{}:{}", iface, port))
+pub fn to_url(address: &Option<::Host>) -> Option<String> {
+	address.as_ref().map(|host| (**host).to_owned())
 }

--- a/rpc/src/v1/impls/light/parity.rs
+++ b/rpc/src/v1/impls/light/parity.rs
@@ -46,6 +46,7 @@ use v1::types::{
 	OperationsInfo, DappId, ChainStatus,
 	AccountInfo, HwAccountInfo, Header, RichHeader,
 };
+use Host;
 
 /// Parity implementation for light client.
 pub struct ParityClient {
@@ -55,8 +56,8 @@ pub struct ParityClient {
 	settings: Arc<NetworkSettings>,
 	health: NodeHealth,
 	signer: Option<Arc<SignerService>>,
-	dapps_address: Option<(String, u16)>,
-	ws_address: Option<(String, u16)>,
+	dapps_address: Option<Host>,
+	ws_address: Option<Host>,
 	eip86_transition: u64,
 }
 
@@ -70,8 +71,8 @@ impl ParityClient {
 		settings: Arc<NetworkSettings>,
 		health: NodeHealth,
 		signer: Option<Arc<SignerService>>,
-		dapps_address: Option<(String, u16)>,
-		ws_address: Option<(String, u16)>,
+		dapps_address: Option<Host>,
+		ws_address: Option<Host>,
 	) -> Self {
 		ParityClient {
 			light_dispatch,

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -51,6 +51,7 @@ use v1::types::{
 	OperationsInfo, DappId, ChainStatus,
 	AccountInfo, HwAccountInfo, RichHeader
 };
+use Host;
 
 /// Parity implementation.
 pub struct ParityClient<C, M, U>  {
@@ -64,8 +65,8 @@ pub struct ParityClient<C, M, U>  {
 	logger: Arc<RotatingLogger>,
 	settings: Arc<NetworkSettings>,
 	signer: Option<Arc<SignerService>>,
-	dapps_address: Option<(String, u16)>,
-	ws_address: Option<(String, u16)>,
+	dapps_address: Option<Host>,
+	ws_address: Option<Host>,
 	eip86_transition: u64,
 }
 
@@ -84,8 +85,8 @@ impl<C, M, U> ParityClient<C, M, U> where
 		logger: Arc<RotatingLogger>,
 		settings: Arc<NetworkSettings>,
 		signer: Option<Arc<SignerService>>,
-		dapps_address: Option<(String, u16)>,
-		ws_address: Option<(String, u16)>,
+		dapps_address: Option<Host>,
+		ws_address: Option<Host>,
 	) -> Self {
 		let eip86_transition = client.eip86_transition();
 		ParityClient {

--- a/rpc/src/v1/tests/mocked/parity.rs
+++ b/rpc/src/v1/tests/mocked/parity.rs
@@ -31,6 +31,7 @@ use v1::metadata::Metadata;
 use v1::helpers::{SignerService, NetworkSettings};
 use v1::tests::helpers::{TestSyncProvider, Config, TestMinerService, TestUpdater};
 use super::manage_network::TestManageNetwork;
+use Host;
 
 pub type TestParityClient = ParityClient<TestBlockChainClient, TestMinerService, TestUpdater>;
 
@@ -44,8 +45,8 @@ pub struct Dependencies {
 	pub settings: Arc<NetworkSettings>,
 	pub network: Arc<ManageNetwork>,
 	pub accounts: Arc<AccountProvider>,
-	pub dapps_address: Option<(String, u16)>,
-	pub ws_address: Option<(String, u16)>,
+	pub dapps_address: Option<Host>,
+	pub ws_address: Option<Host>,
 }
 
 impl Dependencies {
@@ -74,8 +75,8 @@ impl Dependencies {
 			}),
 			network: Arc::new(TestManageNetwork),
 			accounts: Arc::new(AccountProvider::transient_provider()),
-			dapps_address: Some(("127.0.0.1".into(), 18080)),
-			ws_address: Some(("127.0.0.1".into(), 18546)),
+			dapps_address: Some("127.0.0.1:18080".into()),
+			ws_address: Some("127.0.0.1:18546".into()),
 		}
 	}
 


### PR DESCRIPTION
Solves issues for `wallet.parity.io` and possible other setups running behind a proxy and custom ports.