### PR TITLE
fixes typo in user config path

### DIFF
--- a/scripts/parity.service
+++ b/scripts/parity.service
@@ -6,7 +6,7 @@ After=network.target
 # run as root, set base_path in config.toml
 ExecStart=/usr/bin/parity --config /etc/parity/config.toml
 # To run as user, comment out above and uncomment below, fill in user and group
-# picks up users default config.toml in $HOME/.local/.share/io.parity.ethereum/
+# picks up users default config.toml in $HOME/.local/share/io.parity.ethereum/
 # User=username
 # Group=groupname
 # ExecStart=/usr/bin/parity


### PR DESCRIPTION
References the correct [parity_base](https://github.com/paritytech/parity/blob/bb1bbebfd63b5870478ff4bcd60d4a1ac1e00d36/ethstore/src/dir/paths.rs#L65) in the systemd service.