### PR TITLE
move additional_params to machine, fixes registry on non-ethash chains

### DIFF
--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -191,9 +191,6 @@ pub trait Engine<M: Machine>: Sync + Send {
 	/// Additional engine-specific information for the user/developer concerning `header`.
 	fn extra_info(&self, _header: &M::Header) -> BTreeMap<String, String> { BTreeMap::new() }
 
-	/// Additional information.
-	fn additional_params(&self) -> HashMap<String, String> { HashMap::new() }
-
 	/// Maximum number of uncles a block is allowed to declare.
 	fn maximum_uncle_count(&self) -> usize { 2 }
 	/// The number of generations back that uncles can be.
@@ -395,6 +392,11 @@ pub trait EthEngine: Engine<::machine::EthereumMachine> {
 	/// If this machine supports wasm.
 	fn supports_wasm(&self) -> bool {
 		self.machine().supports_wasm()
+	}
+
+	/// Additional information.
+	fn additional_params(&self) -> HashMap<String, String> {
+		self.machine().additional_params()
 	}
 }
 

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -16,7 +16,7 @@
 
 use std::path::Path;
 use std::cmp;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use hash::{KECCAK_EMPTY_LIST_RLP};
 use ethash::{quick_get_difficulty, slow_hash_block_number, EthashManager, OptimizeFor};
@@ -26,7 +26,7 @@ use unexpected::{OutOfBounds, Mismatch};
 use block::*;
 use error::{BlockError, Error};
 use header::Header;
-use engines::{self, Engine, EthEngine};
+use engines::{self, Engine};
 use ethjson;
 use rlp::{self, UntrustedRlp};
 use machine::EthereumMachine;
@@ -149,8 +149,6 @@ impl Engine<EthereumMachine> for Arc<Ethash> {
 
 	// Two fields - nonce and mix.
 	fn seal_fields(&self) -> usize { 2 }
-
-	fn additional_params(&self) -> HashMap<String, String> { hash_map!["registrar".to_owned() => self.params().registrar.hex()] }
 
 	/// Additional engine-specific information for the user/developer concerning `header`.
 	fn extra_info(&self, header: &Header) -> BTreeMap<String, String> {

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -16,7 +16,7 @@
 
 //! Ethereum-like state machine definition.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::cmp;
 use std::sync::Arc;
 
@@ -377,6 +377,13 @@ impl EthereumMachine {
 	/// If this machine supports wasm.
 	pub fn supports_wasm(&self) -> bool {
 		self.params().wasm
+	}
+
+	/// Additional params.
+	pub fn additional_params(&self) -> HashMap<String, String> {
+		hash_map![
+			"registrar".to_owned() => self.params.registrar.hex()
+		]
 	}
 }
 


### PR DESCRIPTION
most implementations of this function were lost in the recent refactor.