### PR TITLE
[stable] Backports + HF block update

### DIFF
--- a/ethcore/res/ethereum/kovan.json
+++ b/ethcore/res/ethereum/kovan.json
@@ -27,7 +27,7 @@
         "validateScoreTransition": 1000000,
         "eip155Transition": 1000000,
         "validateStepTransition": 1500000,
-        "maximumUncleCountTransition": 5100000,
+        "maximumUncleCountTransition": 5067000,
         "maximumUncleCount": 0
 	  }
     }
@@ -37,10 +37,10 @@
     "minGasLimit": "0x1388",
     "networkID" : "0x2A",
     "validateReceiptsTransition" : 1000000,
-    "eip140Transition": 5100000,
-    "eip211Transition": 5100000,
-    "eip214Transition": 5100000,
-    "eip658Transition": 5100000
+    "eip140Transition": 5067000,
+    "eip211Transition": 5067000,
+    "eip214Transition": 5067000,
+    "eip658Transition": 5067000
   },
   "genesis": {
     "seal": {
@@ -57,10 +57,10 @@
     "0x0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
 	"0x0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
 	"0x0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
-	"0x0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": 5100000, "pricing": { "modexp": { "divisor": 20 } } } },
-	"0x0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": 5100000, "pricing": { "linear": { "base": 500, "word": 0 } } } },
-	"0x0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": 5100000, "pricing": { "linear": { "base": 40000, "word": 0 } } } },
-	"0x0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": 5100000, "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } },
+	"0x0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": 5067000, "pricing": { "modexp": { "divisor": 20 } } } },
+	"0x0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": 5067000, "pricing": { "linear": { "base": 500, "word": 0 } } } },
+	"0x0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": 5067000, "pricing": { "linear": { "base": 40000, "word": 0 } } } },
+	"0x0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": 5067000, "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } },
     "0x00521965e7bd230323c423d96c657db5b79d099f": { "balance": "1606938044258990275541962092341162602522202993782792835301376" }
   },
   "nodes": [

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -230,7 +230,7 @@ pub fn verify_header_params(header: &Header, engine: &Engine, is_full: bool) -> 
 		return Err(From::from(BlockError::ExtraDataOutOfBounds(OutOfBounds { min: None, max: Some(maximum_extra_data_size), found: header.extra_data().len() })));
 	}
 	if is_full {
-		let max_time = get_time().sec as u64 + 30;
+		let max_time = get_time().sec as u64 + 15;
 		if header.timestamp() > max_time {
 			return Err(From::from(BlockError::InvalidTimestamp(OutOfBounds { max: Some(max_time), min: None, found: header.timestamp() })))
 		}
@@ -564,8 +564,14 @@ mod tests {
 		check_fail_timestamp(basic_test(&create_test_block_with_data(&header, &good_transactions, &good_uncles), engine));
 
 		header = good.clone();
-		header.set_timestamp(get_time().sec as u64 + 40);
+		header.set_timestamp(get_time().sec as u64 + 20);
 		check_fail_timestamp(basic_test(&create_test_block_with_data(&header, &good_transactions, &good_uncles), engine));
+
+		header = good.clone();
+		header.set_timestamp(get_time().sec as u64 + 10);
+		header.set_uncles_hash(good_uncles_hash.clone());
+		header.set_transactions_root(good_transactions_root.clone());
+		check_ok(basic_test(&create_test_block_with_data(&header, &good_transactions, &good_uncles), engine));
 
 		header = good.clone();
 		header.set_number(9);


### PR DESCRIPTION
* reduce max block timestamp drift to 15 seconds

* add test for block timestamp validation within allowed drift