### PR TITLE
Return error on timed unlock

### DIFF
--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -292,7 +292,7 @@ impl FullDependencies {
 					}
 				},
 				Api::Personal => {
-					handler.extend_with(PersonalClient::new(&self.secret_store, dispatcher.clone(), self.geth_compatibility).to_delegate());
+					handler.extend_with(PersonalClient::new(self.secret_store.clone(), dispatcher.clone(), self.geth_compatibility).to_delegate());
 				},
 				Api::Signer => {
 					handler.extend_with(SignerClient::new(&self.secret_store, dispatcher.clone(), &self.signer_service, self.remote.clone()).to_delegate());
@@ -495,7 +495,7 @@ impl<C: LightChainClient + 'static> LightDependencies<C> {
 				},
 				Api::Personal => {
 					let secret_store = Some(self.secret_store.clone());
-					handler.extend_with(PersonalClient::new(&secret_store, dispatcher.clone(), self.geth_compatibility).to_delegate());
+					handler.extend_with(PersonalClient::new(secret_store, dispatcher.clone(), self.geth_compatibility).to_delegate());
 				},
 				Api::Signer => {
 					let secret_store = Some(self.secret_store.clone());

--- a/rpc/src/v1/tests/mocked/personal.rs
+++ b/rpc/src/v1/tests/mocked/personal.rs
@@ -54,7 +54,7 @@ fn setup() -> PersonalTester {
 	let miner = miner_service();
 
 	let dispatcher = FullDispatcher::new(client, miner.clone());
-	let personal = PersonalClient::new(&opt_accounts, dispatcher, false);
+	let personal = PersonalClient::new(opt_accounts, dispatcher, false);
 
 	let mut io = IoHandler::default();
 	io.extend_with(personal.to_delegate());
@@ -178,7 +178,7 @@ fn sign_and_send_test(method: &str) {
 }
 
 #[test]
-fn should_unlock_account_temporarily() {
+fn should_unlock_not_account_temporarily_if_allow_perm_is_disabled() {
 	let tester = setup();
 	let address = tester.accounts.new_account("password123").unwrap();
 
@@ -192,10 +192,10 @@ fn should_unlock_account_temporarily() {
 		],
 		"id": 1
 	}"#;
-	let response = r#"{"jsonrpc":"2.0","result":true,"id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"Time-unlocking is only supported in --geth compatibility mode.","data":"Restart your client with --geth flag or use personal_sendTransaction instead."},"id":1}"#;
 	assert_eq!(tester.io.handle_request_sync(&request), Some(response.into()));
 
-	assert!(tester.accounts.sign(address, None, Default::default()).is_ok(), "Should unlock account.");
+	assert!(tester.accounts.sign(address, None, Default::default()).is_err(), "Should not unlock account.");
 }
 
 #[test]


### PR DESCRIPTION
Also fixes error reporting from `unlock`
Closes #6763 