### PR TITLE
Fix Windows NSIS installer not working

### DIFF
--- a/nsis/installer.nsi
+++ b/nsis/installer.nsi
@@ -11,8 +11,8 @@
 !define VERSIONMAJOR 1
 !define VERSIONMINOR 9
 !define VERSIONBUILD 0
-!define ARGS "--warp"
-!define FIRST_START_ARGS "ui --warp --mode=passive"
+!define ARGS ""
+!define FIRST_START_ARGS "--mode=passive ui"
 
 !addplugindir .\
 


### PR DESCRIPTION
The Windows NSIS installer currently wouldn't work.

Since https://github.com/paritytech/parity/pull/6356, the `--warp` argument was removed, and the ordering of the arguments changed (global arguments come before subcommands). So Parity as set up by the installer would throw an error on startup.

Not sure how to test this; I don't think that the Windows installer is tested in the CI?