### PR TITLE
Disallow pasting recovery phrases on first run

### DIFF
--- a/js/src/modals/CreateAccount/store.js
+++ b/js/src/modals/CreateAccount/store.js
@@ -35,6 +35,7 @@ export default class Store {
   @observable gethAddresses = [];
   @observable gethImported = [];
   @observable isBusy = false;
+  @observable isTest = false;
   @observable isWindowsPhrase = false;
   @observable name = '';
   @observable nameError = ERRORS.noName;
@@ -308,6 +309,10 @@ export default class Store {
 
   @action prevStage = () => {
     this.stage--;
+  }
+
+  @action setIsTest = isTest => {
+    this.isTest = isTest;
   }
 
   createAccount = (vaultStore) => {

--- a/js/src/modals/FirstRun/firstRun.js
+++ b/js/src/modals/FirstRun/firstRun.js
@@ -78,14 +78,21 @@ class FirstRun extends Component {
     hasAccounts: PropTypes.bool.isRequired,
     newError: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
-    visible: PropTypes.bool.isRequired
+    visible: PropTypes.bool.isRequired,
+    isTest: PropTypes.bool.isRequired
   }
 
-  createStore = new CreateStore(this.context.api, {}, true, false);
+  createStore = new CreateStore(this.context.api, {}, this.props.isTest, false);
 
   state = {
     stage: 0,
     hasAcceptedTnc: false
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.isTest !== this.props.isTest) {
+      this.createStore.setIsTest(nextProps.isTest);
+    }
   }
 
   render () {
@@ -348,9 +355,10 @@ class FirstRun extends Component {
 
 function mapStateToProps (state) {
   const { hasAccounts } = state.personal;
+  const { isTest } = state.nodeStatus;
 
   return {
-    hasAccounts
+    hasAccounts, isTest
   };
 }
 

--- a/js/src/modals/FirstRun/firstRun.spec.js
+++ b/js/src/modals/FirstRun/firstRun.spec.js
@@ -35,6 +35,9 @@ function createRedux () {
       return {
         personal: {
           hasAccounts: false
+        },
+        nodeStatus: {
+          isTest: false
         }
       };
     }

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -18,6 +18,7 @@ import React, { Component, PropTypes } from 'react';
 import { TextField } from 'material-ui';
 import { noop } from 'lodash';
 import keycode from 'keycode';
+import localStore from 'store';
 
 import { nodeOrStringProptype } from '~/util/proptypes';
 import { toString } from '~/util/messages';
@@ -223,7 +224,9 @@ export default class Input extends Component {
   }
 
   onChange = (event, value) => {
-    if (!this.props.allowPaste) {
+    const isDev = localStore.get('allYourBaseAreBelongToUs') || false;
+
+    if (!this.props.allowPaste && !isDev) {
       if (value.length - this.state.value.length > 8) {
         return;
       }


### PR DESCRIPTION
Closes #6581 

The create account dialog on first run was always assuming `isTest` and therefore also allowing users to paste the recovery phrase which eventually leads to situations like #6581. Thanks @tomusdrw for guiding me through the code.