### PR TITLE
Tiny Keccak Fuzzing Harness

### DIFF
--- a/util/hash/fuzz/.gitignore
+++ b/util/hash/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/util/hash/fuzz/Cargo.toml
+++ b/util/hash/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "keccak-hash-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.keccak-hash]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "keccak"
+path = "fuzz_targets/keccak.rs"

--- a/util/hash/fuzz/Cargo.toml
+++ b/util/hash/fuzz/Cargo.toml
@@ -1,8 +1,9 @@
-
 [package]
+description = "Tiny Keccak Fuzzing Harness"
+license = "GPL-3.0"
 name = "keccak-hash-fuzz"
 version = "0.0.1"
-authors = ["Automatically generated"]
+authors = ["Parity Technologies <admin@parity.io>", "Cole Lightfighter <cole@parity.io"]
 publish = false
 
 [package.metadata]

--- a/util/hash/fuzz/fuzz_targets/keccak.rs
+++ b/util/hash/fuzz/fuzz_targets/keccak.rs
@@ -1,8 +1,14 @@
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate keccak_hash;
-use keccak_hash::keccak;
+use keccak_hash::{keccak, keccak_256, keccak_512};
 
 fuzz_target!(|data: &[u8]| {
     keccak(data);
+    unsafe {
+        let mut data_m: Vec<u8> = Vec::with_capacity(data.len());
+        data_m.extend_from_slice(data);
+        keccak_256(data_m.as_mut_slice().as_mut_ptr(), data_m.len(), data.as_ptr(), data.len());
+        keccak_512(data_m.as_mut_slice().as_mut_ptr(), data_m.len(), data.as_ptr(), data.len());
+    }
 });

--- a/util/hash/fuzz/fuzz_targets/keccak.rs
+++ b/util/hash/fuzz/fuzz_targets/keccak.rs
@@ -1,0 +1,8 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate keccak_hash;
+use keccak_hash::keccak;
+
+fuzz_target!(|data: &[u8]| {
+    keccak(data);
+});

--- a/util/hash/fuzz/fuzz_targets/keccak.rs
+++ b/util/hash/fuzz/fuzz_targets/keccak.rs
@@ -1,3 +1,19 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate keccak_hash;


### PR DESCRIPTION
Simple fuzzing harness for the `tiny-keccak` functions exposed by `util/hash`.

Can be added to CI builds on changes to `util/hash`, or run manually:

```
rustup install nightly
cargo install cargo-fuzz
cd parity/util/hash
rustup run nightly cargo fuzz run keccak [-- -max_runs=<n>] # if you want limited runs
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paritytech/parity/7301)
<!-- Reviewable:end -->
