### PR TITLE
Removes  dependency on rustc_serialize (#5988)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,6 @@ dependencies = [
  "rlp 0.2.0",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/benches/evm.rs
+++ b/ethcore/benches/evm.rs
@@ -21,8 +21,9 @@ extern crate ethcore_util as util;
 extern crate rand;
 extern crate bn;
 extern crate crypto;
-extern crate rustc_serialize;
 extern crate ethkey;
+extern crate rustc_hex;
+extern crate ethcore_bigint;
 
 use self::test::{Bencher};
 use rand::{StdRng};
@@ -75,9 +76,9 @@ fn sha256(b: &mut Bencher) {
 
 #[bench]
 fn ecrecover(b: &mut Bencher) {
-	use rustc_serialize::hex::FromHex;
+	use rustc_hex::FromHex;
 	use ethkey::{Signature, recover as ec_recover};
-	use util::H256;
+	use ethcore_bigint::hash::H256;
 	let input = FromHex::from_hex("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b650acf9d3f5f0a2c799776a1254355d5f4061762a237396a99a0e0e3fc2bcd6729514a0dacb2e623ac4abd157cb18163ff942280db4d5caad66ddf941ba12e03").unwrap();
 	let hash = H256::from_slice(&input[0..32]);
 	let v = H256::from_slice(&input[32..64]);

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -21,7 +21,6 @@ libc = "0.2.7"
 parking_lot = "0.4"
 ansi_term = "0.9"
 rustc-hex = "1.0"
-rustc-serialize = "0.3"
 ethcore-io = { path = "../io" }
 ethcore-util = { path = ".." }
 ethcore-bigint = { path = "../bigint" }

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -34,6 +34,7 @@ path = { path = "../path" }
 ethcore-logger = { path ="../../logger" }
 ipnetwork = "0.12.6"
 hash = { path = "../hash" }
+serde_json = "1.0"
 
 [features]
 default = []

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -69,7 +69,6 @@ extern crate rand;
 extern crate time;
 extern crate ansi_term; //TODO: remove this
 extern crate rustc_hex;
-extern crate rustc_serialize;
 extern crate igd;
 extern crate libc;
 extern crate slab;
@@ -81,6 +80,7 @@ extern crate path;
 extern crate ethcore_logger;
 extern crate ipnetwork;
 extern crate hash;
+extern crate serde_json;
 
 #[macro_use]
 extern crate log;

--- a/util/network/src/node_table.rs
+++ b/util/network/src/node_table.rs
@@ -32,7 +32,7 @@ use error::NetworkError;
 use {AllowIP, IpFilter};
 use discovery::{TableUpdates, NodeEntry};
 use ip_utils::*;
-pub use rustc_serialize::json::Json;
+use serde_json::Value;
 
 /// Node public key
 pub type NodeId = H512;
@@ -332,7 +332,7 @@ impl NodeTable {
 					return nodes;
 				}
 			}
-			let json = match Json::from_str(&buf) {
+			let json: Value = match ::serde_json::from_str(&buf) {
 				Ok(json) => json,
 				Err(e) => {
 					warn!("Error parsing node table file: {:?}", e);
@@ -341,7 +341,7 @@ impl NodeTable {
 			};
 			if let Some(list) = json.as_object().and_then(|o| o.get("nodes")).and_then(|n| n.as_array()) {
 				for n in list.iter().filter_map(|n| n.as_object()) {
-					if let Some(url) = n.get("url").and_then(|u| u.as_string()) {
+					if let Some(url) = n.get("url").and_then(|u| u.as_str()) {
 						if let Ok(mut node) = Node::from_str(url) {
 							if let Some(failures) = n.get("failures").and_then(|f| f.as_u64()) {
 								node.failures = failures as u32;


### PR DESCRIPTION
Affects #5988.

- `util/network` was migrated to serde 1.0
- ethcore bench was fixed and adapted to use `rustc_hex`

Looks like these were the last dependencies that used `rustc_serialize`. 

Default test suite passes: 
```
test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Fixed bench shows the following stats:
```
running 4 tests
test bn_128_mul     ... bench:     619,273 ns/iter (+/- 12,419)
test bn_128_pairing ... bench:   6,367,055 ns/iter (+/- 10,457)
test ecrecover      ... bench:     117,225 ns/iter (+/- 7,253)
test sha256         ... bench:       1,227 ns/iter (+/- 64)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```
Just in case, here are my CPU specs:
```
lscpu
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                12
On-line CPU(s) list:   0-11
Thread(s) per core:    2
Core(s) per socket:    6
Socket(s):             1
NUMA node(s):          1
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 63
Model name:            Intel(R) Core(TM) i7-5930K CPU @ 3.50GHz
Stepping:              2
CPU MHz:               1281.738
CPU max MHz:           4000,0000
CPU min MHz:           1200,0000
BogoMIPS:              7012.16
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              15360K
NUMA node0 CPU(s):     0-11
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm epb tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm xsaveopt cqm_llc cqm_occup_llc dtherm ida arat pln pts
```