### PR TITLE
Fix broken flex modal layouts

### DIFF
--- a/js-old/src/ui/AccountCard/accountCard.css
+++ b/js-old/src/ui/AccountCard/accountCard.css
@@ -20,7 +20,6 @@
   background-color: rgba(0, 0, 0, 0.8);
   display: flex;
   flex-direction: row;
-  height: 100%;
   overflow: hidden;
   transition: transform ease-out 0.1s;
   transform: scale(1);

--- a/js-old/src/ui/Form/AddressSelect/addressSelect.css
+++ b/js-old/src/ui/Form/AddressSelect/addressSelect.css
@@ -105,9 +105,7 @@
 }
 
 .inputContainer {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
+  justify-content: flex-start;
 
   .input {
     font-size: 1.5em;
@@ -134,8 +132,6 @@
 }
 
 .category {
-  display: flex;
-  flex-direction: column;
   margin: 0 0.5em;
   max-width: 35em;
 
@@ -149,11 +145,7 @@
   }
 
   .cards {
-    flex: 1;
     overflow: auto;
-
-    display: flex;
-    flex-direction: column;
 
     margin: 1em 0;
   }

--- a/js-old/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js-old/src/ui/Form/AddressSelect/addressSelect.js
@@ -335,7 +335,7 @@ class AddressSelect extends Component {
 
       content = (
         <div className={ styles.cards }>
-          <div>{ cards }</div>
+          { cards }
         </div>
       );
     }

--- a/js-old/src/ui/Portal/portal.css
+++ b/js-old/src/ui/Portal/portal.css
@@ -82,10 +82,9 @@ $popoverZ: 3600;
     /* but may well be) will scretch to non-visible areas.
     */
     &.small {
-      margin: 1.5em auto;
-      max-width: 768px;
-      position: relative;
-      width: 75%;
+      left: 50%;
+      margin: 1.5em -384px;
+      width: 768px;
     }
   }
 

--- a/js-old/src/ui/SelectionList/selectionList.css
+++ b/js-old/src/ui/SelectionList/selectionList.css
@@ -19,7 +19,6 @@
   cursor: pointer;
   display: flex;
   flex: 1;
-  height: 100%;
   position: relative;
   width: 100%;
 
@@ -29,7 +28,6 @@
   }
 
   .content {
-    height: 100%;
     width: 100%;
 
     &:hover {


### PR DESCRIPTION
Closes https://github.com/paritytech/parity/issues/7335

More fixes in relation to https://github.com/paritytech/parity/pull/7285

Small dialogs -

<img width="883" alt="parity 2017-12-20 11-25-59" src="https://user-images.githubusercontent.com/1424473/34202865-5b6e1c36-e579-11e7-816f-3b7689854c34.png">

Account selector -

<img width="709" alt="parity 2017-12-20 11-26-25" src="https://user-images.githubusercontent.com/1424473/34202881-66767b96-e579-11e7-9507-bb436b3c0d03.png">

Account creator -

<img width="633" alt="parity 2017-12-20 11-29-51" src="https://user-images.githubusercontent.com/1424473/34202890-6f192924-e579-11e7-82a0-4b55f7ed56b7.png">

