### PR TITLE
Reduce max block timestamp drift to 15 seconds

### DIFF
--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -646,8 +646,14 @@ mod tests {
 		check_fail_timestamp(basic_test(&create_test_block_with_data(&header, &good_transactions, &good_uncles), engine));
 
 		header = good.clone();
-		header.set_timestamp(get_time().sec as u64 + 40);
+		header.set_timestamp(get_time().sec as u64 + 20);
 		check_fail_timestamp(basic_test(&create_test_block_with_data(&header, &good_transactions, &good_uncles), engine));
+
+		header = good.clone();
+		header.set_timestamp(get_time().sec as u64 + 10);
+		header.set_uncles_hash(good_uncles_hash.clone());
+		header.set_transactions_root(good_transactions_root.clone());
+		check_ok(basic_test(&create_test_block_with_data(&header, &good_transactions, &good_uncles), engine));
 
 		header = good.clone();
 		header.set_number(9);

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -273,7 +273,7 @@ pub fn verify_header_params(header: &Header, engine: &EthEngine, is_full: bool) 
 	}
 
 	if is_full {
-		let max_time = get_time().sec as u64 + 30;
+		let max_time = get_time().sec as u64 + 15;
 		if header.timestamp() > max_time {
 			return Err(From::from(BlockError::InvalidTimestamp(OutOfBounds { max: Some(max_time), min: None, found: header.timestamp() })))
 		}


### PR DESCRIPTION
Reduce the current max block timestamp drift from 30 seconds to 15 seconds.