### PR TITLE
Graceful exit when invalid CLI flags are passed (#6485)

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -1201,6 +1201,7 @@ mod tests {
 		Snapshots, VM, Misc, Whisper, SecretStore,
 	};
 	use toml;
+	use clap::{ErrorKind as ClapErrorKind};
 
 	#[test]
 	fn should_parse_args_and_flags() {
@@ -1215,6 +1216,17 @@ mod tests {
 
 		let args = Args::parse(&["parity", "export", "state", "--min-balance","123"]).unwrap();
 		assert_eq!(args.arg_export_state_min_balance, Some("123".to_string()));
+	}
+
+	#[test]
+	fn should_exit_gracefully_on_unknown_argument() {
+		let result = Args::parse(&["parity", "--please-exit-gracefully"]);
+		assert!(
+			match result {
+				Err(ArgsError::Clap(ref clap_error)) if clap_error.kind == ClapErrorKind::UnknownArgument => true,
+				_ => false
+			}
+		);
 	}
 
 	#[test]

--- a/parity/cli/usage.rs
+++ b/parity/cli/usage.rs
@@ -537,21 +537,20 @@ macro_rules! usage {
 
 				let matches = App::new("Parity")
 				    	.global_setting(AppSettings::VersionlessSubcommands)
-						.global_setting(AppSettings::AllowLeadingHyphen) // allow for example --allow-ips -10.0.0.0/8
 						.global_setting(AppSettings::DisableHelpSubcommand)
 						.help(Args::print_help().as_ref())
-						.args(&usages.iter().map(|u| Arg::from_usage(u).use_delimiter(false)).collect::<Vec<Arg>>())
+						.args(&usages.iter().map(|u| Arg::from_usage(u).use_delimiter(false).allow_hyphen_values(true)).collect::<Vec<Arg>>())
 						$(
 							.subcommand(
 								SubCommand::with_name(&underscore_to_hyphen!(&stringify!($subc)[4..]))
 								.about($subc_help)
-								.args(&subc_usages.get(stringify!($subc)).unwrap().iter().map(|u| Arg::from_usage(u).use_delimiter(false)).collect::<Vec<Arg>>())
+								.args(&subc_usages.get(stringify!($subc)).unwrap().iter().map(|u| Arg::from_usage(u).use_delimiter(false).allow_hyphen_values(true)).collect::<Vec<Arg>>())
 								$(
 									.setting(AppSettings::SubcommandRequired) // prevent from running `parity account`
 									.subcommand(
 										SubCommand::with_name(&underscore_to_hyphen!(&stringify!($subc_subc)[stringify!($subc).len()+1..]))
 										.about($subc_subc_help)
-										.args(&subc_usages.get(stringify!($subc_subc)).unwrap().iter().map(|u| Arg::from_usage(u).use_delimiter(false)).collect::<Vec<Arg>>())
+										.args(&subc_usages.get(stringify!($subc_subc)).unwrap().iter().map(|u| Arg::from_usage(u).use_delimiter(false).allow_hyphen_values(true)).collect::<Vec<Arg>>())
 									)
 								)*
 							)


### PR DESCRIPTION
Fixes https://github.com/paritytech/parity/issues/6485 (due to a bug in Clap; will file issue)