### PR TITLE
fix #6228: do not display eth price in cli for etc

### DIFF
--- a/ethcore/res/ethereum/classic.json
+++ b/ethcore/res/ethereum/classic.json
@@ -31,7 +31,8 @@
 		"forkCanonHash": "0x94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f",
 		"eip155Transition": 3000000,
 		"eip98Transition": "0x7fffffffffffff",
-		"eip86Transition": "0x7fffffffffffff"
+		"eip86Transition": "0x7fffffffffffff",
+		"weiPerGas": 40000000
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/expanse.json
+++ b/ethcore/res/ethereum/expanse.json
@@ -31,7 +31,8 @@
 		"subprotocolName": "exp",
 		"eip98Transition": "0x7fffffffffffff",
 		"eip86Transition": "0x7fffffffffffff",
-		"eip155Transition": "0x927C0"
+		"eip155Transition": "0x927C0",
+		"weiPerGas": 40000000
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -37,7 +37,8 @@
 		"forkCanonHash": "0x0a66d93c2f727dca618fabaf70c39b37018c73d78b939d8b11efbbd09034778f",
 		"validateReceiptsTransition" : 1000000,
 		"eip155Transition": 1000000,
-		"validateChainIdTransition": 1000000
+		"validateChainIdTransition": 1000000,
+		"weiPerGas": 40000000
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/res/ethereum/musicoin.json
+++ b/ethcore/res/ethereum/musicoin.json
@@ -40,7 +40,8 @@
     "eip211Transition":"0x7fffffffffffff",
     "eip214Transition":"0x7fffffffffffff",
     "eip658Transition":"0x7fffffffffffff",
-    "maxCodeSize":"0x6000"
+    "maxCodeSize":"0x6000",
+    "weiPerGas": 40000000
   },
   "genesis":{
     "seal":{

--- a/ethcore/res/ethereum/ropsten.json
+++ b/ethcore/res/ethereum/ropsten.json
@@ -35,7 +35,8 @@
 		"eip140Transition": 1700000,
 		"eip211Transition": 1700000,
 		"eip214Transition": 1700000,
-		"eip658Transition": 1700000
+		"eip658Transition": 1700000,
+		"weiPerGas": 40000000
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -294,6 +294,12 @@ impl Miner {
 			false => ServiceTransactionAction::Check(ServiceTransactionChecker::default()),
 		};
 
+		let amended_gas_pricer = match spec.params().wei_per_gas > 0 {
+			// When dynamic pricing is unavailable on current chain, switch to fixed pricing.
+			true => GasPricer::new_fixed(spec.params().wei_per_gas.into()),
+			false => gas_pricer,
+		};
+
 		Miner {
 			transaction_queue: Arc::new(RwLock::new(txq)),
 			next_allowed_reseal: Mutex::new(Instant::now()),
@@ -312,7 +318,7 @@ impl Miner {
 			accounts: accounts,
 			engine: spec.engine.clone(),
 			notifiers: RwLock::new(notifiers),
-			gas_pricer: Mutex::new(gas_pricer),
+			gas_pricer: Mutex::new(amended_gas_pricer),
 			service_transaction_action: service_transaction_action,
 		}
 	}

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -122,6 +122,8 @@ pub struct CommonParams {
 	pub max_code_size: u64,
 	/// Transaction permission managing contract address.
 	pub transaction_permission_contract: Option<Address>,
+	/// Wei per gas, when dynamic USD conversion is not used
+	pub wei_per_gas: u64,
 }
 
 impl CommonParams {
@@ -227,6 +229,7 @@ impl From<ethjson::spec::Params> for CommonParams {
 			node_permission_contract: p.node_permission_contract.map(Into::into),
 			max_code_size: p.max_code_size.map_or(u64::max_value(), Into::into),
 			transaction_permission_contract: p.transaction_permission_contract.map(Into::into),
+			wei_per_gas: p.wei_per_gas.map_or(0, Into::into),
 		}
 	}
 }

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -117,6 +117,9 @@ pub struct Params {
 	/// Transaction permission contract address.
 	#[serde(rename="transactionPermissionContract")]
 	pub transaction_permission_contract: Option<Address>,
+	/// Wei per gas
+	#[serde(rename="weiPerGas")]
+	pub wei_per_gas: Option<Uint>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Current behaviour:

When the client is started with defaults, the miner's gas calibrator
periodically queries the price of ether in usd and uses it to adjust
the wei_per_gas variable, displaying an info message in the cli each
time calibration happens.

This behaviour is also present when running on a non-foundation chain
such as ethereum classic.

When the client is started with --min-gas-price N, this does not happen
as GasPricer::Fixed is instanciated instead of GasPricer::Calibrated.

Solution:

For non-foundation chain, hard-code a default gas price (wei_per_gas,
currently 40M wei) in the spec json file.

When the wei_per_gas parameter is found and greater than zero, force the
miner to start with GasPricer::Fixed, so the calibrator does not run at
all.