### PR TITLE
Don't display unneeded notifications

### DIFF
--- a/js/src/ParityBar/parityBar.css
+++ b/js/src/ParityBar/parityBar.css
@@ -110,7 +110,7 @@ $modalZ: 10001;
   width: 960px;
 
   .content {
-    background: rgba(255, 255, 255, 0.95);
+    background: #f2f2f2;
     display: flex;
     flex: 1;
     max-width: calc(100vw - 2em);

--- a/js/src/Requests/requests.js
+++ b/js/src/Requests/requests.js
@@ -66,6 +66,12 @@ class Requests extends Component {
       return null;
     }
 
+    const status = this.renderStatus(request);
+
+    if (!status) {
+      return null;
+    }
+
     const state = this.getTransactionState(request);
     const displayedTransaction = { ...transaction };
 
@@ -103,7 +109,7 @@ class Requests extends Component {
         style={ requestStyle }
       >
         <div className={ statusClasses.join(' ') }>
-          { this.renderStatus(request) }
+          { status }
         </div>
         {
           state.type === ERROR_STATE
@@ -193,12 +199,7 @@ class Requests extends Component {
       );
     }
 
-    return (
-      <FormattedMessage
-        id='requests.status.waitingForSigner'
-        defaultMessage='Waiting for authorization in the Parity Signer'
-      />
-    );
+    return null;
   }
 
   getTransactionState (request) {

--- a/js/src/Signer/PendingItem/pendingItem.css
+++ b/js/src/Signer/PendingItem/pendingItem.css
@@ -16,7 +16,10 @@
 */
 
 .request {
+  margin-left: -1.5em;
+  padding-left: 1.5em;
+
   &:nth-child(even) {
-    background: rgba(0, 0, 0, 0.04);
+    background: #eee;
   }
 }


### PR DESCRIPTION
Closes https://github.com/paritytech/parity/issues/7227

1. Don't show the status "Waiting on signer" (notifications already visible)
2. Cleanup signer transparency (less clutter)