### PR TITLE
Fix order of arguments in run_parity()

### DIFF
--- a/parity/main.rs
+++ b/parity/main.rs
@@ -259,7 +259,7 @@ fn run_parity() -> Option<i32> {
 	use ::std::ffi::OsString;
 	let prefix = vec![OsString::from("--can-restart"), OsString::from("--force-direct")];
 	let res = latest_exe_path().and_then(|exe| process::Command::new(exe)
-		.args(&(env::args_os().skip(1).chain(prefix.into_iter()).collect::<Vec<_>>()))
+		.args(&(prefix.into_iter().chain(env::args_os().skip(1)).collect::<Vec<_>>()))
 		.status()
 		.map(|es| es.code().unwrap_or(128))
 		.ok()


### PR DESCRIPTION
`--can-restart` and `--force-direct` need to come as first arguments (before any subcommand). Fixes https://github.com/paritytech/parity/issues/6906.