### PR TITLE
ECIP-1039: Monetary policy rounding specification

### DIFF
--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -520,6 +520,12 @@ mod tests {
 		let (eras, reward) = ecip1017_eras_block_reward(eras_rounds, start_reward, block_number);
 		assert_eq!(15, eras);
 		assert_eq!(U256::from_str("271000000000000").unwrap(), reward);
+		
+		let block_number = 250000000;
+		let (eras, reward) = ecip1017_eras_block_reward(eras_rounds, start_reward, block_number);
+		assert_eq!(48, eras);
+		assert!(U256::from_str("65697BFA9ACB").unwrap() != reward);
+		assert_eq!(U256::from_str("65697BFA9ACD").unwrap(), reward);
 	}
 
 	#[test]

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -449,12 +449,12 @@ fn ecip1017_eras_block_reward(era_rounds: u64, mut reward: U256, block_number:u6
 	} else {
 		block_number / era_rounds
 	};
+	let mut divi = U256::from(1);
 	for _ in 0..eras {
 		reward = reward * U256::from(4);
+		divi = divi * U256::from(5);
 	}
-	for _ in 0..eras {
-		reward = reward / U256::from(5);	
-	}
+	reward = reward / divi;
 	(eras, reward)
 }
 

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -523,9 +523,8 @@ mod tests {
 		
 		let block_number = 250000000;
 		let (eras, reward) = ecip1017_eras_block_reward(eras_rounds, start_reward, block_number);
-		assert_eq!(48, eras);
-		assert!(U256::from_str("65697BFA9ACB").unwrap() != reward);
-		assert_eq!(U256::from_str("65697BFA9ACD").unwrap(), reward);
+		assert_eq!(49, eras);
+		assert_eq!(U256::from_str("51212FFBAF0A").unwrap(), reward);
 	}
 
 	#[test]

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -450,7 +450,10 @@ fn ecip1017_eras_block_reward(era_rounds: u64, mut reward: U256, block_number:u6
 		block_number / era_rounds
 	};
 	for _ in 0..eras {
-		reward = reward / U256::from(5) * U256::from(4);
+		reward = reward * U256::from(4);
+	}
+	for _ in 0..eras {
+		reward = reward / U256::from(5);	
 	}
 	(eras, reward)
 }


### PR DESCRIPTION
(https://github.com/ethereumproject/ECIPs/pull/83 is accepted. Okay to merge.)

Fix potential rounding errors between geth and parity in the long-term future.