### PR TITLE
[beta] Disallow builtin multisig deploy (only watch)

### DIFF
--- a/js/src/modals/CreateWallet/WalletType/walletType.js
+++ b/js/src/modals/CreateWallet/WalletType/walletType.js
@@ -17,35 +17,35 @@
 import React, { Component, PropTypes } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { walletSourceURL } from '~/contracts/code/wallet';
+// import { walletSourceURL } from '~/contracts/code/wallet';
 import { RadioButtons } from '~/ui';
 
 const TYPES = [
-  {
-    label: (
-      <FormattedMessage
-        id='createWallet.type.multisig.label'
-        defaultMessage='Multi-Sig wallet'
-      />
-    ),
-    key: 'MULTISIG',
-    description: (
-      <FormattedMessage
-        id='createWallet.type.multisig.description'
-        defaultMessage='Create/Deploy a {link} Wallet'
-        values={ {
-          link: (
-            <a href={ walletSourceURL } target='_blank'>
-              <FormattedMessage
-                id='createWallet.type.multisig.link'
-                defaultMessage='standard multi-signature'
-              />
-            </a>
-          )
-        } }
-      />
-    )
-  },
+  // {
+  //   label: (
+  //     <FormattedMessage
+  //       id='createWallet.type.multisig.label'
+  //       defaultMessage='Multi-Sig wallet'
+  //     />
+  //   ),
+  //   key: 'MULTISIG',
+  //   description: (
+  //     <FormattedMessage
+  //       id='createWallet.type.multisig.description'
+  //       defaultMessage='Create/Deploy a {link} Wallet'
+  //       values={ {
+  //         link: (
+  //           <a href={ walletSourceURL } target='_blank'>
+  //             <FormattedMessage
+  //               id='createWallet.type.multisig.link'
+  //               defaultMessage='standard multi-signature'
+  //             />
+  //           </a>
+  //         )
+  //       } }
+  //     />
+  //   )
+  // },
   {
     label: (
       <FormattedMessage

--- a/js/src/modals/CreateWallet/createWalletStore.js
+++ b/js/src/modals/CreateWallet/createWalletStore.js
@@ -59,7 +59,7 @@ const STEPS = {
 export default class CreateWalletStore {
   @observable step = null;
   @observable txhash = null;
-  @observable walletType = 'MULTISIG';
+  @observable walletType = 'WATCH'; // 'MULTISIG';
 
   @observable wallet = {
     account: '',


### PR DESCRIPTION
Removes the ability to deploy multisig from the "+ Wallet" button on accounts. The only available option is to watch existing wallets.

Updates for master done as part of https://github.com/paritytech/parity/pull/6935

