### PR TITLE
detect different node, same-key signing in aura

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -486,13 +486,6 @@ impl Engine<EthereumMachine> for AuthorityRound {
 
 		let step = self.step.load();
 
-		// this is guarded against by `can_propose` unless the block was signed
-		// on the same step (implies same key) and on a different node.
-		if parent_step == step.into() {
-			warn!("Attempted to seal block on the same step as parent. Is this authority sealing with more than one node?");
-			return Seal::None;
-		}
-
 		let expected_diff = calculate_score(parent_step, step.into());
 
 		if header.difficulty() != &expected_diff {
@@ -525,6 +518,13 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		};
 
 		if is_step_proposer(validators, header.parent_hash(), step, header.author()) {
+			// this is guarded against by `can_propose` unless the block was signed
+			// on the same step (implies same key) and on a different node.
+			if parent_step == step.into() {
+				warn!("Attempted to seal block on the same step as parent. Is this authority sealing with more than one node?");
+				return Seal::None;
+			}
+
 			if let Ok(signature) = self.sign(header.bare_hash()) {
 				trace!(target: "engine", "generate_seal: Issuing a block for step {}.", step);
 


### PR DESCRIPTION
To add a helpful warning message after confusing a few of us :) 