### PR TITLE
Align README with 1.8 and prepare CHANGELOG with 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Parity [v1.8.1](https://github.com/paritytech/parity/releases/tag/v1.8.1) (2017-10-20)
 
-Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, improves performance of nodes with huge amounts of accounts, and changes the Trezor account devivation path.
+Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, improves the performance of nodes with huge amounts of accounts and changes the Trezor account derivation path.
 
 **Important Note**: The **Trezor** account derivation path was changed in this release ([#6815](https://github.com/paritytech/parity/pull/6815)) to always use the first account (`m/44'/60'/0'/0/0` instead of `m/44'/60'/0'/0`). This way we enable compatibility with other Ethereum wallets supporting Trezor hardware-wallets. However, **action is required** before upgrading, if you have funds on your Parity Trezor wallet. If you already upgraded to 1.8.1, please downgrade to 1.8.0 first to recover the funds with the following steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Parity [v1.8.1](https://github.com/paritytech/parity/releases/tag/v1.8.1) (2017-10-20)
 
-Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, and improves performance of nodes with huge amounts of accounts.
+Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, and changes the Trezor account devivation path.
 
-**Important Note**: The **Trezor** account derivation path was changed in this release (#6815) to always use the first account (`m/44'/60'/0'/0/0` instead of `m/44'/60'/0'/0`). This way we enable compatibility with other Ethereum wallets supporting Trezor hardware-wallets. However, **action is required** before upgrading, if you have funds on your Parity Trezor wallet. If you already upgraded to 1.8.1, please downgrade to 1.8.0 first to recover the funds with the following steps:
+**Important Note**: The **Trezor** account derivation path was changed in this release ([#6815](https://github.com/paritytech/parity/pull/6815)) to always use the first account (`m/44'/60'/0'/0/0` instead of `m/44'/60'/0'/0`). This way we enable compatibility with other Ethereum wallets supporting Trezor hardware-wallets. However, **action is required** before upgrading, if you have funds on your Parity Trezor wallet. If you already upgraded to 1.8.1, please downgrade to 1.8.0 first to recover the funds with the following steps:
 
 1. Make sure you have 1.8.0-beta and your Trezor plugged in.
 2. Create a new standard Parity account. Make sure you have backups of the recovery phrase and don't forget the password.
@@ -15,9 +15,12 @@ If you don't want to downgrade or move your funds off your Trezor-device, you ca
 
 Full list of included changes:
 
-- @TODO waiting for backports
-- Refresh cached tokens based on registry info & random balances (#6824)
-  - Refresh cached tokens based on registry info & random balances (#6818)
+- Bumb to v1.8.1 ([#6843](https://github.com/paritytech/parity/pull/6843))
+- Backport ([#6837](https://github.com/paritytech/parity/pull/6837))
+  - Tweaked snapshot sync threshold ([#6829](https://github.com/paritytech/parity/pull/6829))
+  - Change keypath derivation logic ([#6815](https://github.com/paritytech/parity/pull/6815))
+- Refresh cached tokens based on registry info & random balances ([#6824](https://github.com/paritytech/parity/pull/6824))
+  - Refresh cached tokens based on registry info & random balances ([#6818](https://github.com/paritytech/parity/pull/6818))
   - Don't display errored token images
 
 ## Parity [v1.8.0](https://github.com/paritytech/parity/releases/tag/v1.8.0) (2017-10-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ If you don't want to downgrade or move your funds off your Trezor-device, you ca
 
 Full list of included changes:
 
+- Add ECIP1017 to Morden config ([#6845](https://github.com/paritytech/parity/pull/6845))
 - Ethstore optimizations ([#6844](https://github.com/paritytech/parity/pull/6844))
 - Bumb to v1.8.1 ([#6843](https://github.com/paritytech/parity/pull/6843))
 - Backport ([#6837](https://github.com/paritytech/parity/pull/6837))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Parity [v1.8.1](https://github.com/paritytech/parity/releases/tag/v1.8.1) (2017-10-20)
 
-Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, and changes the Trezor account devivation path.
+Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, improves performance of nodes with huge amounts of accounts, and changes the Trezor account devivation path.
 
 **Important Note**: The **Trezor** account derivation path was changed in this release ([#6815](https://github.com/paritytech/parity/pull/6815)) to always use the first account (`m/44'/60'/0'/0/0` instead of `m/44'/60'/0'/0`). This way we enable compatibility with other Ethereum wallets supporting Trezor hardware-wallets. However, **action is required** before upgrading, if you have funds on your Parity Trezor wallet. If you already upgraded to 1.8.1, please downgrade to 1.8.0 first to recover the funds with the following steps:
 
@@ -15,6 +15,7 @@ If you don't want to downgrade or move your funds off your Trezor-device, you ca
 
 Full list of included changes:
 
+- Ethstore optimizations ([#6844](https://github.com/paritytech/parity/pull/6844))
 - Bumb to v1.8.1 ([#6843](https://github.com/paritytech/parity/pull/6843))
 - Backport ([#6837](https://github.com/paritytech/parity/pull/6837))
   - Tweaked snapshot sync threshold ([#6829](https://github.com/paritytech/parity/pull/6829))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## Parity [v1.8.1](https://github.com/paritytech/parity/releases/tag/v1.8.1) (2017-10-20)
+
+Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, and improves performance of nodes with huge amounts of accounts.
+
+**Important Note**: The **Trezor** account derivation path was changed in this release (#6815) to always use the first account (`m/44'/60'/0'/0/0` instead of `m/44'/60'/0'/0`). This way we enable compatibility with other Ethereum wallets supporting Trezor hardware-wallets. However, **action is required** before upgrading, if you have funds on your Parity Trezor wallet. If you already upgraded to 1.8.1, please downgrade to 1.8.0 first to recover the funds with the following steps:
+
+1. Make sure you have 1.8.0-beta and your Trezor plugged in.
+2. Create a new standard Parity account. Make sure you have backups of the recovery phrase and don't forget the password.
+3. Move your funds from the Trezor hardware-wallet account to the freshly generated Parity account.
+4. Upgrade to 1.8.1-beta and plug in your Trezor.
+5. Move your funds from your Parity account to the new Trezor account.
+6. Keep using Parity as normal.
+
+If you don't want to downgrade, you can also use the official Trezor application or other wallets allowing to select the derivation path to access the funds.
+
+Full list of included changes:
+
+- @TODO waiting for backports
+- Refresh cached tokens based on registry info & random balances (#6824)
+  - Refresh cached tokens based on registry info & random balances (#6818)
+  - Don't display errored token images
+
 ## Parity [v1.8.0](https://github.com/paritytech/parity/releases/tag/v1.8.0) (2017-10-15)
 
 We are happy to announce our newest Parity 1.8 release. Among others, it enables the following features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Parity 1.8.1 fixes several bugs with token balances, tweaks snapshot-sync, and i
 5. Move your funds from your Parity account to the new Trezor account.
 6. Keep using Parity as normal.
 
-If you don't want to downgrade, you can also use the official Trezor application or other wallets allowing to select the derivation path to access the funds.
+If you don't want to downgrade or move your funds off your Trezor-device, you can also use the official Trezor application or other wallets allowing to select the derivation path to access the funds.
 
 Full list of included changes:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Snap Status](https://build.snapcraft.io/badge/paritytech/parity.svg)](https://build.snapcraft.io/user/paritytech/parity)
 [![GPLv3](https://img.shields.io/badge/license-GPL%20v3-green.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
-- [Download the latest release here.](https://github.com/paritytech/parity/releases)
+- [Download the latest release here.](https://github.com/paritytech/parity/releases/latest)
 
 ### Join the chat!
 
@@ -29,19 +29,19 @@ Parity comes with a built-in wallet. To access [Parity Wallet](http://web3.site/
 - create and register your own tokens;
 - and much more.
 
-By default, Parity will also run a JSONRPC server on `127.0.0.1:8545`. This is fully configurable and supports a number of RPC APIs.
+By default, Parity will also run a JSONRPC server on `127.0.0.1:8545` and a websockets server on `127.0.0.1:8546`. This is fully configurable and supports a number of APIs.
 
-If you run into an issue while using parity, feel free to file one in this repository or hop on our [gitter chat room](https://gitter.im/paritytech/parity) to ask a question. We are glad to help!
+If you run into an issue while using parity, feel free to file one in this repository or hop on our [Gitter](https://gitter.im/paritytech/parity) or [Riot](https://riot.im/app/#/room/#parity-watercooler:matrix.org) chat room to ask a question. We are glad to help!
 
-**For security-critical issues**, please refer to the security policy outlined in `SECURITY.MD`.
+**For security-critical issues**, please refer to the security policy outlined in [SECURITY.MD](SECURITY.md).
 
-Parity's current release is 1.7. You can download it at https://github.com/paritytech/parity/releases or follow the instructions below to build from source.
+Parity's current release is 1.8. You can download it at https://github.com/paritytech/parity/releases or follow the instructions below to build from source.
 
 ----
 
 ## Build dependencies
 
-**Parity requires Rust version 1.19.0 to build**
+**Parity requires Rust version 1.21.0 to build**
 
 We recommend installing Rust through [rustup](https://www.rustup.rs/). If you don't already have rustup, you can install it like this:
 
@@ -51,19 +51,20 @@ We recommend installing Rust through [rustup](https://www.rustup.rs/). If you do
 	```
 
 	Parity also requires `gcc`, `g++`, `libssl-dev`/`openssl`, `libudev-dev` and `pkg-config` packages to be installed.
+
 - OSX:
 	```bash
 	$ curl https://sh.rustup.rs -sSf | sh
 	```
 
 	`clang` is required. It comes with Xcode command line tools or can be installed with homebrew.
-- Windows
 
-    Make sure you have Visual Studio 2015 with C++ support installed. Next, download and run the rustup installer from
+- Windows
+  Make sure you have Visual Studio 2015 with C++ support installed. Next, download and run the rustup installer from
 	https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe, start "VS2015 x64 Native Tools Command Prompt", and use the following command to install and set up the msvc toolchain:
-    ```
+  ```bash
 	$ rustup default stable-x86_64-pc-windows-msvc
-    ```
+  ```
 
 Once you have rustup, install parity or download and build from source
 
@@ -98,6 +99,9 @@ Note: if cargo fails to parse manifest try:
 ```bash
 $ ~/.cargo/bin/cargo build --release
 ```
+
+This will always compile the latest nightly builds. If you want to build stable or beta, do a `git checkout stable` or `git checkout beta` first.
+
 ----
 
 ## Simple one-line installer for Mac and Ubuntu
@@ -106,9 +110,14 @@ $ ~/.cargo/bin/cargo build --release
 bash <(curl https://get.parity.io -Lk)
 ```
 
+The one-line installer always defaults to the latest beta release.
+
 ## Start Parity
+
 ### Manually
+
 To start Parity manually, just run
+
 ```bash
 $ ./target/release/parity
 ```
@@ -116,11 +125,9 @@ $ ./target/release/parity
 and Parity will begin syncing the Ethereum blockchain.
 
 ### Using systemd service file
+
 To start Parity as a regular user using systemd init:
 
-1. Copy `parity/scripts/parity.service` to your
+1. Copy `./scripts/parity.service` to your
 systemd user directory (usually `~/.config/systemd/user`).
-2. To pass any argument to Parity, write a `~/.parity/parity.conf` file this way:
-`ARGS="ARG1 ARG2 ARG3"`.
-
-	Example: `ARGS="ui --identity MyMachine"`.
+2. To configure Parity, write a `/etc/parity/config.toml` config file, see [Configuring Parity](https://github.com/paritytech/parity/wiki/Configuring-Parity) for details.


### PR DESCRIPTION
- Update README.md for 1.8
- Update CHANGELOG.md for 1.8.1

Waiting for backports of #6829, #6827, and #6815; and a v1.8.1 tag :)