### PR TITLE
Wasm tests update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3417,7 +3417,7 @@ dependencies = [
  "ethcore-logger 1.9.0",
  "ethcore-util 1.9.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
  "wasm-utils 0.1.0 (git+https://github.com/paritytech/wasm-utils)",
 ]
@@ -3433,7 +3433,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3647,7 +3647,7 @@ dependencies = [
 "checksum parity-tokio-ipc 0.1.5 (git+https://github.com/nikvolf/parity-tokio-ipc)" = "<none>"
 "checksum parity-ui-old-precompiled 1.8.0 (git+https://github.com/paritytech/js-precompiled.git?branch=v1)" = "<none>"
 "checksum parity-ui-precompiled 1.9.0 (git+https://github.com/paritytech/js-precompiled.git)" = "<none>"
-"checksum parity-wasm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "95f6243c2d6fadf903b5edfd0011817efc20522ce5f360abf4648c24ea87581a"
+"checksum parity-wasm 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8431a184ad88cfbcd71a792aaca319cc7203a94300c26b8dce2d0df0681ea87d"
 "checksum parity-wordlist 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81451bfab101d186f8fc4a0aa13cb5539b31b02c4ed96425a0842e2a413daba6"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"

--- a/ethcore/vm/src/schedule.rs
+++ b/ethcore/vm/src/schedule.rs
@@ -127,12 +127,14 @@ pub struct WasmCosts {
 	pub mul: u32,
 	/// Memory (load/store) operations multiplier.
 	pub mem: u32,
-	/// Memory copy operation.
+	/// Memory copy operation, per byte.
 	pub mem_copy: u32,
+	/// Memory move operation, per byte.
+	pub mem_move: u32,
+	/// Memory set operation, per byte.
+	pub mem_set: u32,
 	/// Static region charge, per byte.
 	pub static_region: u32,
-	/// General static query of u64 value from env-info
-	pub static_u64: u32,
 	/// General static query of U256 value from env-info
 	pub static_u256: u32,
 	/// General static query of Address value from env-info
@@ -147,11 +149,9 @@ impl Default for WasmCosts {
 			mul: 4,
 			mem: 2,
 			mem_copy: 1,
+			mem_move: 1,
+			mem_set: 1,
 			static_region: 1,
-
-			// due to runtime issues, this can be slow
-			static_u64: 32,
-
 			static_u256: 64,
 			static_address: 40,
 		}

--- a/ethcore/wasm/src/env.rs
+++ b/ethcore/wasm/src/env.rs
@@ -38,12 +38,12 @@ pub const SIGNATURES: &'static [UserFunctionDescriptor] = &[
 		None,
 	),
 	Static(
-		"_malloc",
+		"_ext_malloc",
 		&[I32],
 		Some(I32),
 	),
 	Static(
-		"_free",
+		"_ext_free",
 		&[I32],
 		None,
 	),
@@ -93,13 +93,28 @@ pub const SIGNATURES: &'static [UserFunctionDescriptor] = &[
 		Some(I32),
 	),
 	Static(
+		"_ext_memcpy",
+		&[I32; 3],
+		Some(I32),
+	),
+	Static(
+		"_ext_memset",
+		&[I32; 3],
+		Some(I32),
+	),
+	Static(
+		"_ext_memmove",
+		&[I32; 3],
+		Some(I32),
+	),
+	Static(
 		"_panic",
 		&[I32; 2],
 		None,
 	),
 	Static(
 		"_blockhash",
-		&[I32; 3],
+		&[I64, I32],
 		Some(I32),
 	),
 	Static(
@@ -130,12 +145,12 @@ pub const SIGNATURES: &'static [UserFunctionDescriptor] = &[
 	Static(
 		"_timestamp",
 		&[],
-		Some(I32),
+		Some(I64),
 	),
 	Static(
 		"_blocknumber",
 		&[],
-		Some(I32),
+		Some(I64),
 	),
 	Static(
 		"_difficulty",
@@ -162,8 +177,8 @@ pub const SIGNATURES: &'static [UserFunctionDescriptor] = &[
 
 	Static(
 		"_llvm_bswap_i64",
-		&[I32; 2],
-		Some(I32)
+		&[I64],
+		Some(I64)
 	),
 ];
 


### PR DESCRIPTION
- We no longer use legalization of JS FFI. Thus we can use i64 types in interfaces directly and we no longer need to use `setTempRet0`. Also, LTO have been enabled for the tests, so gas consumption improved a bit.
- All libc related functions are now with prefix `ext_`, e.g. `_malloc` became `_ext_malloc`. This is needed to workaround some emscripten specific behavior and might change in the future.
- New functions `_ext_memmove` and `_ext_memset` added. 
- `mem_copy` fixes. The arguments poped in a wrong order. Also make it really return a value, as LLVM really could use it sometimes. 
- Small improvement of a test ergonomics: gas checks are pushed to the end of the test functions.
