### PR TITLE
consistent KeyValueDB errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,6 @@ dependencies = [
  "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.6 (git+https://github.com/paritytech/rust-secp256k1)",
  "ethcore-bigint 0.1.3",
  "ethcore-bytes 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
 name = "migration"
 version = "0.1.0"
 dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-devtools 1.9.0",
  "kvdb 0.1.0",
  "kvdb-rocksdb 0.1.0",
@@ -2051,6 +2052,7 @@ dependencies = [
  "ipnetwork 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "isatty 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-1.8)",
+ "kvdb 0.1.0",
  "kvdb-rocksdb 0.1.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "migration 0.1.0",
@@ -3459,6 +3461,7 @@ version = "0.1.0"
 dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-bigint 0.1.3",
+ "kvdb 0.1.0",
  "rlp 0.2.0",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ path = { path = "util/path" }
 panic_hook = { path = "panic_hook" }
 hash = { path = "util/hash" }
 migration = { path = "util/migration" }
+kvdb = { path = "util/kvdb" }
 kvdb-rocksdb = { path = "util/kvdb-rocksdb" }
 
 parity-dapps = { path = "dapps", optional = true }

--- a/ethcore/light/src/client/header_chain.rs
+++ b/ethcore/light/src/client/header_chain.rs
@@ -45,7 +45,7 @@ use rlp::{Encodable, Decodable, DecoderError, RlpStream, Rlp, UntrustedRlp};
 use heapsize::HeapSizeOf;
 use bigint::prelude::U256;
 use bigint::hash::{H256, H256FastMap, H264};
-use kvdb::{DBTransaction, KeyValueDB};
+use kvdb::{self, DBTransaction, KeyValueDB};
 
 use cache::Cache;
 use parking_lot::{Mutex, RwLock};
@@ -198,7 +198,7 @@ impl HeaderChain {
 		col: Option<u32>,
 		spec: &Spec,
 		cache: Arc<Mutex<Cache>>,
-	) -> Result<Self, String> {
+	) -> Result<Self, kvdb::Error> {
 		let mut live_epoch_proofs = ::std::collections::HashMap::default();
 
 		let genesis = ::rlp::encode(&spec.genesis_header()).into_vec();
@@ -240,7 +240,7 @@ impl HeaderChain {
 			let best_block = {
 				let era = match candidates.get(&best_number) {
 					Some(era) => era,
-					None => return Err(format!("Database corrupt: highest block referenced but no data.")),
+					None => return Err("Database corrupt: highest block referenced but no data.".into()),
 				};
 
 				let best = &era.candidates[0];

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -36,7 +36,7 @@ use bigint::prelude::U256;
 use bigint::hash::H256;
 use futures::{IntoFuture, Future};
 
-use kvdb::KeyValueDB;
+use kvdb::{self, KeyValueDB};
 use kvdb_rocksdb::CompactionProfile;
 
 use self::fetch::ChainDataFetcher;
@@ -187,7 +187,7 @@ impl<T: ChainDataFetcher> Client<T> {
 		fetcher: T,
 		io_channel: IoChannel<ClientIoMessage>,
 		cache: Arc<Mutex<Cache>>
-	) -> Result<Self, String> {
+	) -> Result<Self, kvdb::Error> {
 		Ok(Client {
 			queue: HeaderQueue::new(config.queue, spec.engine.clone(), io_channel, config.check_seal),
 			engine: spec.engine.clone(),

--- a/ethcore/light/src/client/service.rs
+++ b/ethcore/light/src/client/service.rs
@@ -25,6 +25,7 @@ use ethcore::db;
 use ethcore::service::ClientIoMessage;
 use ethcore::spec::Spec;
 use io::{IoContext, IoError, IoHandler, IoService};
+use kvdb;
 use kvdb_rocksdb::{Database, DatabaseConfig};
 
 use cache::Cache;
@@ -36,7 +37,7 @@ use super::{ChainDataFetcher, Client, Config as ClientConfig};
 #[derive(Debug)]
 pub enum Error {
 	/// Database error.
-	Database(String),
+	Database(kvdb::Error),
 	/// I/O service error.
 	Io(IoError),
 }

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -29,7 +29,7 @@ use bytes::Bytes;
 use util::{Address, journaldb, DBValue};
 use util_error::UtilError;
 use trie::{TrieSpec, TrieFactory, Trie};
-use kvdb::*;
+use kvdb::{KeyValueDB, DBTransaction};
 
 // other
 use bigint::prelude::U256;

--- a/ethcore/src/client/error.rs
+++ b/ethcore/src/client/error.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use util_error::UtilError;
 use std::fmt::{Display, Formatter, Error as FmtError};
-
+use util_error::UtilError;
+use kvdb;
 use trie::TrieError;
 
 /// Client configuration errors.
@@ -25,7 +25,7 @@ pub enum Error {
 	/// TrieDB-related error.
 	Trie(TrieError),
 	/// Database error
-	Database(String),
+	Database(kvdb::Error),
 	/// Util error
 	Util(UtilError),
 }

--- a/ethcore/src/client/evm_test_client.rs
+++ b/ethcore/src/client/evm_test_client.rs
@@ -38,7 +38,7 @@ pub enum EvmTestError {
 	/// Initialization error.
 	ClientError(::error::Error),
 	/// Low-level database error.
-	Database(String),
+	Database(kvdb::Error),
 	/// Post-condition failure,
 	PostCondition(String),
 }

--- a/local-store/src/lib.rs
+++ b/local-store/src/lib.rs
@@ -56,7 +56,7 @@ const UPDATE_TIMEOUT_MS: u64 = 15 * 60 * 1000; // once every 15 minutes.
 #[derive(Debug)]
 pub enum Error {
 	/// Database errors: these manifest as `String`s.
-	Database(String),
+	Database(kvdb::Error),
 	/// JSON errors.
 	Json(::serde_json::Error),
 }

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -62,6 +62,7 @@ extern crate ethcore_bigint as bigint;
 extern crate ethcore_bytes as bytes;
 extern crate ethcore_network as network;
 extern crate migration as migr;
+extern crate kvdb;
 extern crate kvdb_rocksdb;
 extern crate ethkey;
 extern crate ethsync;

--- a/parity/migration.rs
+++ b/parity/migration.rs
@@ -21,7 +21,8 @@ use std::path::{Path, PathBuf};
 use std::fmt::{Display, Formatter, Error as FmtError};
 use std::sync::Arc;
 use util::journaldb::Algorithm;
-use migr::{Manager as MigrationManager, Config as MigrationConfig, Error as MigrationError, Migration};
+use migr::{self, Manager as MigrationManager, Config as MigrationConfig, Migration};
+use kvdb;
 use kvdb_rocksdb::{CompactionProfile, Database, DatabaseConfig};
 use ethcore::migrations;
 use ethcore::db;
@@ -52,7 +53,7 @@ pub enum Error {
 	/// Migration unexpectadly failed.
 	MigrationFailed,
 	/// Internal migration error.
-	Internal(MigrationError),
+	Internal(migr::Error),
 	/// Migration was completed succesfully,
 	/// but there was a problem with io.
 	Io(IoError),
@@ -80,11 +81,11 @@ impl From<IoError> for Error {
 	}
 }
 
-impl From<MigrationError> for Error {
-	fn from(err: MigrationError) -> Self {
-		match err {
-			MigrationError::Io(e) => Error::Io(e),
-			_ => Error::Internal(err),
+impl From<migr::Error> for Error {
+	fn from(err: migr::Error) -> Self {
+		match err.into() {
+			migr::ErrorKind::Io(e) => Error::Io(e),
+			err => Error::Internal(err.into()),
 		}
 	}
 }
@@ -158,7 +159,7 @@ fn consolidate_database(
 	column: Option<u32>,
 	extract: Extract,
 	compaction_profile: &CompactionProfile) -> Result<(), Error> {
-	fn db_error(e: String) -> Error {
+	fn db_error(e: kvdb::Error) -> Error {
 		warn!("Cannot open Database for consolidation: {:?}", e);
 		Error::MigrationFailed
 	}

--- a/secret_store/src/types/all.rs
+++ b/secret_store/src/types/all.rs
@@ -18,10 +18,7 @@ use std::fmt;
 use std::collections::BTreeMap;
 use serde_json;
 
-use ethkey;
-use bytes;
-use bigint;
-use key_server_cluster;
+use {ethkey, kvdb, bytes, bigint, key_server_cluster};
 
 /// Node id.
 pub type NodeId = ethkey::Public;
@@ -131,6 +128,12 @@ impl From<serde_json::Error> for Error {
 impl From<ethkey::Error> for Error {
 	fn from(err: ethkey::Error) -> Self {
 		Error::Internal(err.into())
+	}
+}
+
+impl From<kvdb::Error> for Error {
+	fn from(err: kvdb::Error) -> Self {
+		Error::Database(err.to_string())
 	}
 }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -26,7 +26,6 @@ parking_lot = "0.4"
 tiny-keccak= "1.0"
 ethcore-logger = { path = "../logger" }
 triehash = { path = "triehash" }
-error-chain = "0.11.0-rc.2"
 hashdb = { path = "hashdb" }
 patricia_trie = { path = "patricia_trie" }
 ethcore-bytes = { path = "bytes" }

--- a/util/error/Cargo.toml
+++ b/util/error/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 rlp = { path = "../rlp" }
+kvdb = { path = "../kvdb" }
 ethcore-bigint = { path = "../bigint" }
 error-chain = "0.11.0-rc.2"
 rustc-hex = "1.0"

--- a/util/error/Cargo.toml
+++ b/util/error/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Parity Technologies <admin@parity.io>"]
 rlp = { path = "../rlp" }
 kvdb = { path = "../kvdb" }
 ethcore-bigint = { path = "../bigint" }
-error-chain = "0.11.0-rc.2"
+error-chain = "0.11.0"
 rustc-hex = "1.0"

--- a/util/error/src/lib.rs
+++ b/util/error/src/lib.rs
@@ -25,6 +25,7 @@ extern crate error_chain;
 extern crate ethcore_bigint as bigint;
 extern crate rlp;
 extern crate rustc_hex;
+extern crate kvdb;
 
 use std::fmt;
 use rustc_hex::FromHexError;
@@ -60,6 +61,10 @@ impl std::error::Error for BaseDataError {
 error_chain! {
 	types {
 		UtilError, ErrorKind, ResultExt, Result;
+	}
+
+	links {
+		Db(kvdb::Error, kvdb::ErrorKind);
 	}
 
 	foreign_links {

--- a/util/kvdb/Cargo.toml
+++ b/util/kvdb/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 elastic-array = "0.9"
-error-chain = "0.11.0-rc.2"
+error-chain = "0.11.0"
 ethcore-bytes = { path = "../bytes" }

--- a/util/kvdb/src/lib.rs
+++ b/util/kvdb/src/lib.rs
@@ -33,7 +33,7 @@ pub type DBValue = ElasticArray128<u8>;
 
 error_chain! {
 	types {
-		Error, ErrorKind, ResultExt;
+		Error, ErrorKind, ResultExt, Result;
 	}
 
 	foreign_links {
@@ -148,7 +148,7 @@ pub trait KeyValueDB: Sync + Send {
 	fn transaction(&self) -> DBTransaction { DBTransaction::new() }
 
 	/// Get a value by key.
-	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>, String>;
+	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>>;
 
 	/// Get a value by partial key. Only works for flushed data.
 	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>>;
@@ -157,13 +157,13 @@ pub trait KeyValueDB: Sync + Send {
 	fn write_buffered(&self, transaction: DBTransaction);
 
 	/// Write a transaction of changes to the backing store.
-	fn write(&self, transaction: DBTransaction) -> Result<(), String> {
+	fn write(&self, transaction: DBTransaction) -> Result<()> {
 		self.write_buffered(transaction);
 		self.flush()
 	}
 
 	/// Flush all buffered data.
-	fn flush(&self) -> Result<(), String>;
+	fn flush(&self) -> Result<()>;
 
 	/// Iterate over flushed data for a given column.
 	fn iter<'a>(&'a self, col: Option<u32>) -> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a>;
@@ -173,5 +173,5 @@ pub trait KeyValueDB: Sync + Send {
 		-> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a>;
 
 	/// Attempt to replace this database with a new one located at the given path.
-	fn restore(&self, new_db: &str) -> Result<(), Error>;
+	fn restore(&self, new_db: &str) -> Result<()>;
 }

--- a/util/migration/Cargo.toml
+++ b/util/migration/Cargo.toml
@@ -9,4 +9,4 @@ macros = { path = "../macros" }
 kvdb = { path = "../kvdb" }
 kvdb-rocksdb = { path = "../kvdb-rocksdb" }
 ethcore-devtools = { path = "../../devtools" }
-error-chain = "0.11.0-rc.2"
+error-chain = "0.11.0"

--- a/util/migration/Cargo.toml
+++ b/util/migration/Cargo.toml
@@ -9,3 +9,4 @@ macros = { path = "../macros" }
 kvdb = { path = "../kvdb" }
 kvdb-rocksdb = { path = "../kvdb-rocksdb" }
 ethcore-devtools = { path = "../../devtools" }
+error-chain = "0.11.0-rc.2"

--- a/util/migration/src/lib.rs
+++ b/util/migration/src/lib.rs
@@ -22,6 +22,8 @@ mod tests;
 extern crate log;
 #[macro_use]
 extern crate macros;
+#[macro_use]
+extern crate error_chain;
 
 extern crate ethcore_devtools as devtools;
 extern crate kvdb;
@@ -30,10 +32,36 @@ extern crate kvdb_rocksdb;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::{fs, fmt};
+use std::{fs, io};
 
 use kvdb::DBTransaction;
 use kvdb_rocksdb::{CompactionProfile, Database, DatabaseConfig};
+
+error_chain! {
+	types {
+		Error, ErrorKind, ResultExt, Result;
+	}
+
+	links {
+		Db(kvdb::Error, kvdb::ErrorKind);
+	}
+
+	foreign_links {
+		Io(io::Error);
+	}
+
+	errors {
+		CannotAddMigration {
+			description("Cannot add migration"),
+			display("Cannot add migration"),
+		}
+
+		MigrationImpossible {
+			description("Migration impossible"),
+			display("Migration impossible"),
+		}
+	}
+}
 
 /// Migration config.
 #[derive(Clone)]
@@ -71,7 +99,7 @@ impl Batch {
 	}
 
 	/// Insert a value into the batch, committing if necessary.
-	pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>, dest: &mut Database) -> Result<(), Error> {
+	pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>, dest: &mut Database) -> Result<()> {
 		self.inner.insert(key, value);
 		if self.inner.len() == self.batch_size {
 			self.commit(dest)?;
@@ -80,7 +108,7 @@ impl Batch {
 	}
 
 	/// Commit all the items in the batch to the given database.
-	pub fn commit(&mut self, dest: &mut Database) -> Result<(), Error> {
+	pub fn commit(&mut self, dest: &mut Database) -> Result<()> {
 		if self.inner.is_empty() { return Ok(()) }
 
 		let mut transaction = DBTransaction::new();
@@ -90,43 +118,7 @@ impl Batch {
 		}
 
 		self.inner.clear();
-		dest.write(transaction).map_err(Error::Custom)
-	}
-}
-
-/// Migration error.
-#[derive(Debug)]
-pub enum Error {
-	/// Error returned when it is impossible to add new migration rules.
-	CannotAddMigration,
-	/// Error returned when migration from specific version can not be performed.
-	MigrationImpossible,
-	/// Io Error.
-	Io(::std::io::Error),
-	/// Custom error.
-	Custom(String),
-}
-
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		match *self {
-			Error::CannotAddMigration => write!(f, "Cannot add migration"),
-			Error::MigrationImpossible => write!(f, "Migration impossible"),
-			Error::Io(ref err) => write!(f, "{}", err),
-			Error::Custom(ref err) => write!(f, "{}", err),
-		}
-	}
-}
-
-impl From<::std::io::Error> for Error {
-	fn from(e: ::std::io::Error) -> Self {
-		Error::Io(e)
-	}
-}
-
-impl From<String> for Error {
-	fn from(e: String) -> Self {
-		Error::Custom(e)
+		dest.write(transaction).map_err(Into::into)
 	}
 }
 
@@ -142,7 +134,7 @@ pub trait Migration: 'static {
 	/// Version of the database after the migration.
 	fn version(&self) -> u32;
 	/// Migrate a source to a destination.
-	fn migrate(&mut self, source: Arc<Database>, config: &Config, destination: &mut Database, col: Option<u32>) -> Result<(), Error>;
+	fn migrate(&mut self, source: Arc<Database>, config: &Config, destination: &mut Database, col: Option<u32>) -> Result<()>;
 }
 
 /// A simple migration over key-value pairs.
@@ -163,7 +155,7 @@ impl<T: SimpleMigration> Migration for T {
 
 	fn alters_existing(&self) -> bool { true }
 
-	fn migrate(&mut self, source: Arc<Database>, config: &Config, dest: &mut Database, col: Option<u32>) -> Result<(), Error> {
+	fn migrate(&mut self, source: Arc<Database>, config: &Config, dest: &mut Database, col: Option<u32>) -> Result<()> {
 		let mut batch = Batch::new(config, col);
 
 		let iter = match source.iter(col) {
@@ -196,7 +188,7 @@ impl Migration for ChangeColumns {
 	fn columns(&self) -> Option<u32> { self.post_columns }
 	fn version(&self) -> u32 { self.version }
 	fn alters_existing(&self) -> bool { false }
-	fn migrate(&mut self, _: Arc<Database>, _: &Config, _: &mut Database, _: Option<u32>) -> Result<(), Error> {
+	fn migrate(&mut self, _: Arc<Database>, _: &Config, _: &mut Database, _: Option<u32>) -> Result<()> {
 		Ok(())
 	}
 }
@@ -250,7 +242,7 @@ impl Manager {
 	}
 
 	/// Adds new migration rules.
-	pub fn add_migration<T>(&mut self, migration: T) -> Result<(), Error> where T: Migration {
+	pub fn add_migration<T>(&mut self, migration: T) -> Result<()> where T: Migration {
 		let is_new = match self.migrations.last() {
 			Some(last) => migration.version() > last.version(),
 			None => true,
@@ -258,17 +250,19 @@ impl Manager {
 
 		match is_new {
 			true => Ok(self.migrations.push(Box::new(migration))),
-			false => Err(Error::CannotAddMigration),
+			false => Err(ErrorKind::CannotAddMigration.into()),
 		}
 	}
 
 	/// Performs migration in order, starting with a source path, migrating between two temporary databases,
 	/// and producing a path where the final migration lives.
-	pub fn execute(&mut self, old_path: &Path, version: u32) -> Result<PathBuf, Error> {
+	pub fn execute(&mut self, old_path: &Path, version: u32) -> Result<PathBuf> {
 		let config = self.config.clone();
 		let migrations = self.migrations_from(version);
 		trace!(target: "migration", "Total migrations to execute for version {}: {}", version, migrations.len());
-		if migrations.is_empty() { return Err(Error::MigrationImpossible) };
+		if migrations.is_empty() {
+			return Err(ErrorKind::MigrationImpossible.into())
+		};
 
 		let columns = migrations.get(0).and_then(|m| m.pre_columns());
 
@@ -286,8 +280,8 @@ impl Manager {
 		let mut temp_path = old_path.to_path_buf();
 
 		// start with the old db.
-		let old_path_str = old_path.to_str().ok_or(Error::MigrationImpossible)?;
-		let mut cur_db = Arc::new(Database::open(&db_config, old_path_str).map_err(Error::Custom)?);
+		let old_path_str = old_path.to_str().ok_or(ErrorKind::MigrationImpossible)?;
+		let mut cur_db = Arc::new(Database::open(&db_config, old_path_str)?);
 
 		for migration in migrations {
 			trace!(target: "migration", "starting migration to version {}", migration.version());
@@ -300,8 +294,8 @@ impl Manager {
 				temp_path = temp_idx.path(&db_root);
 
 				// open the target temporary database.
-				let temp_path_str = temp_path.to_str().ok_or(Error::MigrationImpossible)?;
-				let mut new_db = Database::open(&db_config, temp_path_str).map_err(Error::Custom)?;
+				let temp_path_str = temp_path.to_str().ok_or(ErrorKind::MigrationImpossible)?;
+				let mut new_db = Database::open(&db_config, temp_path_str)?;
 
 				match current_columns {
 					// migrate only default column
@@ -324,11 +318,11 @@ impl Manager {
 				// we can do this in-place.
 				let goal_columns = migration.columns().unwrap_or(0);
 				while cur_db.num_columns() < goal_columns {
-					cur_db.add_column().map_err(Error::Custom)?;
+					cur_db.add_column().map_err(kvdb::Error::from)?;
 				}
 
 				while cur_db.num_columns() > goal_columns {
-					cur_db.drop_column().map_err(Error::Custom)?;
+					cur_db.drop_column().map_err(kvdb::Error::from)?;
 				}
 			}
 		}

--- a/util/patricia_trie/src/lib.rs
+++ b/util/patricia_trie/src/lib.rs
@@ -90,7 +90,7 @@ impl error::Error for TrieError {
 	fn description(&self) -> &str {
 		match *self {
 			TrieError::InvalidStateRoot(_) => "Invalid state root",
-			TrieError::IncompleteDatabase(_) => "IncompleteDatabase",
+			TrieError::IncompleteDatabase(_) => "Incomplete database",
 		}
 	}
 }

--- a/util/patricia_trie/src/lib.rs
+++ b/util/patricia_trie/src/lib.rs
@@ -28,7 +28,7 @@ extern crate ethcore_logger;
 #[macro_use]
 extern crate log;
 
-use std::fmt;
+use std::{fmt, error};
 use bigint::hash::H256;
 use keccak::KECCAK_NULL_RLP;
 use hashdb::{HashDB, DBValue};
@@ -82,6 +82,15 @@ impl fmt::Display for TrieError {
 			TrieError::InvalidStateRoot(ref root) => write!(f, "Invalid state root: {}", root),
 			TrieError::IncompleteDatabase(ref missing) =>
 				write!(f, "Database missing expected key: {}", missing),
+		}
+	}
+}
+
+impl error::Error for TrieError {
+	fn description(&self) -> &str {
+		match *self {
+			TrieError::InvalidStateRoot(_) => "Invalid state root",
+			TrieError::IncompleteDatabase(_) => "IncompleteDatabase",
 		}
 	}
 }


### PR DESCRIPTION
some of the KeyValueDB methods return `Result<(), String>` , while others return `Result<(), Error>`. This pr unifies result type for all methods