### PR TITLE
Update type imports for mocha tests

### DIFF
--- a/js-old/package-lock.json
+++ b/js-old/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@parity/abi": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.1.tgz",
-      "integrity": "sha512-AWd1Lnsau8DvEihzoGg3xCSOIHFqf1tsn14wHVCRv7O5BcCI+6Ww/g4iLjdYKGLjtMKtxdQiUblCcIhaZrqmpQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.2.tgz",
+      "integrity": "sha512-DVH7aEZrSc0seimtehO6pCkkJ/oqXZanAXJXKqgk6x1vSc276pAk7xOcMNe3RKio7VfnIi9c05tqqTX8hUG5hw==",
       "requires": {
         "bignumber.js": "3.0.1",
         "js-sha3": "0.5.5",
@@ -15,12 +15,12 @@
       }
     },
     "@parity/api": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@parity/api/-/api-2.1.3.tgz",
-      "integrity": "sha512-M+/9mGQ6Th6LRIXetUHQQqsqSE//XAd/p5I/jrhKqV9dW73dwTIKW/xlPWPi/JwbRiTehbliJKmrt8vsOtvkww==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@parity/api/-/api-2.1.5.tgz",
+      "integrity": "sha512-HkvMIhIwDMEIyTmXqEjWn1C2qes0qJO270bQldRfCZf0XiOGXG726EzV3FUpUbVONCVQ9riDviAl3fw6D+N6nA==",
       "requires": {
-        "@parity/abi": "2.1.1",
-        "@parity/jsonrpc": "2.1.2",
+        "@parity/abi": "2.1.2",
+        "@parity/jsonrpc": "2.1.4",
         "@parity/wordlist": "1.1.0",
         "bignumber.js": "3.0.1",
         "blockies": "0.0.2",
@@ -51,9 +51,9 @@
       }
     },
     "@parity/jsonrpc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@parity/jsonrpc/-/jsonrpc-2.1.2.tgz",
-      "integrity": "sha512-JN5MTZO9d27ZMLuibnYWri2Is0p5ZM7dAXafJNWBKGe1sMBDqQA44Sz6La4Baem2PTgjWAlWYjeD78SXx+9mYA=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@parity/jsonrpc/-/jsonrpc-2.1.4.tgz",
+      "integrity": "sha512-gGX1LMGxF6Ma4fAbpY3awK0IpB+ARjCH87m/fq8vvUr+5/Z/ywXjjmauPqA435vyjnW4STd2l9FVREVz4wv08A=="
     },
     "@parity/wordlist": {
       "version": "1.1.0",
@@ -150,9 +150,9 @@
       }
     },
     "ajv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -247,11 +247,6 @@
         "default-require-extensions": "1.0.0"
       }
     },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
     "archive-type": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
@@ -339,7 +334,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0"
+        "es-abstract": "1.10.0"
       }
     },
     "arrify": {
@@ -427,7 +422,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000760",
+        "caniuse-db": "1.0.30000778",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -458,8 +453,8 @@
         "babel-runtime": "6.23.0",
         "chokidar": "1.7.0",
         "commander": "2.8.1",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.2",
         "output-file-sync": "1.1.2",
@@ -511,7 +506,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.2",
@@ -2170,6 +2165,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "dev": true,
       "requires": {
         "core-js": "2.4.1",
         "regenerator-runtime": "0.10.5"
@@ -2178,7 +2174,8 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
         }
       }
     },
@@ -2308,7 +2305,7 @@
             "babel-traverse": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
+            "convert-source-map": "1.5.1",
             "debug": "2.6.9",
             "json5": "0.5.1",
             "lodash": "4.17.4",
@@ -2406,9 +2403,9 @@
       "integrity": "sha1-gHZS0Q453jfp40lyR+3HmLt0b3Y="
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "bindings": {
@@ -2575,12 +2572,12 @@
       }
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
@@ -2589,7 +2586,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000760",
+        "caniuse-db": "1.0.30000778",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -2694,15 +2691,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000760",
+        "caniuse-db": "1.0.30000778",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000760",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000760.tgz",
-      "integrity": "sha1-PqKUc+t4psywny63Osnh3r/sUo0=",
+      "version": "1.0.30000778",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
+      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2731,11 +2728,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
@@ -2870,7 +2862,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2904,11 +2896,6 @@
           }
         }
       }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -3019,9 +3006,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codemirror": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.31.0.tgz",
-      "integrity": "sha512-LKbMZKoAz7pMmWuSEl253G6yyloSulj1kXfvYv+3n3I8wMiI7QwnCHwKM3Zw5S9ItNV28Layq0/ihQXWmn9T9w=="
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.32.0.tgz",
+      "integrity": "sha512-95OxAlYiigW0g4n4ixFdavG07clJGILp3MvHh2pKR3FvyrTuHHvqtKSVbrV3/Jz6o0YqGvyCDLDTbH4h6ciaSw=="
     },
     "collapse-white-space": {
       "version": "1.0.3",
@@ -3158,11 +3145,10 @@
       }
     },
     "commonmark-react-renderer": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/commonmark-react-renderer/-/commonmark-react-renderer-4.3.3.tgz",
-      "integrity": "sha1-nEvKE4vIMoe655LM8TNzi+nLxvo=",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/commonmark-react-renderer/-/commonmark-react-renderer-4.3.4.tgz",
+      "integrity": "sha512-+/Rzo3sI37NR8LaVdkUiqBH3+CEW75hc86shwY4E9eEERg78VCy4rSkaP/p7OG5bTvosUMkvhn5d1ZJ5iyt/ag==",
       "requires": {
-        "in-publish": "2.0.0",
         "lodash.assign": "4.2.0",
         "lodash.isplainobject": "4.0.6",
         "pascalcase": "0.1.1",
@@ -3201,11 +3187,6 @@
         }
       }
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -3231,9 +3212,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
     },
     "cookie": {
       "version": "0.3.1",
@@ -3301,7 +3282,8 @@
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3692,7 +3674,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "d3-array": {
@@ -3711,14 +3693,14 @@
       "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
     },
     "d3-format": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.0.tgz",
-      "integrity": "sha1-a0gLqohohdRlHcJIqPSsnaFtsHo="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.1.tgz",
+      "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w=="
     },
     "d3-interpolate": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.5.tgz",
-      "integrity": "sha1-aeCZ/zkhRxblY8muw+qdHqS4p58=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+      "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
       "requires": {
         "d3-color": "1.0.3"
       }
@@ -3736,10 +3718,10 @@
         "d3-array": "1.2.1",
         "d3-collection": "1.0.4",
         "d3-color": "1.0.3",
-        "d3-format": "1.2.0",
-        "d3-interpolate": "1.1.5",
-        "d3-time": "1.0.7",
-        "d3-time-format": "2.1.0"
+        "d3-format": "1.2.1",
+        "d3-interpolate": "1.1.6",
+        "d3-time": "1.0.8",
+        "d3-time-format": "2.1.1"
       }
     },
     "d3-shape": {
@@ -3751,16 +3733,16 @@
       }
     },
     "d3-time": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.7.tgz",
-      "integrity": "sha1-lMr27bt4ebuAnQ0fdXK8SEgvcnA="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+      "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
     },
     "d3-time-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.0.tgz",
-      "integrity": "sha512-mqTsfDTylgwE3YE/VNs9oB2OGX274fO0B5j1irbgLQI+X3FPoJg25pesNxrcdZ2nBeRx/6sHDJlDyMIjWL0BGQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+      "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
       "requires": {
-        "d3-time": "1.0.7"
+        "d3-time": "1.0.8"
       }
     },
     "dashdash": {
@@ -3844,7 +3826,7 @@
         "is-tar": "1.0.0",
         "object-assign": "2.1.1",
         "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.4",
+        "tar-stream": "1.5.5",
         "through2": "0.6.5",
         "vinyl": "0.4.6"
       },
@@ -3879,7 +3861,7 @@
         "object-assign": "2.1.1",
         "seek-bzip": "1.0.5",
         "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.4",
+        "tar-stream": "1.5.5",
         "through2": "0.6.5",
         "vinyl": "0.4.6"
       },
@@ -3913,7 +3895,7 @@
         "is-gzip": "1.0.0",
         "object-assign": "2.1.1",
         "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.4",
+        "tar-stream": "1.5.5",
         "through2": "0.6.5",
         "vinyl": "0.4.6"
       },
@@ -4113,7 +4095,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000760",
+        "caniuse-db": "1.0.30000778",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -4355,12 +4337,6 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "ejs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz",
-      "integrity": "sha1-ycYKSKRu5FL7MqccMXuV5aofyz0=",
-      "dev": true
-    },
     "ejs-loader": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ejs-loader/-/ejs-loader-0.3.0.tgz",
@@ -4389,16 +4365,6 @@
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
-      }
-    },
-    "ejsify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ejsify/-/ejsify-1.0.0.tgz",
-      "integrity": "sha1-NxlPWoXBKuQ4QpOVeZ7Ee0O8RT8=",
-      "dev": true,
-      "requires": {
-        "ejs": "1.0.0",
-        "through": "2.3.8"
       }
     },
     "electron-to-chromium": {
@@ -4531,9 +4497,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -4555,9 +4521,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.35",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -4576,7 +4542,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4587,7 +4553,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4606,7 +4572,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4619,7 +4585,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "es6-templates": {
@@ -4639,7 +4605,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4700,7 +4666,7 @@
         "debug": "2.6.9",
         "doctrine": "1.5.0",
         "escope": "3.6.0",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
@@ -4814,9 +4780,9 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -4880,9 +4846,9 @@
         "bn.js": "4.11.8",
         "create-hash": "1.1.3",
         "ethjs-util": "0.1.4",
-        "keccak": "1.3.0",
+        "keccak": "1.4.0",
         "rlp": "2.0.0",
-        "secp256k1": "3.3.1"
+        "secp256k1": "3.4.0"
       },
       "dependencies": {
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -4959,7 +4925,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "es5-ext": "0.10.37"
       }
     },
     "eventemitter3": {
@@ -5012,11 +4978,6 @@
       "requires": {
         "fill-range": "2.2.3"
       }
-    },
-    "expand-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
     },
     "express": {
       "version": "4.14.1",
@@ -5502,9 +5463,9 @@
       }
     },
     "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -5513,14 +5474,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -5678,7 +5639,6 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -5722,6 +5682,12 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5867,7 +5833,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -6039,11 +6004,13 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -6251,7 +6218,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -6456,18 +6422,15 @@
       "dev": true
     },
     "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
+        "ansi": "0.3.1",
         "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "lodash.pad": "4.5.1",
+        "lodash.padend": "4.6.1",
+        "lodash.padstart": "4.6.1"
       }
     },
     "generate-function": {
@@ -6532,11 +6495,6 @@
           "dev": true
         }
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
       "version": "5.0.15",
@@ -6731,7 +6689,7 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "requires": {
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "graceful-fs": "4.1.11",
         "strip-bom": "2.0.0",
         "through2": "2.0.3",
@@ -6870,15 +6828,15 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "commander": "2.11.0",
+        "commander": "2.12.2",
         "is-my-json-valid": "2.16.1",
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
           "dev": true
         }
       }
@@ -7038,7 +6996,7 @@
       "requires": {
         "es6-templates": "0.2.3",
         "fastparse": "1.1.1",
-        "html-minifier": "3.5.6",
+        "html-minifier": "3.5.7",
         "loader-utils": "0.2.17",
         "object-assign": "4.1.1"
       },
@@ -7058,25 +7016,25 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.6.tgz",
-      "integrity": "sha512-88FjtKrlak2XjczhxrBomgzV4jmGzM3UnHRBScRkJcmcRum0kb+IwhVAETJ8AVp7j0p3xugjSaw9L+RmI5/QOA==",
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.7.tgz",
+      "integrity": "sha512-GISXn6oKDo7+gVpKOgZJTbHMCUI2TSGfpg/8jgencWhWJsvEmsvp3M8emX7QocsXsYznWloLib3OeSfeyb/ewg==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.9",
-        "commander": "2.11.0",
+        "commander": "2.12.2",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.1.8"
+        "uglify-js": "3.2.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
           "dev": true
         },
         "source-map": {
@@ -7086,12 +7044,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.1.8",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.8.tgz",
-          "integrity": "sha512-1lnTkrJWw6LJ7n43ZyYVXx0eN2PQh0c3Inb0nY/vj5fNfwykXQFif2kvNgm/Bf0ClLA8R6SKaMHFzo9io4Q+vg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.1.tgz",
+          "integrity": "sha512-BhZTJPmOKPSUcjnx2nlfaOQKHLyjjT4HFyzFWF1BUErx9knJNpdW94ql5o8qVxeNL+8IAWjEjnPvASH2yZnkMg==",
           "dev": true,
           "requires": {
-            "commander": "2.11.0",
+            "commander": "2.12.2",
             "source-map": "0.6.1"
           }
         }
@@ -7110,7 +7068,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "html-minifier": "3.5.6",
+        "html-minifier": "3.5.7",
         "loader-utils": "0.2.17",
         "lodash": "4.17.4",
         "pretty-error": "2.1.1",
@@ -7210,9 +7168,9 @@
       }
     },
     "https-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "humanize": {
@@ -7247,12 +7205,6 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
-    },
-    "ignore-styles": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
-      "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=",
       "dev": true
     },
     "immediate": {
@@ -7305,9 +7257,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inline-style-prefixer": {
       "version": "2.0.5",
@@ -7340,9 +7292,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "intl-format-cache": {
@@ -7421,7 +7373,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -7564,13 +7516,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -7915,9 +7867,9 @@
       }
     },
     "js-base64": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
       "dev": true
     },
     "js-sha3": {
@@ -8097,14 +8049,13 @@
       "dev": true
     },
     "keccak": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.3.0.tgz",
-      "integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "requires": {
         "bindings": "1.3.0",
         "inherits": "2.0.3",
-        "nan": "2.7.0",
-        "prebuild-install": "2.3.0",
+        "nan": "2.8.0",
         "safe-buffer": "5.1.1"
       }
     },
@@ -8133,9 +8084,9 @@
             "bn.js": "4.11.8",
             "create-hash": "1.1.3",
             "ethjs-util": "0.1.4",
-            "keccak": "1.3.0",
+            "keccak": "1.4.0",
             "rlp": "2.0.0",
-            "secp256k1": "3.3.1"
+            "secp256k1": "3.4.0"
           }
         },
         "validator": {
@@ -9112,9 +9063,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "napa": {
       "version": "2.3.0",
@@ -9137,28 +9088,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-        },
-        "gauge": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-          "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
-          }
-        },
-        "npmlog": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
-          "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.1.4",
-            "gauge": "1.2.7"
-          }
         }
       }
     },
@@ -9214,14 +9143,6 @@
         "qs": "6.3.0"
       }
     },
-    "node-abi": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
-      "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
-      "requires": {
-        "semver": "5.4.1"
-      }
-    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -9241,21 +9162,21 @@
       }
     },
     "node-libs-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
-      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
         "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
+        "browserify-zlib": "0.2.0",
         "buffer": "4.9.1",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
         "domain-browser": "1.1.7",
         "events": "1.1.1",
-        "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
         "process": "0.11.10",
         "punycode": "1.4.1",
@@ -9263,7 +9184,7 @@
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
         "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
+        "string_decoder": "1.0.3",
         "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
@@ -9276,12 +9197,6 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
           "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         }
       }
     },
@@ -9289,11 +9204,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
-    },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "nopt": {
       "version": "3.0.6",
@@ -9353,14 +9263,13 @@
       "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
     },
     "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+      "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "requires": {
+        "ansi": "0.3.1",
         "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "gauge": "1.2.7"
       }
     },
     "nth-check": {
@@ -9430,7 +9339,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1",
         "has": "1.0.1"
       }
@@ -9451,7 +9360,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.9.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1",
         "has": "1.0.1"
       }
@@ -9474,9 +9383,9 @@
       }
     },
     "onecolor": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.4.tgz",
-      "integrity": "sha1-daRvgNpseqpbTarhekcZi9llJJQ=",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.5.tgz",
+      "integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY=",
       "dev": true
     },
     "onetime": {
@@ -9534,9 +9443,9 @@
       }
     },
     "os-browserify": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "os-homedir": {
@@ -9584,9 +9493,9 @@
       }
     },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
     "param-case": {
@@ -9775,7 +9684,7 @@
       "integrity": "sha1-GVV2CVno0aEcsqUOyD7sRwYz5J8=",
       "dev": true,
       "requires": {
-        "onecolor": "3.0.4",
+        "onecolor": "3.0.5",
         "synesthesia": "1.0.1"
       }
     },
@@ -9821,7 +9730,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.3.2",
+        "js-base64": "2.4.0",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -10632,27 +10541,6 @@
         "uniqs": "2.0.0"
       }
     },
-    "prebuild-install": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
-      "integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
-      "requires": {
-        "expand-template": "1.1.0",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.1.2",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "1.0.2",
-        "rc": "1.2.2",
-        "simple-get": "1.4.3",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
-        "xtend": "4.0.1"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -10789,15 +10677,6 @@
         "randombytes": "2.0.5"
       }
     },
-    "pump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
-      }
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -10923,7 +10802,7 @@
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       }
@@ -11019,7 +10898,7 @@
       "integrity": "sha1-zWvW70WOweA1z9iz/nswyMeIPGw=",
       "requires": {
         "classnames": "2.2.5",
-        "codemirror": "5.31.0",
+        "codemirror": "5.32.0",
         "lodash.debounce": "4.0.8"
       }
     },
@@ -11138,8 +11017,24 @@
     "react-inspector": {
       "version": "github:paritytech/react-inspector#73b5214261a5131821eb9088f58d7e5f31210c23",
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.26.0",
         "is-dom": "1.0.9"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "requires": {
+            "core-js": "2.5.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+        }
       }
     },
     "react-intl": {
@@ -11168,7 +11063,7 @@
       "integrity": "sha1-JtglQ40pLnym4pL+diAeHb8s/u4=",
       "requires": {
         "commonmark": "0.24.0",
-        "commonmark-react-renderer": "4.3.3",
+        "commonmark-react-renderer": "4.3.4",
         "in-publish": "2.0.0"
       }
     },
@@ -11491,13 +11386,13 @@
         "lodash": "4.17.2",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.1.0"
       },
       "dependencies": {
         "symbol-observable": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-          "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+          "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
         }
       }
     },
@@ -11725,12 +11620,6 @@
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
           "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
         }
       }
     },
@@ -11906,7 +11795,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "5.3.0"
+        "ajv": "5.5.1"
       }
     },
     "script-ext-html-webpack-plugin": {
@@ -11929,9 +11818,9 @@
       "integrity": "sha1-jgOPbdsUvXZa4fS1IW4SCUUR4NA="
     },
     "secp256k1": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
-      "integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.4.0.tgz",
+      "integrity": "sha512-eC120ESQ6MB3gMkxj0PVcSjv/9VtSUmm9uPGNc58yTs93iMCUQZ1xeGPidQMY1z1O4psbCtOxRu3vNqpbuck6Q==",
       "requires": {
         "bindings": "1.3.0",
         "bip66": "1.1.5",
@@ -11939,8 +11828,7 @@
         "create-hash": "1.1.3",
         "drbg.js": "1.0.1",
         "elliptic": "6.4.0",
-        "nan": "2.7.0",
-        "prebuild-install": "2.3.0",
+        "nan": "2.8.0",
         "safe-buffer": "5.1.1"
       }
     },
@@ -12081,7 +11969,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       },
       "dependencies": {
@@ -12110,16 +11998,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
       "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
-    },
-    "simple-get": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-      "requires": {
-        "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
-      }
     },
     "sinon": {
       "version": "1.17.7",
@@ -12767,7 +12645,7 @@
           "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
           "dev": true,
           "requires": {
-            "ajv": "5.3.0",
+            "ajv": "5.5.1",
             "ajv-keywords": "2.1.1",
             "chalk": "2.3.0",
             "lodash": "4.17.4",
@@ -12967,17 +12845,6 @@
         "inherits": "2.0.3"
       }
     },
-    "tar-fs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-      "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.2",
-        "tar-stream": "1.5.4"
-      }
-    },
     "tar-pack": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
@@ -12994,9 +12861,9 @@
       }
     },
     "tar-stream": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
         "bl": "1.2.1",
         "end-of-stream": "1.4.0",
@@ -13174,12 +13041,9 @@
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -13664,13 +13528,13 @@
         "ajv-keywords": "1.5.1",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "json-loader": "0.5.4",
         "loader-runner": "2.3.0",
         "loader-utils": "0.2.17",
         "memory-fs": "0.4.1",
         "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
+        "node-libs-browser": "2.1.0",
         "source-map": "0.5.7",
         "supports-color": "3.2.3",
         "tapable": "0.2.8",
@@ -13800,7 +13664,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "nan": "2.7.0",
+        "nan": "2.8.0",
         "typedarray-to-buffer": "3.1.2",
         "yaeti": "0.0.6"
       }
@@ -13856,14 +13720,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "requires": {
-        "string-width": "1.0.2"
-      }
     },
     "window-size": {
       "version": "0.2.0",

--- a/js-old/package.json
+++ b/js-old/package.json
@@ -35,7 +35,7 @@
     "lint": "npm run lint:css && npm run lint:js",
     "lint:css": "stylelint ./src/**/*.css",
     "lint:js": "eslint --ignore-path .gitignore ./src/",
-    "test": "NODE_ENV=test mocha --compilers ejs:ejsify 'src/**/*.spec.js'",
+    "test": "NODE_ENV=test mocha 'src/**/*.spec.js'",
     "watch": "webpack --watch --config webpack/app"
   },
   "napa": {
@@ -75,7 +75,6 @@
     "cross-env": "5.1.1",
     "css-loader": "0.26.1",
     "ejs-loader": "0.3.0",
-    "ejsify": "1.0.0",
     "empty-module": "0.0.2",
     "enzyme": "2.7.1",
     "eslint": "3.16.1",
@@ -93,7 +92,6 @@
     "html-loader": "0.4.4",
     "html-webpack-plugin": "2.28.0",
     "http-proxy-middleware": "0.17.3",
-    "ignore-styles": "5.0.1",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "9.11.0",
     "json-loader": "0.5.4",

--- a/js-old/src/views/Home/home.spec.js
+++ b/js-old/src/views/Home/home.spec.js
@@ -57,17 +57,8 @@ function createApi () {
 
 function render () {
   component = shallow(
-    <Home />,
-    {
-      context: {
-        store: createStore()
-      }
-    }
-  ).find('Home').shallow({
-    context: {
-      api: createApi()
-    }
-  });
+    <Home />
+  );
   instance = component.instance();
 
   return component;
@@ -82,38 +73,9 @@ describe('views/Home', () => {
     expect(component).to.be.ok;
   });
 
-  describe('lifecycle', () => {
-    describe('componentWillMount', () => {
-      beforeEach(() => {
-        sinon.stub(instance.webStore, 'loadHistory');
-        return instance.componentWillMount();
-      });
-
-      afterEach(() => {
-        instance.webStore.loadHistory.restore();
-      });
-
-      it('calls into webStore loadHistory', () => {
-        expect(instance.webStore.loadHistory).to.have.been.called;
-      });
-    });
-  });
-
   describe('components', () => {
-    it('renders Accounts', () => {
-      expect(component.find('Connect(Accounts)').length).to.equal(1);
-    });
-
-    it('renders Dapps', () => {
-      expect(component.find('Dapps').length).to.equal(1);
-    });
-
     it('renders News', () => {
       expect(component.find('News').length).to.equal(1);
-    });
-
-    it('renders Urls', () => {
-      expect(component.find('Urls').length).to.equal(1);
     });
   });
 });

--- a/js-old/src/views/Home/home.spec.js
+++ b/js-old/src/views/Home/home.spec.js
@@ -16,50 +16,15 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
 
 import Home from './';
 
-const TEST_APP_HISTORY = [];
-
-let api;
 let component;
-let instance;
-let store;
-
-function createStore () {
-  store = {
-    dispatch: sinon.stub(),
-    subscribe: sinon.stub(),
-    getState: () => {
-      return {
-        nodeStatus: {
-          nodeKind: {
-            'availability': 'personal'
-          }
-        }
-      };
-    }
-  };
-
-  return store;
-}
-
-function createApi () {
-  api = {
-    parity: {
-      listRecentDapps: sinon.stub().resolves(TEST_APP_HISTORY)
-    }
-  };
-
-  return api;
-}
 
 function render () {
   component = shallow(
     <Home />
   );
-  instance = component.instance();
 
   return component;
 }

--- a/js-old/src/views/Signer/components/SignRequest/signRequest.spec.js
+++ b/js-old/src/views/Signer/components/SignRequest/signRequest.spec.js
@@ -68,7 +68,7 @@ function render () {
   return component;
 }
 
-describe.only('views/Signer/components/SignRequest', () => {
+describe('views/Signer/components/SignRequest', () => {
   beforeEach(() => {
     render();
   });

--- a/js-old/test/ignoreImports.js
+++ b/js-old/test/ignoreImports.js
@@ -1,0 +1,24 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+const EXTENSIONS = ['.css', '.ejs', '.png', '.svg'];
+
+function noop () {
+}
+
+EXTENSIONS.forEach((extension) => {
+  require.extensions[extension] = noop;
+});

--- a/js-old/test/mocha.opts
+++ b/js-old/test/mocha.opts
@@ -1,3 +1,3 @@
 -r ./test/babel
 -r ./test/mocha.config
--r ignore-styles
+-r ./test/ignoreImports

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -20,7 +20,7 @@
       "integrity": "sha512-HkvMIhIwDMEIyTmXqEjWn1C2qes0qJO270bQldRfCZf0XiOGXG726EzV3FUpUbVONCVQ9riDviAl3fw6D+N6nA==",
       "requires": {
         "@parity/abi": "2.1.2",
-        "@parity/jsonrpc": "2.1.3",
+        "@parity/jsonrpc": "2.1.4",
         "@parity/wordlist": "1.1.0",
         "bignumber.js": "3.0.1",
         "blockies": "0.0.2",
@@ -44,11 +44,6 @@
       "version": "github:paritytech/dapp-accounts#ca55be1774563862e7b0cc72740d0747a60036b8",
       "requires": {
         "@parity/dapp-vaults": "github:paritytech/dapp-vaults#1bd5de3994227e6b733e7b3e985117a59f0ad638"
-      },
-      "dependencies": {
-        "@parity/dapp-vaults": {
-          "version": "github:paritytech/dapp-vaults#1bd5de3994227e6b733e7b3e985117a59f0ad638"
-        }
       }
     },
     "@parity/dapp-console": {
@@ -274,6 +269,12 @@
             "intl-messageformat-parser": "1.2.0"
           }
         },
+        "intl-messageformat-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz",
+          "integrity": "sha1-WQa3+VOrdHDg3IVJCXtki5kYkv8=",
+          "dev": true
+        },
         "intl-relativeformat": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-1.3.0.tgz",
@@ -381,6 +382,18 @@
             "sortobject": "1.1.1",
             "stringify-object": "3.2.1",
             "traverse": "0.6.6"
+          }
+        },
+        "react-event-listener": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.5.tgz",
+          "integrity": "sha1-4+iVoJcM8U7o+JAROvaBl6vz0LE=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "fbjs": "0.8.16",
+            "prop-types": "15.6.0",
+            "warning": "3.0.0"
           }
         },
         "react-markdown": {
@@ -740,6 +753,12 @@
             "intl-messageformat-parser": "1.2.0"
           }
         },
+        "intl-messageformat-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz",
+          "integrity": "sha1-WQa3+VOrdHDg3IVJCXtki5kYkv8=",
+          "dev": true
+        },
         "intl-relativeformat": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-1.3.0.tgz",
@@ -861,6 +880,18 @@
               "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
               "dev": true
             }
+          }
+        },
+        "react-event-listener": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.5.tgz",
+          "integrity": "sha1-4+iVoJcM8U7o+JAROvaBl6vz0LE=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "fbjs": "0.8.16",
+            "prop-types": "15.6.0",
+            "warning": "3.0.0"
           }
         },
         "react-markdown": {
@@ -1042,8 +1073,7 @@
       "dev": true
     },
     "@parity/dapp-vaults": {
-      "version": "github:paritytech/dapp-vaults#1bd5de3994227e6b733e7b3e985117a59f0ad638",
-      "dev": true
+      "version": "github:paritytech/dapp-vaults#1bd5de3994227e6b733e7b3e985117a59f0ad638"
     },
     "@parity/dapp-web": {
       "version": "github:paritytech/dapp-web#6ea1fe0c7c0d01c43788dbf6a11d1573a443ce1d",
@@ -1066,9 +1096,9 @@
       }
     },
     "@parity/jsonrpc": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@parity/jsonrpc/-/jsonrpc-2.1.3.tgz",
-      "integrity": "sha512-ALSn/gwX0r3aTcsKI6ucuEtFXCjIFdFmMN455yade1dju+PSWQ0aR61H3/zzZMGx6fV9OQh+n3xAueBxUjJpzQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@parity/jsonrpc/-/jsonrpc-2.1.4.tgz",
+      "integrity": "sha512-gGX1LMGxF6Ma4fAbpY3awK0IpB+ARjCH87m/fq8vvUr+5/Z/ywXjjmauPqA435vyjnW4STd2l9FVREVz4wv08A=="
     },
     "@parity/ledger": {
       "version": "2.1.2",
@@ -1152,9 +1182,9 @@
       }
     },
     "@parity/ui": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@parity/ui/-/ui-3.0.2.tgz",
-      "integrity": "sha512-96hH+2+usH7Itl0j+nErFYXXGW9G+GvowEYxx9nqW3yAp5PCwzS3+qUI9ETz/cX9DroItXixHWICHareW9eIFw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@parity/ui/-/ui-3.0.4.tgz",
+      "integrity": "sha512-/IS+6Qxr5HGAvdaB0xud9lU2c48Crg2dY7yzkb7V+99qvqYV/OAI31IffaBOt3UbLz/QWF+Da+ZOWT96eIVlAg==",
       "requires": {
         "@parity/api": "2.1.5",
         "@parity/etherscan": "2.1.3",
@@ -1221,27 +1251,6 @@
           "integrity": "sha1-WM2hBbgBj5v4e9beMzrF6w1cnf4=",
           "requires": {
             "hoist-non-react-statics": "2.3.1"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "react-event-listener": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.1.tgz",
-          "integrity": "sha1-ujYHbke8N8Wmf/XM1Kn/DxViEEA=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "fbjs": "0.8.16",
-            "prop-types": "15.6.0",
-            "warning": "3.0.0"
           }
         }
       }
@@ -1353,9 +1362,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
-      "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -1666,7 +1675,7 @@
       "dev": true,
       "requires": {
         "browserslist": "2.9.1",
-        "caniuse-lite": "1.0.30000772",
+        "caniuse-lite": "1.0.30000778",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.14",
@@ -1705,7 +1714,7 @@
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.12.1",
+        "commander": "2.12.2",
         "convert-source-map": "1.5.1",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
@@ -2034,7 +2043,7 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "intl-messageformat-parser": "1.2.0",
+        "intl-messageformat-parser": "1.4.0",
         "mkdirp": "0.5.1"
       }
     },
@@ -3239,7 +3248,7 @@
       "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000772",
+        "caniuse-lite": "1.0.30000778",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -3344,7 +3353,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000772",
+        "caniuse-db": "1.0.30000778",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -3355,22 +3364,22 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "electron-to-chromium": "1.3.27"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000772",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000772.tgz",
-      "integrity": "sha1-UarokXaChureSj2DGep21qAbUSs=",
+      "version": "1.0.30000778",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
+      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000772",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000772.tgz",
-      "integrity": "sha1-eBKWIsq/7Xrx/zi2SraApqCGVCA=",
+      "version": "1.0.30000778",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000778.tgz",
+      "integrity": "sha1-8efLixOx9nREAikddfC81MMWA2k=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3737,7 +3746,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -3798,9 +3807,9 @@
       }
     },
     "commander": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.1.tgz",
-      "integrity": "sha512-PCNLExLlI5HiPdaJs4pMXwOTHkSCpNQ1QJH9ykZLKtKEyKu3p9HgmH5l97vM8c0IUz6d54l+xEu2GG9yuYrFzA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "commondir": {
@@ -4165,7 +4174,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.12.1",
+            "commander": "2.12.2",
             "is-my-json-valid": "2.16.1",
             "pinkie-promise": "2.0.1"
           }
@@ -4435,7 +4444,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -4659,7 +4668,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -4672,7 +4681,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -4689,7 +4698,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -5058,7 +5067,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000772",
+        "caniuse-db": "1.0.30000778",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -5077,7 +5086,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -5115,7 +5124,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           },
@@ -5359,12 +5368,6 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "ejs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz",
-      "integrity": "sha1-ycYKSKRu5FL7MqccMXuV5aofyz0=",
-      "dev": true
-    },
     "ejs-loader": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ejs-loader/-/ejs-loader-0.3.0.tgz",
@@ -5393,16 +5396,6 @@
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
-      }
-    },
-    "ejsify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ejsify/-/ejsify-1.0.0.tgz",
-      "integrity": "sha1-NxlPWoXBKuQ4QpOVeZ7Ee0O8RT8=",
-      "dev": true,
-      "requires": {
-        "ejs": "1.0.0",
-        "through": "2.3.8"
       }
     },
     "electron": {
@@ -6310,9 +6303,9 @@
         "bn.js": "4.11.8",
         "create-hash": "1.1.3",
         "ethjs-util": "0.1.4",
-        "keccak": "1.3.0",
+        "keccak": "1.4.0",
         "rlp": "2.0.0",
-        "secp256k1": "3.3.1"
+        "secp256k1": "3.4.0"
       }
     },
     "ethjs-util": {
@@ -6932,15 +6925,13 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6950,21 +6941,18 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -6974,49 +6962,42 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "bundled": true,
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7025,8 +7006,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -7034,8 +7014,7 @@
         },
         "boom": {
           "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -7043,8 +7022,7 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -7053,34 +7031,29 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "bundled": true,
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -7088,26 +7061,22 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7116,8 +7085,7 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7126,8 +7094,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7135,8 +7102,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7145,28 +7111,24 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "bundled": true,
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7175,28 +7137,24 @@
         },
         "extend": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "bundled": true,
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7207,14 +7165,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -7225,8 +7181,7 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7237,8 +7192,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7254,8 +7208,7 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7264,8 +7217,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7273,8 +7225,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7287,21 +7238,18 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7311,15 +7259,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7331,14 +7277,12 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "bundled": true,
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7349,8 +7293,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -7359,21 +7302,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -7381,28 +7321,24 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7411,22 +7347,19 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7435,22 +7368,19 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7462,8 +7392,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7471,14 +7400,12 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "bundled": true,
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -7486,8 +7413,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -7495,14 +7421,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -7510,15 +7434,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7535,8 +7457,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7546,8 +7467,7 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7559,28 +7479,24 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -7588,22 +7504,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7613,41 +7526,35 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "bundled": true,
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7659,8 +7566,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7668,8 +7574,7 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -7683,8 +7588,7 @@
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7714,8 +7618,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -7723,35 +7626,30 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "bundled": true,
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7760,8 +7658,7 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7778,8 +7675,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -7787,8 +7683,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -7798,8 +7693,7 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -7807,15 +7701,13 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -7823,15 +7715,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -7841,8 +7731,7 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7858,8 +7747,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7868,8 +7756,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7878,35 +7765,30 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7915,8 +7797,7 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -7925,8 +7806,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         }
       }
@@ -8268,7 +8148,7 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.1",
         "har-schema": "2.0.0"
       }
     },
@@ -8484,12 +8364,12 @@
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.9",
-        "commander": "2.12.1",
+        "commander": "2.12.2",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.2.0"
+        "uglify-js": "3.2.1"
       },
       "dependencies": {
         "source-map": {
@@ -8499,12 +8379,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.0.tgz",
-          "integrity": "sha512-L98DlTshoPGnZGF8pr3MoE+CCo6n9joktHNHMPkckeBV8xTVc4CWtC0kGGhQsIvnX2Ug4nXFTAeE7SpTrPX2tg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.1.tgz",
+          "integrity": "sha512-BhZTJPmOKPSUcjnx2nlfaOQKHLyjjT4HFyzFWF1BUErx9knJNpdW94ql5o8qVxeNL+8IAWjEjnPvASH2yZnkMg==",
           "dev": true,
           "requires": {
-            "commander": "2.12.1",
+            "commander": "2.12.2",
             "source-map": "0.6.1"
           }
         }
@@ -8721,12 +8601,6 @@
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
-    "ignore-styles": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
-      "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE=",
-      "dev": true
-    },
     "import-local": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
@@ -8886,9 +8760,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "intl-format-cache": {
@@ -8902,20 +8776,12 @@
       "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
       "requires": {
         "intl-messageformat-parser": "1.4.0"
-      },
-      "dependencies": {
-        "intl-messageformat-parser": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
-          "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
-        }
       }
     },
     "intl-messageformat-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz",
-      "integrity": "sha1-WQa3+VOrdHDg3IVJCXtki5kYkv8=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
     },
     "intl-relativeformat": {
       "version": "2.1.0",
@@ -9141,13 +9007,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -9855,9 +9721,9 @@
       "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
     },
     "js-base64": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
       "dev": true
     },
     "js-sha3": {
@@ -10074,14 +9940,13 @@
       "dev": true
     },
     "keccak": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.3.0.tgz",
-      "integrity": "sha512-JgsKPxYhcJxKrV+TrCyg/GwZbOjhpRPrz2kG8xbAsUaIDelUlKjm08YcwBO9Fm8sqf/Kg8ZWkk6nWujhLykfvw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "requires": {
         "bindings": "1.3.0",
         "inherits": "2.0.3",
         "nan": "2.8.0",
-        "prebuild-install": "2.3.0",
         "safe-buffer": "5.1.1"
       }
     },
@@ -10646,7 +10511,7 @@
       "dev": true,
       "requires": {
         "loader-utils": "0.2.17",
-        "marked": "0.3.6"
+        "marked": "0.3.7"
       },
       "dependencies": {
         "loader-utils": {
@@ -10664,9 +10529,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
       "dev": true
     },
     "material-ui": {
@@ -10685,6 +10550,19 @@
         "recompose": "0.20.2",
         "simple-assign": "0.1.0",
         "warning": "3.0.0"
+      },
+      "dependencies": {
+        "react-event-listener": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.5.tgz",
+          "integrity": "sha1-4+iVoJcM8U7o+JAROvaBl6vz0LE=",
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "fbjs": "0.8.16",
+            "prop-types": "15.5.10",
+            "warning": "3.0.0"
+          }
+        }
       }
     },
     "math-expression-evaluator": {
@@ -11980,7 +11858,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12020,7 +11898,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12059,7 +11937,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12097,7 +11975,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12135,7 +12013,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12173,7 +12051,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12211,7 +12089,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12250,7 +12128,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12289,7 +12167,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12349,7 +12227,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12439,7 +12317,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12477,7 +12355,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12512,7 +12390,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -12529,7 +12407,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12575,7 +12453,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12614,7 +12492,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12655,7 +12533,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12696,7 +12574,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12783,7 +12661,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12824,7 +12702,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12863,7 +12741,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12902,7 +12780,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12940,7 +12818,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12980,7 +12858,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -13021,7 +12899,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -13065,7 +12943,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -13126,7 +13004,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -13166,7 +13044,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -13212,7 +13090,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -13788,14 +13666,26 @@
       "dev": true
     },
     "react-event-listener": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.4.5.tgz",
-      "integrity": "sha1-4+iVoJcM8U7o+JAROvaBl6vz0LE=",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.1.tgz",
+      "integrity": "sha1-ujYHbke8N8Wmf/XM1Kn/DxViEEA=",
       "requires": {
         "babel-runtime": "6.26.0",
         "fbjs": "0.8.16",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "warning": "3.0.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.0",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "react-hot-loader": {
@@ -14090,7 +13980,7 @@
           "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
           "dev": true,
           "requires": {
-            "ajv": "5.5.0",
+            "ajv": "5.5.1",
             "babel-code-frame": "6.26.0",
             "chalk": "2.3.0",
             "concat-stream": "1.6.0",
@@ -14344,7 +14234,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -14505,12 +14395,12 @@
           "requires": {
             "acorn": "5.2.1",
             "acorn-dynamic-import": "2.0.2",
-            "ajv": "5.5.0",
+            "ajv": "5.5.1",
             "ajv-keywords": "2.1.1",
             "async": "2.6.0",
             "enhanced-resolve": "3.4.1",
             "escope": "3.6.0",
-            "interpret": "1.0.4",
+            "interpret": "1.1.0",
             "json-loader": "0.5.4",
             "json5": "0.5.1",
             "loader-runner": "2.3.0",
@@ -15482,9 +15372,9 @@
       }
     },
     "rtcpeerconnection-shim": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.1.tgz",
-      "integrity": "sha512-1IsK2xj8yrxYfce1YpaI53KwMlwHfnAMx34DjPja9nUbmOlJe43L5ZlAuE5wh+SynyuuSZxoxhFoIlXPgXPEKA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.2.tgz",
+      "integrity": "sha512-8gk72X25Z31XEkk5DZd6y4aziHgj0mZMB7xMv4mUrS6moTmZOrcKE8+rvEVRModMkaaUyspEVwBn8JGuG8Z1ww==",
       "requires": {
         "sdp": "2.5.0"
       }
@@ -15577,7 +15467,7 @@
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.0"
+        "ajv": "5.5.1"
       }
     },
     "scryptsy": {
@@ -15591,9 +15481,9 @@
       "integrity": "sha512-4HT7gdxA+AZHl5LDdiLpagFKBS5qAKFYE71CPSNrr+2dCFg9iKXY4JSIhHKZHVnwJAzZ/4jA+z1nam4U+LoYug=="
     },
     "secp256k1": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.3.1.tgz",
-      "integrity": "sha512-lygjgfjzjBHblEDDkppUF5KK1EeVk6P/Dv2MsJZpYIR3vW5TKFRexOFkf0hHy9J5YxEpjQZ6x98Y3XQpMQO/vA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.4.0.tgz",
+      "integrity": "sha512-eC120ESQ6MB3gMkxj0PVcSjv/9VtSUmm9uPGNc58yTs93iMCUQZ1xeGPidQMY1z1O4psbCtOxRu3vNqpbuck6Q==",
       "requires": {
         "bindings": "1.3.0",
         "bip66": "1.1.5",
@@ -15602,7 +15492,6 @@
         "drbg.js": "1.0.1",
         "elliptic": "6.4.0",
         "nan": "2.8.0",
-        "prebuild-install": "2.3.0",
         "safe-buffer": "5.1.1"
       }
     },
@@ -15830,7 +15719,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
     },
@@ -16391,7 +16280,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -16414,7 +16303,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -16502,7 +16391,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -16521,7 +16410,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000772",
+            "caniuse-db": "1.0.30000778",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -16563,7 +16452,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -16632,7 +16521,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -16710,7 +16599,7 @@
       "requires": {
         "del": "2.2.2",
         "sw-precache": "5.2.0",
-        "uglify-js": "3.2.0"
+        "uglify-js": "3.2.1"
       },
       "dependencies": {
         "source-map": {
@@ -16720,12 +16609,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.0.tgz",
-          "integrity": "sha512-L98DlTshoPGnZGF8pr3MoE+CCo6n9joktHNHMPkckeBV8xTVc4CWtC0kGGhQsIvnX2Ug4nXFTAeE7SpTrPX2tg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.1.tgz",
+          "integrity": "sha512-BhZTJPmOKPSUcjnx2nlfaOQKHLyjjT4HFyzFWF1BUErx9knJNpdW94ql5o8qVxeNL+8IAWjEjnPvASH2yZnkMg==",
           "dev": true,
           "requires": {
-            "commander": "2.12.1",
+            "commander": "2.12.2",
             "source-map": "0.6.1"
           }
         }
@@ -16775,7 +16664,7 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.1",
         "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",
@@ -17701,12 +17590,12 @@
       "requires": {
         "acorn": "5.2.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.0",
+        "ajv": "5.5.1",
         "ajv-keywords": "2.1.1",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
-        "interpret": "1.0.4",
+        "interpret": "1.1.0",
         "json-loader": "0.5.4",
         "json5": "0.5.1",
         "loader-runner": "2.3.0",
@@ -17881,7 +17770,7 @@
       "integrity": "sha1-k56kZeRVk1Op/OQK9RGCDyFqnIA=",
       "dev": true,
       "requires": {
-        "commander": "2.12.1",
+        "commander": "2.12.2",
         "filesize": "3.5.11",
         "humanize": "0.0.9"
       }
@@ -18099,7 +17988,7 @@
       "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-5.0.6.tgz",
       "integrity": "sha512-dh2hPQFOPP0tLEYlFxtGI5vuQmRqkOdYni5wMKUHIx5I2dw0TJ1HdG7P+UechRWt6TvwPWhtbjVNQcQf1KXJmQ==",
       "requires": {
-        "rtcpeerconnection-shim": "1.2.1",
+        "rtcpeerconnection-shim": "1.2.2",
         "sdp": "2.5.0"
       }
     },

--- a/js/package.json
+++ b/js/package.json
@@ -40,8 +40,8 @@
     "start": "npm run clean && npm install && npm run build:inject && npm run start:app",
     "start:app": "node webpack/dev.server",
     "start:electron": "npm run build:app && electron .build/",
-    "test": "cross-env NODE_ENV=test mocha --compilers ejs:ejsify 'src/**/*.spec.js'",
-    "test:coverage": "cross-env NODE_ENV=test istanbul cover _mocha -- --compilers ejs:ejsify 'src/**/*.spec.js'"
+    "test": "cross-env NODE_ENV=test mocha 'src/**/*.spec.js'",
+    "test:coverage": "cross-env NODE_ENV=test istanbul cover _mocha -- 'src/**/*.spec.js'"
   },
   "devDependencies": {
     "@parity/dapp-console": "paritytech/dapp-console",
@@ -84,7 +84,6 @@
     "cross-env": "5.1.1",
     "css-loader": "0.28.4",
     "ejs-loader": "0.3.0",
-    "ejsify": "1.0.0",
     "electron": "1.7.5",
     "empty-module": "0.0.2",
     "enzyme": "3.2.0",
@@ -105,7 +104,6 @@
     "html-loader": "0.4.4",
     "html-webpack-plugin": "2.30.1",
     "http-proxy-middleware": "0.17.3",
-    "ignore-styles": "5.0.1",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "9.11.0",
     "json-loader": "0.5.4",

--- a/js/test/ignoreImports.js
+++ b/js/test/ignoreImports.js
@@ -1,0 +1,24 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+const EXTENSIONS = ['.css', '.ejs', '.png', '.svg'];
+
+function noop () {
+}
+
+EXTENSIONS.forEach((extension) => {
+  require.extensions[extension] = noop;
+});

--- a/js/test/mocha.opts
+++ b/js/test/mocha.opts
@@ -1,3 +1,3 @@
 -r ./test/babel
 -r ./test/mocha.config
--r ignore-styles
+-r ./test/ignoreImports


### PR DESCRIPTION
Imports for mocha tests:
- Introduce generic filetype skip handler
- Remove ejsify (security advisory, replaced by generic)
- Remove ignore-style (replaced by generic)

Cleanups for tests:
- Remove misplaced .only in js-old, fixup changed tests