### PR TITLE
Removes `MAX_TX_TO_IMPORT` from `ChainSync`

### DIFF
--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -129,7 +129,6 @@ const MIN_PEERS_PROPAGATION: usize = 4;
 const MAX_PEERS_PROPAGATION: usize = 128;
 const MAX_PEER_LAG_PROPAGATION: BlockNumber = 20;
 const MAX_NEW_HASHES: usize = 64;
-const MAX_TX_TO_IMPORT: usize = 512;
 const MAX_NEW_BLOCK_AGE: BlockNumber = 20;
 const MAX_TRANSACTION_SIZE: usize = 300*1024;
 // maximal packet size with transactions (cannot be greater than 16MB - protocol limitation).
@@ -1477,9 +1476,8 @@ impl ChainSync {
 			trace!(target: "sync", "{} Ignoring transactions from unconfirmed/unknown peer", peer_id);
 		}
 
-		let mut item_count = r.item_count()?;
+		let item_count = r.item_count()?;
 		trace!(target: "sync", "{:02} -> Transactions ({} entries)", peer_id, item_count);
-		item_count = cmp::min(item_count, MAX_TX_TO_IMPORT);
 		let mut transactions = Vec::with_capacity(item_count);
 		for i in 0 .. item_count {
 			let rlp = r.at(i)?;


### PR DESCRIPTION
This PR removes `MAX_TX_TO_IMPORT` constant and its uses in `sync/src/chain.rs`.

As @tomusdrw explained:
> …back in the past we were parsing the transactions and actually importing them to the queue which took significant amount of time. Currently we have a queue of `unverifiedTransactions` that are later parsed and imported to the queue in batches (the method is now called `queue_transactions`). So the limiting doesn't currently make sense at all.