### PR TITLE
Problem: Cargo.toml file contains [project] key

### DIFF
--- a/util/bloom/Cargo.toml
+++ b/util/bloom/Cargo.toml
@@ -1,4 +1,4 @@
-[project]
+[package]
 name = "ethcore-bloom-journal"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]


### PR DESCRIPTION
This key is not recognized by some software
(like carnix).

It is also not documented in http://doc.crates.io/manifest.html

Solution: rename this key to [package]