### PR TITLE
Make Signing Requests more visible

### DIFF
--- a/js/src/Status/SignerPending/EtherValue/etherValue.js
+++ b/js/src/Status/SignerPending/EtherValue/etherValue.js
@@ -1,0 +1,39 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const EtherValue = ({ value }, { api }) => {
+  const ether = api.util.fromWei(value);
+
+  return (
+    <span>
+      {ether.toFormat(5)}
+      <small> ETH</small>
+    </span>
+  );
+};
+
+EtherValue.propTypes = {
+  value: PropTypes.object.isRequired
+};
+
+EtherValue.contextTypes = {
+  api: PropTypes.object.isRequired
+};
+
+export default EtherValue;

--- a/js/src/Status/SignerPending/EtherValue/index.js
+++ b/js/src/Status/SignerPending/EtherValue/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './etherValue';

--- a/js/src/Status/SignerPending/RequestItem/index.js
+++ b/js/src/Status/SignerPending/RequestItem/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './requestItem';

--- a/js/src/Status/SignerPending/RequestItem/requestItem.css
+++ b/js/src/Status/SignerPending/RequestItem/requestItem.css
@@ -15,16 +15,10 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-.signerPending {
-  margin-top: 4px !important;
-  position: relative;
-  cursor: pointer;
+.listDescription {
+  display: flex !important;
 }
 
-.label {
-  font-size: 0.65rem !important;
-}
-
-.noRequest {
-  min-width: 280px;
+.toAvatar {
+  margin-left: 3px;
 }

--- a/js/src/Status/SignerPending/RequestItem/requestItem.js
+++ b/js/src/Status/SignerPending/RequestItem/requestItem.js
@@ -24,7 +24,6 @@ import MethodDecodingStore from '@parity/ui/lib/MethodDecoding/methodDecodingSto
 import { TOKEN_METHODS } from '@parity/ui/lib/MethodDecoding/constants';
 import TokenValue from '@parity/ui/lib/MethodDecoding/tokenValue';
 import IdentityIcon from '@parity/ui/lib/IdentityIcon';
-import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
 import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 import List from 'semantic-ui-react/dist/commonjs/elements/List';
 
@@ -166,21 +165,7 @@ class RequestItem extends Component {
     if (!this.state.decoded) { return null; }
 
     return (
-      <List.Item >
-        <List.Content floated='right'>
-          <Button
-            icon='unlock alternate'
-            content={
-              <FormattedMessage
-                id='application.status.signerPendingView'
-                defaultMessage='View'
-              />
-            }
-            primary
-            onClick={ onClick }
-            size='mini'
-          />
-        </List.Content>
+      <List.Item onClick={ onClick }>
         <Image avatar size='mini' verticalAlign='middle'>
           <IdentityIcon
             address={ transaction.from }

--- a/js/src/Status/SignerPending/RequestItem/requestItem.js
+++ b/js/src/Status/SignerPending/RequestItem/requestItem.js
@@ -1,0 +1,185 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { observer } from 'mobx-react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import MethodDecodingStore from '@parity/ui/lib/MethodDecoding/methodDecodingStore';
+import { TOKEN_METHODS } from '@parity/ui/lib/MethodDecoding/constants';
+import IdentityIcon from '@parity/ui/lib/IdentityIcon';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
+
+import styles from './requestItem.css';
+
+@observer
+@connect(({ tokens }, { request: { payload: { sendTransaction } } }) => ({
+  token: Object.values(tokens).find(({ address }) => address === sendTransaction.to)
+}))
+class RequestItem extends Component {
+  static propTypes = {
+    onClick: PropTypes.func.isRequired,
+    request: PropTypes.object.isRequired,
+    token: PropTypes.string
+  };
+
+  static contextTypes = {
+    api: PropTypes.object.isRequired
+  };
+
+  state = {
+    transaction: null
+  };
+
+  methodDecodingStore = MethodDecodingStore.get(this.context.api);
+
+  componentWillMount () {
+    const { request: { payload: { sendTransaction } } } = this.props;
+
+    this.methodDecodingStore
+      .lookup(sendTransaction.from, sendTransaction)
+      .then(lookup => this.setState({
+        transaction: lookup
+      }));
+  }
+
+  renderDescription = () => {
+    // Decide what to display in the description, depending
+    // on what type of transaction we're dealing with
+    const { token } = this.props;
+    const {
+      inputs,
+      signature,
+      contract,
+      deploy
+    } = this.state.transaction;
+
+    console.log(this.state.transaction);
+
+    if (deploy) {
+      return this.renderDeploy();
+    }
+
+    if (contract && signature) {
+      if (token && TOKEN_METHODS[signature] && inputs) {
+        return this.renderTokenTransfer();
+      }
+      return this.renderContractMethod();
+    }
+
+    return this.renderValueTransfer();
+  }
+
+  renderDeploy = () => {
+    return (
+      <FormattedMessage
+        id='application.status.signerPendingContractDeploy'
+        defaultMessage='Deploying contract'
+      />
+    );
+  };
+
+  renderContractMethod = () => {
+    return (
+      <FormattedMessage
+        id='application.status.signerPendingContractMethod'
+        defaultMessage='Executing method on contract'
+      />
+    );
+  };
+
+  renderTokenTransfer = () => {
+    const { request: { payload: { sendTransaction } } } = this.props;
+
+    return (
+      <FormattedMessage
+        id='application.status.signerendingTokenTransfer'
+        defaultMessage='Sending {tokenValue} to'
+        values={ {
+          tokenValue: this.renderTokenValue(sendTransaction.value)
+        }
+        }
+      />
+    );
+  };
+
+  renderValueTransfer = () => {
+    const { request: { payload: { sendTransaction } } } = this.props;
+
+    return (
+      <FormattedMessage
+        id='application.status.signerendingValueTransfer'
+        defaultMessage='Sending {etherValue} to'
+        values={ {
+          etherValue: this.renderEtherValue(sendTransaction.value)
+        }
+        }
+      />
+    );
+  };
+
+  render () {
+    const { request: { payload: { sendTransaction } }, onClick } = this.props;
+
+    if (!this.state.transaction) { return null; }
+
+    return (
+      <List.Item >
+        <List.Content floated='right'>
+          <Button
+            icon='unlock alternate'
+            content={
+              <FormattedMessage
+                id='application.status.signerPendingView'
+                defaultMessage='View'
+              />
+            }
+            primary
+            onClick={ onClick }
+            size='mini'
+          />
+        </List.Content>
+        <Image avatar size='mini' verticalAlign='middle'>
+          <IdentityIcon
+            address={ sendTransaction.from }
+          />
+        </Image>
+        <List.Content>
+          <List.Header>
+            <FormattedMessage
+              id='application.status.signerPendingSignerRequest'
+              defaultMessage='Parity Signer Request'
+            />
+          </List.Header>
+          <List.Description className={ styles.listDescription }>
+            {this.renderDescription()}
+            <IdentityIcon
+              tiny
+              address={ sendTransaction.to }
+              className={ styles.toAvatar }
+            />
+          </List.Description>
+        </List.Content>
+      </List.Item >
+    );
+  }
+}
+
+export default RequestItem;

--- a/js/src/Status/SignerPending/index.js
+++ b/js/src/Status/SignerPending/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './signerPending';

--- a/js/src/Status/SignerPending/signerPending.css
+++ b/js/src/Status/SignerPending/signerPending.css
@@ -1,0 +1,34 @@
+/* Copyright 2015-2017 Parity Technologies (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.signerPending {
+  margin-top: 4px !important;
+  position: relative;
+  cursor: pointer;
+}
+
+.label {
+  font-size: 0.65rem !important;
+}
+
+.listDescription {
+  display: flex !important;
+}
+
+.toAvatar {
+  margin-left: 3px;
+}

--- a/js/src/Status/SignerPending/signerPending.css
+++ b/js/src/Status/SignerPending/signerPending.css
@@ -32,3 +32,7 @@
 .toAvatar {
   margin-left: 3px;
 }
+
+.noRequest {
+  min-width: 280px;
+}

--- a/js/src/Status/SignerPending/signerPending.js
+++ b/js/src/Status/SignerPending/signerPending.js
@@ -19,18 +19,17 @@ import { observer } from 'mobx-react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import IdentityIcon from '@parity/ui/lib/IdentityIcon';
-import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
+import MethodDecodingStore from '@parity/ui/lib/MethodDecoding/methodDecodingStore';
 import Container from 'semantic-ui-react/dist/commonjs/elements/Container';
 import Header from 'semantic-ui-react/dist/commonjs/elements/Header';
 import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon';
-import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
 import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
 import List from 'semantic-ui-react/dist/commonjs/elements/List';
 import Popup from 'semantic-ui-react/dist/commonjs/modules/Popup';
 
 import Store from './store';
 import ParityBarStore from '../../ParityBar/store';
+import RequestItem from './RequestItem';
 import styles from './signerPending.css';
 
 @observer
@@ -47,8 +46,9 @@ class SignerPending extends Component {
 
   store = Store.get(this.context.api);
   parityBarStore = ParityBarStore.get();
+  methodDecodingStore = MethodDecodingStore.get(this.context.api);
 
-  handleViewRequest = () => {
+  handleRequestClick = () => {
     this.parityBarStore.toggleOpenSigner();
     this.handleClose();
   };
@@ -61,78 +61,23 @@ class SignerPending extends Component {
     this.setState({ isOpen: false });
   };
 
-  renderEtherValue (value) {
-    const { api } = this.context;
-    const ether = api.util.fromWei(value);
-
-    return (
-      <span>
-        {ether.toFormat(5)}
-        <small> ETH</small>
-      </span>
-    );
-  }
-
   renderPopupContent = () => (
     <div>
-      <Header
-        as='h5'
-        content={
-          <FormattedMessage
-            id='application.status.signerPendingTitle'
-            defaultMessage='Authorization Requests'
-          />
-        }
-      />
+      <Header as='h5'>
+        <FormattedMessage
+          id='application.status.signerPendingTitle'
+          defaultMessage='Authorization Requests'
+        />
+      </Header>
       {this.store.pending.length > 0
         ? (
-          <List divided relaxed='very'>
+          <List divided relaxed='very' selection>
             {this.store.pending.map(request => (
-              <List.Item key={ request.id.toNumber() }>
-                <List.Content floated='right'>
-                  <Button
-                    icon='unlock alternate'
-                    content={
-                      <FormattedMessage
-                        id='application.status.signerPendingView'
-                        defaultMessage='View'
-                      />
-                    }
-                    primary
-                    onClick={ this.handleViewRequest }
-                    size='mini'
-                  />
-                </List.Content>
-                <Image avatar size='mini' verticalAlign='middle'>
-                  <IdentityIcon
-                    address={ request.payload.sendTransaction.from }
-                  />
-                </Image>
-                <List.Content>
-                  <List.Header>
-                    <FormattedMessage
-                      id='application.status.signerPendingSignerRequest'
-                      defaultMessage='Parity Signer Request'
-                    />
-                  </List.Header>
-                  <List.Description className={ styles.listDescription }>
-                    <FormattedMessage
-                      id='application.status.signerPendingSending'
-                      defaultMessage='Sending {etherValue} to'
-                      values={ {
-                        etherValue: this.renderEtherValue(
-                          request.payload.sendTransaction.value
-                        )
-                      } }
-                    />
-                    <IdentityIcon
-                      tiny
-                      address={ request.payload.sendTransaction.to }
-                      className={ styles.toAvatar }
-                    />
-                  </List.Description>
-                </List.Content>
-              </List.Item>
+              <RequestItem
+                request={ request }
+                key={ request.id.toNumber() }
+                onClick={ this.handleRequestClick }
+              />
             ))}
           </List>
         ) : (
@@ -142,7 +87,8 @@ class SignerPending extends Component {
               defaultMessage='You have no pending requests.'
             />
           </Container>
-        )}
+        )
+      }
     </div>
   );
 

--- a/js/src/Status/SignerPending/signerPending.js
+++ b/js/src/Status/SignerPending/signerPending.js
@@ -19,7 +19,6 @@ import { observer } from 'mobx-react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import MethodDecodingStore from '@parity/ui/lib/MethodDecoding/methodDecodingStore';
 import Container from 'semantic-ui-react/dist/commonjs/elements/Container';
 import Header from 'semantic-ui-react/dist/commonjs/elements/Header';
 import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon';
@@ -46,7 +45,6 @@ class SignerPending extends Component {
 
   store = Store.get(this.context.api);
   parityBarStore = ParityBarStore.get();
-  methodDecodingStore = MethodDecodingStore.get(this.context.api);
 
   handleRequestClick = () => {
     this.parityBarStore.toggleOpenSigner();

--- a/js/src/Status/SignerPending/signerPending.js
+++ b/js/src/Status/SignerPending/signerPending.js
@@ -74,7 +74,7 @@ class SignerPending extends Component {
           <List divided relaxed='very' selection>
             {this.store.pending.map(request => (
               <RequestItem
-                request={ request }
+                transaction={ request.payload.sendTransaction }
                 key={ request.id.toNumber() }
                 onClick={ this.handleRequestClick }
               />

--- a/js/src/Status/SignerPending/signerPending.js
+++ b/js/src/Status/SignerPending/signerPending.js
@@ -35,31 +35,31 @@ import styles from './signerPending.css';
 
 @observer
 class SignerPending extends Component {
-  static propTypes = {}
+  static propTypes = {};
 
   static contextTypes = {
     api: PropTypes.object.isRequired
-  }
+  };
 
   state = {
     isOpen: false
-  }
+  };
 
-  store = Store.get(this.context.api)
+  store = Store.get(this.context.api);
   parityBarStore = ParityBarStore.get();
 
   handleViewRequest = () => {
     this.parityBarStore.toggleOpenSigner();
     this.handleClose();
-  }
+  };
 
   handleOpen = () => {
     this.setState({ isOpen: true });
-  }
+  };
 
   handleClose = () => {
     this.setState({ isOpen: false });
-  }
+  };
 
   renderEtherValue (value) {
     const { api } = this.context;
@@ -67,10 +67,84 @@ class SignerPending extends Component {
 
     return (
       <span>
-        {ether.toFormat(5)}<small> ETH</small>
+        {ether.toFormat(5)}
+        <small> ETH</small>
       </span>
     );
   }
+
+  renderPopupContent = () => (
+    <div>
+      <Header
+        as='h5'
+        content={
+          <FormattedMessage
+            id='application.status.signerPendingTitle'
+            defaultMessage='Authorization Requests'
+          />
+        }
+      />
+      {this.store.pending.length > 0
+        ? (
+          <List divided relaxed='very'>
+            {this.store.pending.map(request => (
+              <List.Item key={ request.id.toNumber() }>
+                <List.Content floated='right'>
+                  <Button
+                    icon='unlock alternate'
+                    content={
+                      <FormattedMessage
+                        id='application.status.signerPendingView'
+                        defaultMessage='View'
+                      />
+                    }
+                    primary
+                    onClick={ this.handleViewRequest }
+                    size='mini'
+                  />
+                </List.Content>
+                <Image avatar size='mini' verticalAlign='middle'>
+                  <IdentityIcon
+                    address={ request.payload.sendTransaction.from }
+                  />
+                </Image>
+                <List.Content>
+                  <List.Header>
+                    <FormattedMessage
+                      id='application.status.signerPendingSignerRequest'
+                      defaultMessage='Parity Signer Request'
+                    />
+                  </List.Header>
+                  <List.Description className={ styles.listDescription }>
+                    <FormattedMessage
+                      id='application.status.signerPendingSending'
+                      defaultMessage='Sending {etherValue} to'
+                      values={ {
+                        etherValue: this.renderEtherValue(
+                          request.payload.sendTransaction.value
+                        )
+                      } }
+                    />
+                    <IdentityIcon
+                      tiny
+                      address={ request.payload.sendTransaction.to }
+                      className={ styles.toAvatar }
+                    />
+                  </List.Description>
+                </List.Content>
+              </List.Item>
+            ))}
+          </List>
+        ) : (
+          <Container textAlign='center' fluid className={ styles.noRequest }>
+            <FormattedMessage
+              id='application.status.signerPendingNoRequest'
+              defaultMessage='You have no pending requests.'
+            />
+          </Container>
+        )}
+    </div>
+  );
 
   render () {
     return (
@@ -78,82 +152,23 @@ class SignerPending extends Component {
         wide='very'
         trigger={
           <div className={ [styles.signerPending].join(' ') }>
-            <Icon name={ this.store.pending.length > 0 ? 'bell' : 'bell outline' } />
-            {this.store.pending.length > 0 &&
-              <Label floating color='red' size='mini' circular className={ styles.label }>
+            <Icon
+              name={ this.store.pending.length > 0 ? 'bell' : 'bell outline' }
+            />
+            {this.store.pending.length > 0 && (
+              <Label
+                floating
+                color='red'
+                size='mini'
+                circular
+                className={ styles.label }
+              >
                 {this.store.pending.length}
               </Label>
-            }
+            )}
           </div>
         }
-        content={
-          <div>
-            <Header
-              as='h5'
-              content={
-                <FormattedMessage
-                  id='application.status.signerPendingTitle'
-                  defaultMessage='Authorization Requests'
-                />
-              }
-            />
-            {this.store.pending.length > 0
-              ? (
-                <List divided relaxed='very'>
-                  {this.store.pending.map(request =>
-                    <List.Item key={ request.id.toNumber() }>
-                      <List.Content floated='right'>
-                        <Button
-                          icon='unlock alternate'
-                          content={
-                            <FormattedMessage
-                              id='application.status.signerPendingView'
-                              defaultMessage='View'
-                            />
-                          }
-                          primary
-                          onClick={ this.handleViewRequest }
-                          size='mini'
-                        />
-                      </List.Content>
-                      <Image avatar size='mini' verticalAlign='middle'>
-                        <IdentityIcon
-                          address={ request.payload.sendTransaction.from }
-                        />
-                      </Image>
-                      <List.Content>
-                        <List.Header>
-                          <FormattedMessage
-                            id='application.status.signerPendingSignerRequest'
-                            defaultMessage='Parity Signer Request'
-                          />
-                        </List.Header>
-                        <List.Description className={ styles.listDescription }>
-                          <FormattedMessage
-                            id='application.status.signerPendingSending'
-                            defaultMessage='Sending {etherValue} to'
-                            values={ { etherValue: this.renderEtherValue(request.payload.sendTransaction.value) } }
-                          />
-                          <IdentityIcon
-                            tiny
-                            address={ request.payload.sendTransaction.to }
-                            className={ styles.toAvatar }
-                          />
-                        </List.Description>
-                      </List.Content>
-                    </List.Item>)
-                  }
-                </List>
-              ) : (
-                <Container textAlign='center' fluid className={ styles.noRequest }>
-                  <FormattedMessage
-                    id='application.status.signerPendingNoRequest'
-                    defaultMessage='You have no pending requests.'
-                  />
-                </Container>
-              )}
-          </div>
-        }
+        content={ this.renderPopupContent() }
         offset={ 8 } // Empirically looks better
         on='click'
         hideOnScroll

--- a/js/src/Status/SignerPending/signerPending.js
+++ b/js/src/Status/SignerPending/signerPending.js
@@ -21,6 +21,7 @@ import { FormattedMessage } from 'react-intl';
 
 import IdentityIcon from '@parity/ui/lib/IdentityIcon';
 import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
+import Container from 'semantic-ui-react/dist/commonjs/elements/Container';
 import Header from 'semantic-ui-react/dist/commonjs/elements/Header';
 import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon';
 import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
@@ -34,9 +35,7 @@ import styles from './signerPending.css';
 
 @observer
 class SignerPending extends Component {
-  static propTypes = {
-
-  }
+  static propTypes = {}
 
   static contextTypes = {
     api: PropTypes.object.isRequired
@@ -79,7 +78,7 @@ class SignerPending extends Component {
         wide='very'
         trigger={
           <div className={ [styles.signerPending].join(' ') }>
-            <Icon name='lock' />
+            <Icon name={ this.store.pending.length > 0 ? 'bell' : 'bell outline' } />
             {this.store.pending.length > 0 &&
               <Label floating color='red' size='mini' circular className={ styles.label }>
                 {this.store.pending.length}
@@ -99,51 +98,61 @@ class SignerPending extends Component {
                 />
               }
             />
-            <List divided relaxed='very'>
-              {this.store.pending.map(request =>
-                <List.Item key={ request.id.toNumber() }>
-                  <List.Content floated='right'>
-                    <Button
-                      icon='unlock alternate'
-                      content={
-                        <FormattedMessage
-                          id='application.status.signerPendingView'
-                          defaultMessage='View'
+            {this.store.pending.length > 0
+              ? (
+                <List divided relaxed='very'>
+                  {this.store.pending.map(request =>
+                    <List.Item key={ request.id.toNumber() }>
+                      <List.Content floated='right'>
+                        <Button
+                          icon='unlock alternate'
+                          content={
+                            <FormattedMessage
+                              id='application.status.signerPendingView'
+                              defaultMessage='View'
+                            />
+                          }
+                          primary
+                          onClick={ this.handleViewRequest }
+                          size='mini'
                         />
-                      }
-                      primary
-                      onClick={ this.handleViewRequest }
-                      size='mini'
-                    />
-                  </List.Content>
-                  <Image avatar size='mini' verticalAlign='middle'>
-                    <IdentityIcon
-                      address={ request.payload.sendTransaction.from }
-                    />
-                  </Image>
-                  <List.Content>
-                    <List.Header>
-                      <FormattedMessage
-                        id='application.status.signerPendingSignerRequest'
-                        defaultMessage='Parity Signer Request'
-                      />
-                    </List.Header>
-                    <List.Description className={ styles.listDescription }>
-                      <FormattedMessage
-                        id='application.status.signerPendingSending'
-                        defaultMessage='Sending {etherValue} to'
-                        values={ { etherValue: this.renderEtherValue(request.payload.sendTransaction.value) } }
-                      />
-                      <IdentityIcon
-                        tiny
-                        address={ request.payload.sendTransaction.to }
-                        className={ styles.toAvatar }
-                      />
-                    </List.Description>
-                  </List.Content>
-                </List.Item>)
-              }
-            </List>
+                      </List.Content>
+                      <Image avatar size='mini' verticalAlign='middle'>
+                        <IdentityIcon
+                          address={ request.payload.sendTransaction.from }
+                        />
+                      </Image>
+                      <List.Content>
+                        <List.Header>
+                          <FormattedMessage
+                            id='application.status.signerPendingSignerRequest'
+                            defaultMessage='Parity Signer Request'
+                          />
+                        </List.Header>
+                        <List.Description className={ styles.listDescription }>
+                          <FormattedMessage
+                            id='application.status.signerPendingSending'
+                            defaultMessage='Sending {etherValue} to'
+                            values={ { etherValue: this.renderEtherValue(request.payload.sendTransaction.value) } }
+                          />
+                          <IdentityIcon
+                            tiny
+                            address={ request.payload.sendTransaction.to }
+                            className={ styles.toAvatar }
+                          />
+                        </List.Description>
+                      </List.Content>
+                    </List.Item>)
+                  }
+                </List>
+              ) : (
+                <Container textAlign='center' fluid className={ styles.noRequest }>
+                  <FormattedMessage
+                    id='application.status.signerPendingNoRequest'
+                    defaultMessage='You have no pending requests.'
+                  />
+                </Container>
+              )}
           </div>
         }
         offset={ 8 } // Empirically looks better

--- a/js/src/Status/SignerPending/signerPending.js
+++ b/js/src/Status/SignerPending/signerPending.js
@@ -90,7 +90,6 @@ class SignerPending extends Component {
           <div>
             <Header
               as='h5'
-              icon='lock'
               content={
                 <FormattedMessage
                   id='application.status.signerPendingTitle'

--- a/js/src/Status/SignerPending/signerPending.js
+++ b/js/src/Status/SignerPending/signerPending.js
@@ -1,0 +1,161 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import IdentityIcon from '@parity/ui/lib/IdentityIcon';
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button';
+import Header from 'semantic-ui-react/dist/commonjs/elements/Header';
+import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon';
+import Image from 'semantic-ui-react/dist/commonjs/elements/Image';
+import Label from 'semantic-ui-react/dist/commonjs/elements/Label';
+import List from 'semantic-ui-react/dist/commonjs/elements/List';
+import Popup from 'semantic-ui-react/dist/commonjs/modules/Popup';
+
+import Store from './store';
+import ParityBarStore from '../../ParityBar/store';
+import styles from './signerPending.css';
+
+@observer
+class SignerPending extends Component {
+  static propTypes = {
+
+  }
+
+  static contextTypes = {
+    api: PropTypes.object.isRequired
+  }
+
+  state = {
+    isOpen: false
+  }
+
+  store = Store.get(this.context.api)
+  parityBarStore = ParityBarStore.get();
+
+  handleViewRequest = () => {
+    this.parityBarStore.toggleOpenSigner();
+    this.handleClose();
+  }
+
+  handleOpen = () => {
+    this.setState({ isOpen: true });
+  }
+
+  handleClose = () => {
+    this.setState({ isOpen: false });
+  }
+
+  renderEtherValue (value) {
+    const { api } = this.context;
+    const ether = api.util.fromWei(value);
+
+    return (
+      <span>
+        {ether.toFormat(5)}<small> ETH</small>
+      </span>
+    );
+  }
+
+  render () {
+    return (
+      <Popup
+        wide='very'
+        trigger={
+          <div className={ [styles.signerPending].join(' ') }>
+            <Icon name='lock' />
+            {this.store.pending.length > 0 &&
+              <Label floating color='red' size='mini' circular className={ styles.label }>
+                {this.store.pending.length}
+              </Label>
+            }
+          </div>
+        }
+        content={
+          <div>
+            <Header
+              as='h5'
+              icon='lock'
+              content={
+                <FormattedMessage
+                  id='application.status.signerPendingTitle'
+                  defaultMessage='Authorization Requests'
+                />
+              }
+            />
+            <List divided relaxed='very'>
+              {this.store.pending.map(request =>
+                <List.Item key={ request.id.toNumber() }>
+                  <List.Content floated='right'>
+                    <Button
+                      icon='unlock alternate'
+                      content={
+                        <FormattedMessage
+                          id='application.status.signerPendingView'
+                          defaultMessage='View'
+                        />
+                      }
+                      primary
+                      onClick={ this.handleViewRequest }
+                      size='mini'
+                    />
+                  </List.Content>
+                  <Image avatar size='mini' verticalAlign='middle'>
+                    <IdentityIcon
+                      address={ request.payload.sendTransaction.from }
+                    />
+                  </Image>
+                  <List.Content>
+                    <List.Header>
+                      <FormattedMessage
+                        id='application.status.signerPendingSignerRequest'
+                        defaultMessage='Parity Signer Request'
+                      />
+                    </List.Header>
+                    <List.Description className={ styles.listDescription }>
+                      <FormattedMessage
+                        id='application.status.signerPendingSending'
+                        defaultMessage='Sending {etherValue} to'
+                        values={ { etherValue: this.renderEtherValue(request.payload.sendTransaction.value) } }
+                      />
+                      <IdentityIcon
+                        tiny
+                        address={ request.payload.sendTransaction.to }
+                        className={ styles.toAvatar }
+                      />
+                    </List.Description>
+                  </List.Content>
+                </List.Item>)
+              }
+            </List>
+          </div>
+        }
+        offset={ 8 } // Empirically looks better
+        on='click'
+        hideOnScroll
+        open={ this.state.isOpen }
+        onClose={ this.handleClose }
+        onOpen={ this.handleOpen }
+        position='bottom right'
+      />
+    );
+  }
+}
+
+export default SignerPending;

--- a/js/src/Status/SignerPending/store.js
+++ b/js/src/Status/SignerPending/store.js
@@ -1,0 +1,50 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { action, observable } from 'mobx';
+
+let instance;
+
+export default class Store {
+  @observable pending = [];
+
+  constructor (api) {
+    this._api = api;
+    this.startSubscription();
+  }
+
+  @action setPending = (pending = []) => {
+    this.pending = pending;
+  }
+
+  startSubscription () {
+    this._api.subscribe('signer_requestsToConfirm', (error, pending) => {
+      if (error) {
+        return;
+      }
+
+      this.setPending(pending);
+    });
+  }
+
+  static get (api) {
+    if (!instance) {
+      instance = new Store(api);
+    }
+
+    return instance;
+  }
+}

--- a/js/src/Status/status.css
+++ b/js/src/Status/status.css
@@ -75,10 +75,6 @@ $textColor: #ccc;
     opacity: 0.75;
   }
 
-  .signerPending {
-    cursor: pointer;
-  }
-
   .health {
     > span {
       margin: -0.5rem 0 0.2rem 0 !important;

--- a/js/src/Status/status.js
+++ b/js/src/Status/status.js
@@ -25,21 +25,19 @@ import GradientBg from '@parity/ui/lib/GradientBg';
 import { HomeIcon } from '@parity/ui/lib/Icons';
 import NetChain from '@parity/ui/lib/NetChain';
 import NetPeers from '@parity/ui/lib/NetPeers';
-import SignerPending from '@parity/ui/lib/SignerPending';
 import StatusIndicator from '@parity/ui/lib/StatusIndicator';
 
 import Consensus from './Consensus';
 import DefaultAccount from './DefaultAccount';
 import AccountStore from '../ParityBar/accountStore';
-import ParityBarStore from '../ParityBar/store';
 import SyncWarning from '../SyncWarning';
 import PluginStore from './pluginStore';
+import SignerPending from './SignerPending';
 import Upgrade from './Upgrade';
 
 import styles from './status.css';
 
 const pluginStore = PluginStore.get();
-const parityBarStore = ParityBarStore.get();
 
 function Status ({ className = '', upgradeStore }, { api }) {
   const accountStore = AccountStore.get(api);
@@ -63,10 +61,6 @@ function Status ({ className = '', upgradeStore }, { api }) {
               ))
             }
             <div className={ styles.divider } />
-            <SignerPending
-              className={ styles.signerPending }
-              onClick={ parityBarStore.toggleOpenSigner }
-            />
 
             <DefaultAccount
               accountStore={ accountStore }
@@ -75,6 +69,8 @@ function Status ({ className = '', upgradeStore }, { api }) {
               className={ styles.health }
               id='application.status.health'
             />
+            <SignerPending />
+
             <div className={ styles.divider } />
             <BlockNumber
               className={ styles.blockNumber }


### PR DESCRIPTION
Fix #7192. Red label was not comprehensible to drive users to action, so introducing a more classic notification UX.

![screen shot 2017-12-05 at 12 53 03 pm](https://user-images.githubusercontent.com/1293565/33605887-cd0722a8-d9bb-11e7-8cf6-a27af3b16459.png)

![screen shot 2017-12-05 at 12 52 43 pm](https://user-images.githubusercontent.com/1293565/33605892-d08c1a64-d9bb-11e7-9df6-bc036a7774b0.png)

"View" button opens the Signer as before.