### PR TITLE
Statically link the C runtime on Windows

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[target.x86_64-pc-windows-msvc]
+# Link the C runtime statically ; https://github.com/paritytech/parity/issues/6643
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/nsis/installer.nsi
+++ b/nsis/installer.nsi
@@ -92,10 +92,6 @@ section "install"
 	file /oname=ptray.exe ..\windows\ptray\x64\Release\ptray.exe
 
 	file "logo.ico"
-	file vc_redist.x64.exe
-
-	ExecWait '"$INSTDIR\vc_redist.x64.exe"  /passive /norestart'
-	delete $INSTDIR\vc_redist.x64.exe
 	# Add any other files for the install directory (license files, app data, etc) here
 
 	# Uninstaller - See function un.onInit and section "uninstall" for configuration


### PR DESCRIPTION
Embed the C runtime inside Parity instead of linking dynamically.
Without this option, the user has to install the MSVC redistributable packages.

Untested, but I'm confident that it should fix #6643 
