### PR TITLE
SecretStore: return error 404 when there's no key shares for given key on all nodes

### DIFF
--- a/secret_store/src/types/all.rs
+++ b/secret_store/src/types/all.rs
@@ -136,6 +136,7 @@ impl From<key_server_cluster::Error> for Error {
 	fn from(err: key_server_cluster::Error) -> Self {
 		match err {
 			key_server_cluster::Error::AccessDenied => Error::AccessDenied,
+			key_server_cluster::Error::MissingKeyShare => Error::DocumentNotFound,
 			_ => Error::Internal(err.into()),
 		}
 	}


### PR DESCRIPTION
The same behavior was there before `KeyVersionNegotiationSession` was introduced: return HTTP 404 error when trying to restore the key before it was generated.
By @grbIzl requrest