### PR TITLE
SecretStore: secretstore_signRawHash method

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -450,7 +450,7 @@ usage! {
 			"--jsonrpc-interface=[IP]",
 			"Specify the hostname portion of the JSONRPC API server, IP should be an interface's IP address, or all (all interfaces) or local.",
 
-			ARG arg_jsonrpc_apis: (String) = "web3,eth,pubsub,net,parity,parity_pubsub,traces,rpc,secretstore,shh,shh_pubsub", or |c: &Config| otry!(c.rpc).apis.as_ref().map(|vec| vec.join(",")),
+			ARG arg_jsonrpc_apis: (String) = "web3,eth,pubsub,net,parity,parity_pubsub,traces,rpc,shh,shh_pubsub", or |c: &Config| otry!(c.rpc).apis.as_ref().map(|vec| vec.join(",")),
 			"--jsonrpc-apis=[APIS]",
 			"Specify the APIs available through the JSONRPC interface. APIS is a comma-delimited list of API name. Possible name are all, safe, web3, eth, net, personal, parity, parity_set, traces, rpc, parity_accounts. You can also disable a specific API by putting '-' in the front: all,-personal.",
 
@@ -483,7 +483,7 @@ usage! {
 			"--ws-interface=[IP]",
 			"Specify the hostname portion of the WebSockets server, IP should be an interface's IP address, or all (all interfaces) or local.",
 
-			ARG arg_ws_apis: (String) = "web3,eth,pubsub,net,parity,parity_pubsub,traces,rpc,secretstore,shh,shh_pubsub", or |c: &Config| otry!(c.websockets).apis.as_ref().map(|vec| vec.join(",")),
+			ARG arg_ws_apis: (String) = "web3,eth,pubsub,net,parity,parity_pubsub,traces,rpc,shh,shh_pubsub", or |c: &Config| otry!(c.websockets).apis.as_ref().map(|vec| vec.join(",")),
 			"--ws-apis=[APIS]",
 			"Specify the APIs available through the WebSockets interface. APIS is a comma-delimited list of API name. Possible name are web3, eth, pubsub, net, personal, parity, parity_set, traces, rpc, parity_accounts..",
 
@@ -504,7 +504,7 @@ usage! {
 			"--ipc-path=[PATH]",
 			"Specify custom path for JSON-RPC over IPC service.",
 
-			ARG arg_ipc_apis: (String) = "web3,eth,pubsub,net,parity,parity_pubsub,parity_accounts,traces,rpc,secretstore,shh,shh_pubsub", or |c: &Config| otry!(c.ipc).apis.as_ref().map(|vec| vec.join(",")),
+			ARG arg_ipc_apis: (String) = "web3,eth,pubsub,net,parity,parity_pubsub,parity_accounts,traces,rpc,shh,shh_pubsub", or |c: &Config| otry!(c.ipc).apis.as_ref().map(|vec| vec.join(",")),
 			"--ipc-apis=[APIS]",
 			"Specify custom API set available via JSON-RPC over IPC.",
 

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -66,7 +66,7 @@ pub enum Api {
 	Traces,
 	/// Rpc (Safe)
 	Rpc,
-	/// SecretStore (Safe)
+	/// SecretStore (UNSAFE: arbitrary hash signing)
 	SecretStore,
 	/// Whisper (Safe)
 	// TODO: _if_ someone guesses someone else's key or filter IDs they can remove
@@ -602,7 +602,6 @@ impl ApiSet {
 			Api::EthPubSub,
 			Api::Parity,
 			Api::Rpc,
-			Api::SecretStore,
 			Api::Whisper,
 			Api::WhisperPubSub,
 		].into_iter().cloned().collect();
@@ -627,6 +626,7 @@ impl ApiSet {
 				public_list.insert(Api::ParityAccounts);
 				public_list.insert(Api::ParitySet);
 				public_list.insert(Api::Signer);
+				public_list.insert(Api::SecretStore);
 				public_list
 			},
 			ApiSet::All => {
@@ -636,6 +636,7 @@ impl ApiSet {
 				public_list.insert(Api::ParitySet);
 				public_list.insert(Api::Signer);
 				public_list.insert(Api::Personal);
+				public_list.insert(Api::SecretStore);
 				public_list
 			},
 			ApiSet::PubSub => [
@@ -686,7 +687,7 @@ mod test {
 	fn test_api_set_unsafe_context() {
 		let expected = vec![
 			// make sure this list contains only SAFE methods
-			Api::Web3, Api::Net, Api::Eth, Api::EthPubSub, Api::Parity, Api::ParityPubSub, Api::Traces, Api::Rpc, Api::SecretStore, Api::Whisper, Api::WhisperPubSub,
+			Api::Web3, Api::Net, Api::Eth, Api::EthPubSub, Api::Parity, Api::ParityPubSub, Api::Traces, Api::Rpc, Api::Whisper, Api::WhisperPubSub,
 		].into_iter().collect();
 		assert_eq!(ApiSet::UnsafeContext.list_apis(), expected);
 	}
@@ -695,7 +696,7 @@ mod test {
 	fn test_api_set_ipc_context() {
 		let expected = vec![
 			// safe
-			Api::Web3, Api::Net, Api::Eth, Api::EthPubSub, Api::Parity, Api::ParityPubSub, Api::Traces, Api::Rpc, Api::SecretStore, Api::Whisper, Api::WhisperPubSub,
+			Api::Web3, Api::Net, Api::Eth, Api::EthPubSub, Api::Parity, Api::ParityPubSub, Api::Traces, Api::Rpc, Api::Whisper, Api::WhisperPubSub,
 			// semi-safe
 			Api::ParityAccounts
 		].into_iter().collect();
@@ -737,7 +738,7 @@ mod test {
 	#[test]
 	fn test_safe_parsing() {
 		assert_eq!("safe".parse::<ApiSet>().unwrap(), ApiSet::List(vec![
-			Api::Web3, Api::Net, Api::Eth, Api::EthPubSub, Api::Parity, Api::ParityPubSub, Api::Traces, Api::Rpc, Api::SecretStore, Api::Whisper, Api::WhisperPubSub,
+			Api::Web3, Api::Net, Api::Eth, Api::EthPubSub, Api::Parity, Api::ParityPubSub, Api::Traces, Api::Rpc, Api::Whisper, Api::WhisperPubSub,
 		].into_iter().collect()));
 	}
 }

--- a/rpc/src/v1/impls/secretstore.rs
+++ b/rpc/src/v1/impls/secretstore.rs
@@ -28,7 +28,7 @@ use v1::helpers::errors;
 use v1::helpers::accounts::unwrap_provider;
 use v1::helpers::secretstore::{encrypt_document, decrypt_document, decrypt_document_with_shadow, ordered_servers_keccak};
 use v1::traits::SecretStore;
-use v1::types::{H160, H512, Bytes};
+use v1::types::{H160, H256, H512, Bytes};
 
 /// Parity implementation.
 pub struct SecretStoreClient {
@@ -84,12 +84,15 @@ impl SecretStore for SecretStoreClient {
 			.map(Into::into)
 	}
 
-	fn sign_servers_set(&self, address: H160, password: String, servers_set: BTreeSet<H512>) -> Result<Bytes> {
-		let servers_set_keccak_value = ordered_servers_keccak(servers_set);
+	fn servers_set_hash(&self, servers_set: BTreeSet<H512>) -> Result<H256> {
+		Ok(ordered_servers_keccak(servers_set))
+	}
+
+	fn sign_raw_hash(&self, address: H160, password: String, raw_hash: H256) -> Result<Bytes> {
 		let store = self.account_provider()?;
 		store
-			.sign(address.into(), Some(password), servers_set_keccak_value.into())
+			.sign(address.into(), Some(password), raw_hash.into())
 			.map(|s| Bytes::new((*s).to_vec()))
-			.map_err(|e| errors::account("Could not sign servers set.", e))
+			.map_err(|e| errors::account("Could not sign raw hash.", e))
 	}
 }

--- a/rpc/src/v1/traits/secretstore.rs
+++ b/rpc/src/v1/traits/secretstore.rs
@@ -19,7 +19,7 @@
 use std::collections::BTreeSet;
 use jsonrpc_core::Result;
 
-use v1::types::{H160, H512, Bytes};
+use v1::types::{H160, H256, H512, Bytes};
 
 build_rpc_trait! {
 	/// Parity-specific rpc interface.
@@ -39,9 +39,16 @@ build_rpc_trait! {
 		#[rpc(name = "secretstore_shadowDecrypt")]
 		fn shadow_decrypt(&self, H160, String, H512, H512, Vec<Bytes>, Bytes) -> Result<Bytes>;
 
-		/// Sign servers set for use in ServersSetChange session.
-		/// Arguments: `account`, `password`, `servers_set`.
-		#[rpc(name = "secretstore_signServersSet")]
-		fn sign_servers_set(&self, H160, String, BTreeSet<H512>) -> Result<Bytes>;
+		/// Calculates the hash (keccak256) of servers set for using in ServersSetChange session.
+		/// Returned hash must be signed later by using `secretstore_signRawHash` method.
+		/// Arguments: `servers_set`.
+		#[rpc(name = "secretstore_serversSetHash")]
+		fn servers_set_hash(&self, BTreeSet<H512>) -> Result<H256>;
+
+		/// Generate recoverable ECDSA signature of raw hash.
+		/// Passed hash is treated as an input to the `sign` function (no prefixes added, no hash function is applied).
+		/// Arguments: `account`, `password`, `raw_hash`.
+		#[rpc(name = "secretstore_signRawHash")]
+		fn sign_raw_hash(&self, H160, String, H256) -> Result<Bytes>;
 	}
 }


### PR DESCRIPTION
closes #7248 

Overview:
1) added `secretstore_signRawHash` method
2) renamed `secretstore_signServersSet` (semantics is changed also)
3) marked `secretstore` API set as unsafe, because it now allows to sign any passed raw hash (without prepending with the prefix && without applying hash function)

`secretstore_signRawHash` can now be used to sign the server key id, which was initially intended to be a `keccak256(document_contents)`. It also should be used to sign the servers set hash after calling the `secretstore_serversSetHash` method.