### PR TITLE
[Public Node] Disable tx scheduling and hardware wallets

### DIFF
--- a/js/src/api/local/localAccountsMiddleware.js
+++ b/js/src/api/local/localAccountsMiddleware.js
@@ -188,6 +188,10 @@ export default class LocalAccountsMiddleware extends Middleware {
       return [];
     });
 
+    register('parity_lockedHardwareAccountsInfo', () => {
+      return [];
+    });
+
     register('parity_hashContent', () => {
       throw new Error('Functionality unavailable on a public wallet.');
     });

--- a/js/src/modals/DeployContract/deployContract.js
+++ b/js/src/modals/DeployContract/deployContract.js
@@ -66,6 +66,7 @@ class DeployContract extends Component {
   };
 
   static propTypes = {
+    availability: PropTypes.string.isRequired,
     accounts: PropTypes.object.isRequired,
     abi: PropTypes.string,
     code: PropTypes.string,
@@ -331,6 +332,7 @@ class DeployContract extends Component {
 
     return (
       <Extras
+        availability={ this.props.availability }
         gasStore={ this.gasStore }
         hideData
         isEth
@@ -490,9 +492,11 @@ class DeployContract extends Component {
 }
 
 function mapStateToProps (state) {
-  const { gasLimit } = state.nodeStatus;
+  const { gasLimit, nodeKind = {} } = state.nodeStatus;
+  const { availability = 'unknown' } = nodeKind;
 
   return {
+    availability,
     gasLimit
   };
 }

--- a/js/src/modals/ExecuteContract/AdvancedStep/advancedStep.js
+++ b/js/src/modals/ExecuteContract/AdvancedStep/advancedStep.js
@@ -22,15 +22,19 @@ import styles from '../executeContract.css';
 
 export default class AdvancedStep extends Component {
   static propTypes = {
+    availability: PropTypes.string.isRequired,
     gasStore: PropTypes.object.isRequired
   };
 
   render () {
-    const { gasStore } = this.props;
+    const { availability, gasStore } = this.props;
 
     return (
       <div className={ styles.gaseditor }>
-        <GasPriceEditor store={ gasStore } />
+        <GasPriceEditor
+          availability={ availability }
+          store={ gasStore }
+        />
       </div>
     );
   }

--- a/js/src/modals/ExecuteContract/executeContract.js
+++ b/js/src/modals/ExecuteContract/executeContract.js
@@ -57,6 +57,7 @@ class ExecuteContract extends Component {
   };
 
   static propTypes = {
+    availability: PropTypes.string.isRequired,
     accounts: PropTypes.object,
     contract: PropTypes.object.isRequired,
     fromAddress: PropTypes.string,
@@ -198,7 +199,7 @@ class ExecuteContract extends Component {
   }
 
   renderStep () {
-    const { accounts, contract, fromAddress, onFromAddressChange } = this.props;
+    const { availability, accounts, contract, fromAddress, onFromAddressChange } = this.props;
     const { step } = this.state;
 
     if (step === STEP_DETAILS) {
@@ -218,7 +219,10 @@ class ExecuteContract extends Component {
     }
 
     return (
-      <AdvancedStep gasStore={ this.gasStore } />
+      <AdvancedStep
+        availability={ availability }
+        gasStore={ this.gasStore }
+      />
     );
   }
 
@@ -337,9 +341,10 @@ class ExecuteContract extends Component {
 }
 
 function mapStateToProps (state) {
-  const { gasLimit } = state.nodeStatus;
+  const { gasLimit, nodeKind = {} } = state.nodeStatus;
+  const { availability = 'unknown' } = nodeKind;
 
-  return { gasLimit };
+  return { availability, gasLimit };
 }
 
 export default connect(

--- a/js/src/modals/Transfer/Extras/extras.js
+++ b/js/src/modals/Transfer/Extras/extras.js
@@ -23,6 +23,7 @@ import styles from '../transfer.css';
 
 export default class Extras extends Component {
   static propTypes = {
+    availability: PropTypes.string.isRequired,
     data: PropTypes.string,
     dataError: PropTypes.string,
     hideData: PropTypes.bool,
@@ -38,13 +39,14 @@ export default class Extras extends Component {
   };
 
   render () {
-    const { gasStore, onChange } = this.props;
+    const { availability, gasStore, onChange } = this.props;
 
     return (
       <Form>
         { this.renderData() }
         <div className={ styles.gaseditor }>
           <GasPriceEditor
+            availability={ availability }
             store={ gasStore }
             onChange={ onChange }
           />

--- a/js/src/modals/Transfer/transfer.js
+++ b/js/src/modals/Transfer/transfer.js
@@ -42,6 +42,7 @@ class Transfer extends Component {
   }
 
   static propTypes = {
+    availability: PropTypes.string.isRequired,
     newError: PropTypes.func.isRequired,
     gasLimit: PropTypes.object.isRequired,
 
@@ -186,6 +187,7 @@ class Transfer extends Component {
         onChange={ this.store.onUpdateDetails }
         total={ total }
         totalError={ totalError }
+        availability={ this.props.availability }
       />
     );
   }
@@ -291,13 +293,14 @@ function mapStateToProps (initState, initProps) {
     : null;
 
   return (state) => {
-    const { gasLimit } = state.nodeStatus;
+    const { gasLimit, nodeKind = {} } = state.nodeStatus;
     const { balances } = state;
+    const { availability = 'unknown' } = nodeKind;
 
     const balance = balances[address];
     const sendersBalances = senders ? pick(balances, Object.keys(senders)) : null;
 
-    return { balance, gasLimit, senders, sendersBalances, tokens, wallet };
+    return { availability, balance, gasLimit, senders, sendersBalances, tokens, wallet };
   };
 }
 

--- a/js/src/ui/GasPriceEditor/gasPriceEditor.js
+++ b/js/src/ui/GasPriceEditor/gasPriceEditor.js
@@ -64,7 +64,8 @@ export default class GasPriceEditor extends Component {
   static propTypes = {
     children: PropTypes.node,
     onChange: PropTypes.func,
-    store: PropTypes.object.isRequired
+    store: PropTypes.object.isRequired,
+    availability: PropTypes.string.isRequired
   }
 
   static Store = Store;
@@ -72,7 +73,7 @@ export default class GasPriceEditor extends Component {
   render () {
     const { api } = this.context;
     const { children, store } = this.props;
-    const { conditionType, errorGas, errorPrice, errorTotal, estimated, gas, histogram, price, priceDefault, totalValue } = store;
+    const { errorGas, errorPrice, errorTotal, estimated, gas, histogram, price, priceDefault, totalValue } = store;
 
     const eth = api.util.fromWei(totalValue).toFormat();
     const gasLabel = `gas (estimated: ${new BigNumber(estimated).toFormat()})`;
@@ -80,18 +81,7 @@ export default class GasPriceEditor extends Component {
 
     return (
       <div className={ styles.container }>
-        <RadioButtons
-          className={ styles.conditionRadio }
-          label={
-            <FormattedMessage
-              id='txEditor.condition.label'
-              defaultMessage='Condition where transaction activates'
-            />
-          }
-          onChange={ this.onChangeConditionType }
-          value={ conditionType }
-          values={ CONDITION_VALUES }
-        />
+        { this.renderConditionRadioButtons() }
         { this.renderConditions() }
 
         <div className={ styles.graphContainer }>
@@ -148,10 +138,35 @@ export default class GasPriceEditor extends Component {
     );
   }
 
+  renderConditionRadioButtons () {
+    const { availability } = this.props;
+    const { conditionType } = this.props.store;
+
+    if (availability !== 'personal') {
+      return null;
+    }
+
+    return (
+      <RadioButtons
+        className={ styles.conditionRadio }
+        label={
+          <FormattedMessage
+            id='txEditor.condition.label'
+            defaultMessage='Condition where transaction activates'
+          />
+        }
+        onChange={ this.onChangeConditionType }
+        value={ conditionType }
+        values={ CONDITION_VALUES }
+      />
+    );
+  }
+
   renderConditions () {
+    const { availability } = this.props;
     const { conditionType, condition, conditionBlockError } = this.props.store;
 
-    if (conditionType === CONDITIONS.NONE) {
+    if (conditionType === CONDITIONS.NONE || availability !== 'personal') {
       return null;
     }
 

--- a/js/src/views/Signer/components/TransactionPending/transactionPending.js
+++ b/js/src/views/Signer/components/TransactionPending/transactionPending.js
@@ -36,6 +36,7 @@ class TransactionPending extends Component {
   };
 
   static propTypes = {
+    availability: PropTypes.string.isRequired,
     accounts: PropTypes.object.isRequired,
     className: PropTypes.string,
     date: PropTypes.instanceOf(Date).isRequired,
@@ -140,11 +141,11 @@ class TransactionPending extends Component {
   }
 
   renderTxEditor () {
-    const { className } = this.props;
+    const { availability, className } = this.props;
 
     return (
       <div className={ `${styles.container} ${className}` }>
-        <GasPriceEditor store={ this.gasStore }>
+        <GasPriceEditor availability={ availability } store={ this.gasStore }>
           <Button
             label={
               <FormattedMessage
@@ -190,9 +191,12 @@ class TransactionPending extends Component {
 }
 
 function mapStateToProps (state) {
+  const { nodeKind = {} } = state.nodeStatus;
   const { accounts } = state.personal;
+  const { availability = 'unknown' } = nodeKind;
 
   return {
+    availability,
     accounts
   };
 }


### PR DESCRIPTION
* Disables scheduling in the UI - it never worked, and there is no way to make it work that wouldn't make it tricky with nonces.
* Also mocks `parity_lockedHardwareAccountsInfo` to stop the UI from spamming the node and repeatedly get errors as result.