### PR TITLE
Refactoring/cache 6693

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "macros 0.1.0",
- "memory_cache 0.1.0",
+ "memory-cache 0.1.0",
  "memorydb 0.1.0",
  "migration 0.1.0",
  "native-contracts 0.1.0",
@@ -760,7 +760,7 @@ dependencies = [
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory_cache 0.1.0",
+ "memory-cache 0.1.0",
  "memorydb 0.1.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia_trie 0.1.0",
@@ -1048,7 +1048,7 @@ dependencies = [
  "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory_cache 0.1.0",
+ "memory-cache 0.1.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -1648,7 +1648,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "memory_cache"
+name = "memory-cache"
 version = "0.1.0"
 dependencies = [
  "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,6 @@ dependencies = [
  "kvdb 0.1.0",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memorydb 0.1.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia_trie 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "macros 0.1.0",
+ "memory_cache 0.1.0",
  "memorydb 0.1.0",
  "migration 0.1.0",
  "native-contracts 0.1.0",
@@ -759,6 +760,7 @@ dependencies = [
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory_cache 0.1.0",
  "memorydb 0.1.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia_trie 0.1.0",
@@ -1047,6 +1049,7 @@ dependencies = [
  "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory_cache 0.1.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -1643,6 +1646,14 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memory_cache"
+version = "0.1.0"
+dependencies = [
+ "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -32,6 +32,7 @@ ethcore-logger = { path = "../logger" }
 ethcore-stratum = { path = "../stratum" }
 ethcore-util = { path = "../util" }
 ethcore-bigint = { path = "../util/bigint" }
+memory_cache = { path = "../util/memory_cache" }
 ethjson = { path = "../json" }
 ethkey = { path = "../ethkey" }
 ethstore = { path = "../ethstore" }

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -32,7 +32,7 @@ ethcore-logger = { path = "../logger" }
 ethcore-stratum = { path = "../stratum" }
 ethcore-util = { path = "../util" }
 ethcore-bigint = { path = "../util/bigint" }
-memory_cache = { path = "../util/memory_cache" }
+memory-cache = { path = "../util/memory_cache" }
 ethjson = { path = "../json" }
 ethkey = { path = "../ethkey" }
 ethstore = { path = "../ethstore" }

--- a/ethcore/evm/Cargo.toml
+++ b/ethcore/evm/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.3"
 vm = { path = "../vm" }
 hash = { path = "../../util/hash" }
 parking_lot = "0.4"
+memory_cache = { path = "../../util/memory_cache" }
 
 [dev-dependencies]
 rustc-hex = "1.0"

--- a/ethcore/evm/Cargo.toml
+++ b/ethcore/evm/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.3"
 vm = { path = "../vm" }
 hash = { path = "../../util/hash" }
 parking_lot = "0.4"
-memory_cache = { path = "../../util/memory_cache" }
+memory-cache = { path = "../../util/memory_cache" }
 
 [dev-dependencies]
 rustc-hex = "1.0"

--- a/ethcore/evm/src/interpreter/shared_cache.rs
+++ b/ethcore/evm/src/interpreter/shared_cache.rs
@@ -19,7 +19,7 @@ use hash::KECCAK_EMPTY;
 use heapsize::HeapSizeOf;
 use bigint::hash::H256;
 use parking_lot::Mutex;
-use util::cache::MemoryLruCache;
+use memory_cache::MemoryLruCache;
 use bit_set::BitSet;
 use super::super::instructions;
 

--- a/ethcore/evm/src/lib.rs
+++ b/ethcore/evm/src/lib.rs
@@ -23,6 +23,7 @@ extern crate parking_lot;
 extern crate heapsize;
 extern crate vm;
 extern crate hash;
+extern crate memory_cache;
 
 #[macro_use]
 extern crate lazy_static;

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -40,6 +40,7 @@ stats = { path = "../../util/stats" }
 hash = { path = "../../util/hash" }
 triehash = { path = "../../util/triehash" }
 kvdb = { path = "../../util/kvdb" }
+memory_cache = { path = "../../util/memory_cache" }
 
 [features]
 default = []

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -40,7 +40,7 @@ stats = { path = "../../util/stats" }
 hash = { path = "../../util/hash" }
 triehash = { path = "../../util/triehash" }
 kvdb = { path = "../../util/kvdb" }
-memory_cache = { path = "../../util/memory_cache" }
+memory-cache = { path = "../../util/memory_cache" }
 
 [features]
 default = []

--- a/ethcore/light/src/cache.rs
+++ b/ethcore/light/src/cache.rs
@@ -29,7 +29,7 @@ use time::{SteadyTime, Duration};
 use heapsize::HeapSizeOf;
 use bigint::prelude::U256;
 use bigint::hash::H256;
-use util::cache::MemoryLruCache;
+use memory_cache::MemoryLruCache;
 
 /// Configuration for how much data to cache.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ethcore/light/src/lib.rs
+++ b/ethcore/light/src/lib.rs
@@ -92,6 +92,7 @@ extern crate vm;
 extern crate hash;
 extern crate triehash;
 extern crate kvdb;
+extern crate memory_cache;
 
 #[cfg(feature = "ipc")]
 extern crate ethcore_ipc as ipc;

--- a/ethcore/src/engines/validator_set/safe_contract.rs
+++ b/ethcore/src/engines/validator_set/safe_contract.rs
@@ -27,7 +27,7 @@ use parking_lot::{Mutex, RwLock};
 
 use util::*;
 use bytes::Bytes;
-use util::cache::MemoryLruCache;
+use memory_cache::MemoryLruCache;
 use unexpected::Mismatch;
 use rlp::{UntrustedRlp, RlpStream};
 

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -129,6 +129,7 @@ extern crate bloomable;
 extern crate vm;
 extern crate wasm;
 extern crate ethcore_util as util;
+extern crate memory_cache;
 
 #[macro_use]
 extern crate macros;

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -17,7 +17,7 @@
 use std::collections::{VecDeque, HashSet};
 use std::sync::Arc;
 use lru_cache::LruCache;
-use util::cache::MemoryLruCache;
+use memory_cache::MemoryLruCache;
 use util::journaldb::JournalDB;
 use kvdb::{KeyValueDB, DBTransaction};
 use bigint::hash::H256;

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -24,7 +24,6 @@ target_info = "0.1"
 ethcore-bigint = { path = "bigint", features = ["heapsizeof"] }
 parking_lot = "0.4"
 tiny-keccak= "1.0"
-lru-cache = "0.1.0"
 ethcore-logger = { path = "../logger" }
 triehash = { path = "triehash" }
 error-chain = "0.11.0-rc.2"

--- a/util/memory_cache/Cargo.toml
+++ b/util/memory_cache/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "memory_cache"
+name = "memory-cache"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "An LRU-cache which operates on memory used"

--- a/util/memory_cache/Cargo.toml
+++ b/util/memory_cache/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "memory_cache"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "An LRU-cache which operates on memory used"
+license = "GPL3"
+
+[dependencies]
+heapsize = "0.4"
+lru-cache = "0.1"

--- a/util/memory_cache/src/lib.rs
+++ b/util/memory_cache/src/lib.rs
@@ -18,6 +18,9 @@
 //! crate.
 // TODO: push changes upstream in a clean way.
 
+extern crate heapsize;
+extern crate lru_cache;
+
 use heapsize::HeapSizeOf;
 use lru_cache::LruCache;
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -116,7 +116,6 @@ extern crate log as rlog;
 pub mod misc;
 pub mod overlaydb;
 pub mod journaldb;
-pub mod cache;
 
 pub use misc::*;
 pub use hashdb::*;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -100,7 +100,6 @@ extern crate ethcore_bytes as bytes;
 extern crate parking_lot;
 extern crate tiny_keccak;
 extern crate rlp;
-extern crate lru_cache;
 extern crate heapsize;
 extern crate ethcore_logger;
 extern crate hash as keccak;


### PR DESCRIPTION
Affects #6693.

`MemoryLruCache` was extracted from `util/src` into separate crate `util/memory_cache`. Also, references in `ethcore` was altered to reflect this change.