### PR TITLE
Fix double initialization of embeded providers.

### DIFF
--- a/js/src/embed.js
+++ b/js/src/embed.js
@@ -66,6 +66,8 @@ class FrameSecureApi extends SecureApi {
       () => transport,
       () => 'http:'
     );
+
+    this._isConnected = false;
   }
 
   connect () {
@@ -73,6 +75,7 @@ class FrameSecureApi extends SecureApi {
     this.emit('connecting');
     // Fire connected event with some delay.
     setTimeout(() => {
+      this._isConnected = true;
       this.emit('connected');
     });
   }
@@ -86,7 +89,7 @@ class FrameSecureApi extends SecureApi {
   }
 
   isConnected () {
-    return true;
+    return this._isConnected;
   }
 }
 

--- a/js/webpack/app.js
+++ b/js/webpack/app.js
@@ -53,7 +53,7 @@ module.exports = {
   cache: !isProd,
   devtool: isProd
     ? false
-    : '#eval',
+    : isEmbed ? '#source-map' : '#eval',
   context: path.join(__dirname, '../src'),
   entry,
   output: {


### PR DESCRIPTION
First initialization happened because of `isConnected === true`, second on `connected` event.