### PR TITLE
use cc 1.0 instead of gcc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,8 +1199,8 @@ dependencies = [
 name = "hash"
 version = "0.1.0"
 dependencies = [
+ "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-bigint 0.1.3",
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -12,7 +12,7 @@ ethcore-bigint = { path = "../bigint" }
 tiny-keccak = "1.3"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/util/hash/build.rs
+++ b/util/hash/build.rs
@@ -16,11 +16,11 @@
 
  // build.rs
 
-// Bring in a dependency on an externally maintained `gcc` package which manages
+// Bring in a dependency on an externally maintained `cc` package which manages
 // invoking the C compiler.
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-    gcc::Build::new().file("src/tinykeccak.c").compile("libtinykeccak.a");
+	cc::Build::new().file("src/tinykeccak.c").compile("libtinykeccak.a");
 }
 


### PR DESCRIPTION
`gcc` has been stabilized and changed the name to `cc`