### PR TITLE
Tweaked snapshot sync threshold

### DIFF
--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -137,7 +137,7 @@ const MAX_TRANSACTION_PACKET_SIZE: usize = 8 * 1024 * 1024;
 // Maximal number of transactions in sent in single packet.
 const MAX_TRANSACTIONS_TO_PROPAGATE: usize = 64;
 // Min number of blocks to be behind for a snapshot sync
-const SNAPSHOT_RESTORE_THRESHOLD: BlockNumber = 10000;
+const SNAPSHOT_RESTORE_THRESHOLD: BlockNumber = 30000;
 const SNAPSHOT_MIN_PEERS: usize = 3;
 
 const STATUS_PACKET: u8 = 0x00;


### PR DESCRIPTION
Tweaked snapshot sync to start when falling back more than 30k blocks. Given that block times has decreased 2x and snapshot sync still has to download all the historical blocks again this seems appropriate.