### PR TITLE
Get rid of clippy remainings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,28 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clippy"
-version = "0.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "clippy_lints 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clippy_lints"
-version = "0.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "coco"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,7 +458,6 @@ dependencies = [
  "bloomchain 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bn 0.4.4 (git+https://github.com/paritytech/bn)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0",
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethash 1.9.0",
@@ -654,7 +631,6 @@ version = "1.9.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-bigint 0.2.1",
  "ethcore-bytes 0.1.0",
@@ -739,7 +715,6 @@ dependencies = [
 name = "ethcore-util"
 version = "1.9.0"
 dependencies = [
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
@@ -783,7 +758,6 @@ dependencies = [
 name = "ethjson"
 version = "0.1.0"
 dependencies = [
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-bigint 0.2.1",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -865,7 +839,6 @@ dependencies = [
 name = "ethsync"
 version = "1.9.0"
 dependencies = [
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.9.0",
  "ethcore-bigint 0.2.1",
@@ -1756,11 +1729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "ntp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,7 +1896,6 @@ dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)",
  "daemonize 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1996,7 +1963,6 @@ name = "parity-dapps"
 version = "1.9.0"
 dependencies = [
  "base32 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-bigint 0.2.1",
  "ethcore-bytes 0.1.0",
@@ -2032,7 +1998,6 @@ name = "parity-dapps-glue"
 version = "1.9.1"
 dependencies = [
  "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2130,7 +2095,6 @@ version = "1.9.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethash 1.9.0",
  "ethcore 1.9.0",
  "ethcore-bigint 0.2.1",
@@ -2559,11 +2523,6 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "quine-mc_cluskey"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,11 +2581,6 @@ dependencies = [
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -2855,14 +2809,6 @@ version = "0.1.0"
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "semver"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "semver"
@@ -3278,14 +3224,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -3615,8 +3553,6 @@ dependencies = [
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "34aa7da06f10541fbca6850719cdaa8fa03060a5d2fb33840f149cf8133a00c7"
 "checksum clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3451e409013178663435d6f15fdb212f14ee4424a3d74f979d081d0a66b6f1f2"
-"checksum clippy 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "5b4fabf979ddf6419a313c1c0ada4a5b95cfd2049c56e8418d622d27b4b6ff32"
-"checksum clippy_lints 0.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "ce96ec05bfe018a0d5d43da115e54850ea2217981ff0f2e462780ab9d594651a"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum cookie 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d53b80dde876f47f03cda35303e368a79b91c70b0d65ecba5fd5280944a08591"
@@ -3710,7 +3646,6 @@ dependencies = [
 "checksum native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04b781c9134a954c84f0594b9ab3f5606abc516030388e8511887ef4c204a1e5"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
-"checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum ntp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "143149743832c6543b60a8ef2a26cd9122dfecec2b767158e852a7beecf6d7a0"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
 "checksum num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8fd0f8dbb4c0960998958a796281d88c16fbe68d87b1baa6f31e2979e81fd0bd"
@@ -3756,7 +3691,6 @@ dependencies = [
 "checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
 "checksum quasi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29cec87bc2816766d7e4168302d505dd06b0a825aed41b00633d296e922e02dd"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
-"checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
@@ -3764,7 +3698,6 @@ dependencies = [
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
-"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum reqwest 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5866613d84e2a39c0479a960bf2d0eff1fbfc934f02cd42b5c08c1e1efc5b1fd"
 "checksum ring 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "24293de46bac74c9b9c05b40ff8496bbc8b9ae242a9b89f754e1154a43bc7c4c"
@@ -3787,7 +3720,6 @@ dependencies = [
 "checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d5b7638a1f03815d94e88cb3b3c08e87f0db4d683ef499d1836aaf70a45623f"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
@@ -3835,7 +3767,6 @@ dependencies = [
 "checksum tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
 "checksum tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d88e411cac1c87e405e4090be004493c5d8072a370661033b1a64ea205ec2e13"
 "checksum tokio-uds 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6116c71be48f8f1656551fd16458247fdd6c03201d7893ad81189055fcde03e8"
-"checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum transient-hashmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "715254c8f0811be1a79ad3ea5e6fa3c8eddec2b03d7f5ba78cf093e56d79c24f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ kvdb-rocksdb = { path = "util/kvdb-rocksdb" }
 journaldb = { path = "util/journaldb" }
 
 parity-dapps = { path = "dapps", optional = true }
-clippy = { version = "0.0.103", optional = true}
 ethcore-secretstore = { path = "secret_store", optional = true }
 
 [build-dependencies]
@@ -94,7 +93,6 @@ ui-precompiled = [
 ui-enabled = ["dapps"]
 dapps = ["parity-dapps"]
 jit = ["ethcore/jit"]
-dev = ["clippy", "ethcore/dev", "ethcore-util/dev", "ethsync/dev", "parity-rpc/dev", "parity-dapps/dev"]
 json-tests = ["ethcore/json-tests"]
 test-heavy = ["ethcore/test-heavy"]
 evm-debug = ["ethcore/evm-debug"]

--- a/dapps/Cargo.toml
+++ b/dapps/Cargo.toml
@@ -38,14 +38,10 @@ parity-reactor = { path = "../util/reactor" }
 parity-ui = { path = "./ui" }
 keccak-hash = { path = "../util/hash" }
 
-clippy = { version = "0.0.103", optional = true}
-
 [dev-dependencies]
 env_logger = "0.4"
 ethcore-devtools = { path = "../devtools" }
 
 [features]
-dev = ["clippy", "ethcore-util/dev"]
-
 ui = ["parity-ui/no-precompiled-js"]
 ui-precompiled = ["parity-ui/use-precompiled-js"]

--- a/dapps/js-glue/Cargo.toml
+++ b/dapps/js-glue/Cargo.toml
@@ -18,13 +18,10 @@ quasi = { version = "0.32", default-features = false }
 quasi_macros = { version = "0.32", optional = true }
 syntex = { version = "0.58", optional = true }
 syntex_syntax = { version = "0.58", optional = true }
-clippy = { version = "0.0.103", optional = true }
 
 [features]
-dev = ["clippy"]
 default = ["with-syntex"]
 nightly = ["quasi_macros"]
-nightly-testing = ["clippy"]
 with-syntex = ["quasi/with-syntex", "quasi_codegen", "quasi_codegen/with-syntex", "syntex", "syntex_syntax"]
 use-precompiled-js = []
 

--- a/dapps/src/lib.rs
+++ b/dapps/src/lib.rs
@@ -16,8 +16,6 @@
 
 //! Ethcore Webapplications for Parity
 #![warn(missing_docs)]
-#![cfg_attr(feature="nightly", feature(plugin))]
-#![cfg_attr(feature="nightly", plugin(clippy))]
 
 extern crate base32;
 extern crate futures_cpupool;

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -11,7 +11,6 @@ ansi_term = "0.9"
 bloomchain = "0.1"
 bn = { git = "https://github.com/paritytech/bn" }
 byteorder = "1.0"
-clippy = { version = "0.0.103", optional = true}
 common-types = { path = "types" }
 crossbeam = "0.2.9"
 ethash = { path = "../ethash" }
@@ -83,6 +82,5 @@ evm-debug-tests = ["evm-debug"]
 slow-blocks = [] # Use SLOW_TX_DURATION="50" (compile time!) to track transactions over 50ms
 json-tests = []
 test-heavy = []
-dev = ["clippy"]
 default = []
 benches = []

--- a/ethcore/evm/src/interpreter/gasometer.rs
+++ b/ethcore/evm/src/interpreter/gasometer.rs
@@ -32,7 +32,6 @@ macro_rules! overflowing {
 	}}
 }
 
-#[cfg_attr(feature="dev", allow(enum_variant_names))]
 enum Request<Cost: ::evm::CostType> {
 	Gas(Cost),
 	GasMem(Cost, Cost),
@@ -101,7 +100,6 @@ impl<Gas: evm::CostType> Gasometer<Gas> {
 		}
 	}
 
-	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
 	/// Determine how much gas is used by the given instruction, given the machine's state.
 	///
 	/// We guarantee that the final element of the returned tuple (`provided`) will be `Some`

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -66,7 +66,6 @@ struct CodeReader<'a> {
 	code: &'a [u8]
 }
 
-#[cfg_attr(feature="dev", allow(len_without_is_empty))]
 impl<'a> CodeReader<'a> {
 
 	/// Create new code reader - starting at position 0.
@@ -287,7 +286,6 @@ impl<Cost: CostType> Interpreter<Cost> {
 		}
 	}
 
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	fn exec_instruction(
 		&mut self,
 		gas: Cost,

--- a/ethcore/src/basic_types.rs
+++ b/ethcore/src/basic_types.rs
@@ -22,7 +22,6 @@ pub type LogBloom = ::log_entry::LogBloom;
 /// Constant 2048-bit datum for 0. Often used as a default.
 pub static ZERO_LOGBLOOM: LogBloom = ::bigint::hash::H2048([0x00; 256]);
 
-#[cfg_attr(feature="dev", allow(enum_variant_names))]
 /// Semantic boolean for when a seal/signature is included.
 pub enum Seal {
 	/// The seal/signature is included.

--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -301,7 +301,6 @@ pub struct SealedBlock {
 }
 
 impl<'x> OpenBlock<'x> {
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	/// Create a new `OpenBlock` ready for transaction pushing.
 	pub fn new(
 		engine: &'x EthEngine,
@@ -614,7 +613,6 @@ impl IsBlock for SealedBlock {
 }
 
 /// Enact the block given by block header, transactions and uncles
-#[cfg_attr(feature="dev", allow(too_many_arguments))]
 pub fn enact(
 	header: &Header,
 	transactions: &[SignedTransaction],
@@ -688,7 +686,6 @@ fn push_transactions(block: &mut OpenBlock, transactions: &[SignedTransaction]) 
 
 // TODO [ToDr] Pass `PreverifiedBlock` by move, this will avoid unecessary allocation
 /// Enact the block given by `block_bytes` using `engine` on the database `db` with given `parent` block header
-#[cfg_attr(feature="dev", allow(too_many_arguments))]
 pub fn enact_verified(
 	block: &PreverifiedBlock,
 	engine: &EthEngine,
@@ -731,7 +728,6 @@ mod tests {
 	use transaction::SignedTransaction;
 
 	/// Enact the block given by `block_bytes` using `engine` on the database `db` with given `parent` block header
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	fn enact_bytes(
 		block_bytes: &[u8],
 		engine: &EthEngine,
@@ -778,7 +774,6 @@ mod tests {
 	}
 
 	/// Enact the block given by `block_bytes` using `engine` on the database `db` with given `parent` block header. Seal the block aferwards
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	fn enact_and_seal(
 		block_bytes: &[u8],
 		engine: &EthEngine,

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -970,7 +970,6 @@ impl BlockChain {
 		self.cache_man.lock().note_used(CacheId::BlockDetails(block_hash));
 	}
 
-	#[cfg_attr(feature="dev", allow(similar_names))]
 	/// Inserts the block into backing cache database.
 	/// Expects the block to be valid and already verified.
 	/// If the block is already known, does nothing.
@@ -1475,7 +1474,6 @@ impl BlockChain {
 
 #[cfg(test)]
 mod tests {
-	#![cfg_attr(feature="dev", allow(similar_names))]
 	use std::sync::Arc;
 	use rustc_hex::FromHex;
 	use hash::keccak;
@@ -1583,7 +1581,6 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
 	fn test_find_uncles() {
 		let mut canon_chain = ChainGenerator::default();
 		let mut finalizer = BlockFinalizer::default();
@@ -1793,7 +1790,6 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
 	fn test_small_fork() {
 		let mut canon_chain = ChainGenerator::default();
 		let mut finalizer = BlockFinalizer::default();

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -336,7 +336,6 @@ impl Engine<EthereumMachine> for Arc<Ethash> {
 	}
 }
 
-#[cfg_attr(feature="dev", allow(wrong_self_convention))]
 impl Ethash {
 	fn calculate_difficulty(&self, header: &Header, parent: &Header) -> U256 {
 		const EXP_DIFF_PERIOD: u64 = 100_000;

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -85,7 +85,6 @@ impl<'a, T: 'a, V: 'a, B: 'a> Externalities<'a, T, V, B>
 	where T: Tracer, V: VMTracer, B: StateBackend
 {
 	/// Basic `Externalities` constructor.
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	pub fn new(state: &'a mut State<B>,
 		env_info: &'a EnvInfo,
 		machine: &'a Machine,
@@ -302,7 +301,6 @@ impl<'a, T: 'a, V: 'a, B: 'a> Ext for Externalities<'a, T, V, B>
 		Ok(self.state.code_size(address)?.unwrap_or(0))
 	}
 
-	#[cfg_attr(feature="dev", allow(match_ref_pats))]
 	fn ret(mut self, gas: &U256, data: &ReturnData, apply_state: bool) -> vm::Result<U256>
 		where Self: Sized {
 		let handle_copy = |to: &mut Option<&mut Bytes>| {

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -16,23 +16,6 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(feature="benches", feature(test))]
-#![cfg_attr(feature="dev", feature(plugin))]
-#![cfg_attr(feature="dev", plugin(clippy))]
-
-// Clippy settings
-// Most of the time much more readable
-#![cfg_attr(feature="dev", allow(needless_range_loop))]
-// Shorter than if-else
-#![cfg_attr(feature="dev", allow(match_bool))]
-// Keeps consistency (all lines with `.clone()`).
-#![cfg_attr(feature="dev", allow(clone_on_copy))]
-// Complains on Box<E> when implementing From<Box<E>>
-#![cfg_attr(feature="dev", allow(boxed_local))]
-// Complains about nested modules with same name as parent
-#![cfg_attr(feature="dev", allow(module_inception))]
-// TODO [todr] a lot of warnings to be fixed
-#![cfg_attr(feature="dev", allow(assign_op_pattern))]
-
 
 //! Ethcore library
 //!

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -366,7 +366,6 @@ impl Miner {
 		)
 	}
 
-	#[cfg_attr(feature="dev", allow(match_same_arms))]
 	/// Prepares new block for sealing including top transactions from queue.
 	fn prepare_block(&self, chain: &MiningBlockChainClient) -> (ClosedBlock, Option<H256>) {
 		let _timer = PerfTimer::new("prepare_block");
@@ -708,8 +707,6 @@ impl Miner {
 	/// Are we allowed to do a non-mandatory reseal?
 	fn tx_reseal_allowed(&self) -> bool { Instant::now() > *self.next_allowed_reseal.lock() }
 
-	#[cfg_attr(feature="dev", allow(wrong_self_convention))]
-	#[cfg_attr(feature="dev", allow(redundant_closure))]
 	fn from_pending_block<H, F, G>(&self, latest_block_number: BlockNumber, from_chain: F, map_block: G) -> H
 		where F: Fn() -> H, G: FnOnce(&ClosedBlock) -> H {
 		let sealing_work = self.sealing_work.lock();
@@ -869,7 +866,6 @@ impl MinerService for Miner {
 		results
 	}
 
-	#[cfg_attr(feature="dev", allow(collapsible_if))]
 	fn import_own_transaction(
 		&self,
 		chain: &MiningBlockChainClient,

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -15,8 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
-#![cfg_attr(all(nightly, feature="dev"), feature(plugin))]
-#![cfg_attr(all(nightly, feature="dev"), plugin(clippy))]
 
 //! Miner module
 //! Keeps track of transactions and mined block.

--- a/ethcore/src/miner/transaction_queue.rs
+++ b/ethcore/src/miner/transaction_queue.rs
@@ -136,7 +136,6 @@ impl PartialOrd for TransactionOrigin {
 }
 
 impl Ord for TransactionOrigin {
-	#[cfg_attr(feature="dev", allow(match_same_arms))]
 	fn cmp(&self, other: &TransactionOrigin) -> Ordering {
 		if *other == *self {
 			return Ordering::Equal;
@@ -516,7 +515,6 @@ pub struct AccountDetails {
 const GAS_PRICE_BUMP_SHIFT: usize = 3; // 2 = 25%, 3 = 12.5%, 4 = 6.25%
 
 /// Describes the strategy used to prioritize transactions in the queue.
-#[cfg_attr(feature="dev", allow(enum_variant_names))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PrioritizationStrategy {
 	/// Use only gas price. Disregards the actual computation cost of the transaction.

--- a/ethcore/src/service.rs
+++ b/ethcore/src/service.rs
@@ -186,7 +186,6 @@ impl IoHandler<ClientIoMessage> for ClientIoHandler {
 		}
 	}
 
-	#[cfg_attr(feature="dev", allow(single_match))]
 	fn message(&self, _io: &IoContext<ClientIoMessage>, net_message: &ClientIoMessage) {
 		use std::thread;
 

--- a/ethcore/src/snapshot/tests/helpers.rs
+++ b/ethcore/src/snapshot/tests/helpers.rs
@@ -57,7 +57,6 @@ impl StateProducer {
 		}
 	}
 
-	#[cfg_attr(feature="dev", allow(let_and_return))]
 	/// Tick the state producer. This alters the state, writing new data into
 	/// the database.
 	pub fn tick<R: Rng>(&mut self, rng: &mut R, db: &mut HashDB) {

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -604,7 +604,6 @@ impl<B: Backend> State<B> {
 	}
 
 	/// Add `incr` to the balance of account `a`.
-	#[cfg_attr(feature="dev", allow(single_match))]
 	pub fn add_balance(&mut self, a: &Address, incr: &U256, cleanup_mode: CleanupMode) -> trie::Result<()> {
 		trace!(target: "state", "add_balance({}, {}): {}", a, incr, self.balance(a)?);
 		let is_value_transfer = !incr.is_zero();
@@ -744,8 +743,6 @@ impl<B: Backend> State<B> {
 	}
 
 	/// Commits our cached account changes into the trie.
-	#[cfg_attr(feature="dev", allow(match_ref_pats))]
-	#[cfg_attr(feature="dev", allow(needless_borrow))]
 	pub fn commit(&mut self) -> Result<(), Error> {
 		// first, commit the sub trees.
 		let mut accounts = self.cache.borrow_mut();

--- a/ethcore/src/state/substate.rs
+++ b/ethcore/src/state/substate.rs
@@ -58,7 +58,6 @@ impl Substate {
 	}
 
 	/// Get the cleanup mode object from this.
-	#[cfg_attr(feature="dev", allow(wrong_self_convention))]
 	pub fn to_cleanup_mode(&mut self, schedule: &Schedule) -> CleanupMode {
 		match (schedule.kill_dust != CleanDustMode::Off, schedule.no_empty, schedule.kill_empty) {
 			(false, false, _) => CleanupMode::ForceCreate,

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -427,7 +427,6 @@ impl state::Backend for StateDB {
 		cache.accounts.get_mut(addr).map(|a| a.as_ref().map(|a| a.clone_basic()))
 	}
 
-	#[cfg_attr(feature="dev", allow(map_clone))]
 	fn get_cached_code(&self, hash: &H256) -> Option<Arc<Vec<u8>>> {
 		let mut cache = self.code_cache.lock();
 

--- a/ethcore/src/trace/db.rs
+++ b/ethcore/src/trace/db.rs
@@ -34,7 +34,6 @@ use cache_manager::CacheManager;
 const TRACE_DB_VER: &'static [u8] = b"1.0";
 
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature="dev", allow(enum_variant_names))]
 enum TraceDBIndex {
 	/// Block traces index.
 	BlockTraces = 0,

--- a/ethcore/src/verification/queue/mod.rs
+++ b/ethcore/src/verification/queue/mod.rs
@@ -164,7 +164,6 @@ struct QueueSignal {
 }
 
 impl QueueSignal {
-	#[cfg_attr(feature="dev", allow(bool_comparison))]
 	fn set_sync(&self) {
 		// Do not signal when we are about to close
 		if self.deleting.load(AtomicOrdering::Relaxed) {
@@ -179,7 +178,6 @@ impl QueueSignal {
 		}
 	}
 
-	#[cfg_attr(feature="dev", allow(bool_comparison))]
 	fn set_async(&self) {
 		// Do not signal when we are about to close
 		if self.deleting.load(AtomicOrdering::Relaxed) {

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -498,7 +498,6 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(feature="dev", allow(similar_names))]
 	fn test_verify_block() {
 		use rlp::RlpStream;
 

--- a/ethcore/vm/src/ext.rs
+++ b/ethcore/vm/src/ext.rs
@@ -96,7 +96,6 @@ pub trait Ext {
 	/// Returns Err, if we run out of gas.
 	/// Otherwise returns call_result which contains gas left
 	/// and true if subcall was successfull.
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	fn call(&mut self,
 		gas: &U256,
 		sender_address: &Address,

--- a/ethcrypto/src/lib.rs
+++ b/ethcrypto/src/lib.rs
@@ -174,7 +174,6 @@ pub mod aes {
 }
 
 /// ECDH functions
-#[cfg_attr(feature="dev", allow(similar_names))]
 pub mod ecdh {
 	use secp256k1::{ecdh, key, Error as SecpError};
 	use ethkey::{Secret, Public, SECP256K1};
@@ -199,7 +198,6 @@ pub mod ecdh {
 }
 
 /// ECIES function
-#[cfg_attr(feature="dev", allow(similar_names))]
 pub mod ecies {
 	use rcrypto::digest::Digest;
 	use rcrypto::sha2::Sha256;

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -9,5 +9,4 @@ rustc-hex = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-clippy = { version = "0.0.103", optional = true}
 

--- a/parity/helpers.rs
+++ b/parity/helpers.rs
@@ -217,7 +217,6 @@ pub fn default_network_config() -> ::ethsync::NetworkConfiguration {
 	}
 }
 
-#[cfg_attr(feature = "dev", allow(too_many_arguments))]
 pub fn to_client_config(
 		cache_config: &CacheConfig,
 		spec_name: String,
@@ -453,7 +452,6 @@ but the first password is trimmed
 	}
 
 	#[test]
-	#[cfg_attr(feature = "dev", allow(float_cmp))]
 	fn test_to_price() {
 		assert_eq!(to_price("1").unwrap(), 1.0);
 		assert_eq!(to_price("2.3").unwrap(), 2.3);

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -252,7 +252,6 @@ impl<T: InformantData> Informant<T> {
 		self.in_shutdown.store(true, ::std::sync::atomic::Ordering::SeqCst);
 	}
 
-	#[cfg_attr(feature="dev", allow(match_bool))]
 	pub fn tick(&self) {
 		let elapsed = self.last_tick.read().elapsed();
 		if elapsed < Duration::from_secs(5) {

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -17,10 +17,6 @@
 //! Ethcore client application.
 
 #![warn(missing_docs)]
-#![cfg_attr(feature="dev", feature(plugin))]
-#![cfg_attr(feature="dev", plugin(clippy))]
-#![cfg_attr(feature="dev", allow(useless_format))]
-#![cfg_attr(feature="dev", allow(match_bool))]
 
 extern crate ansi_term;
 extern crate app_dirs;

--- a/parity/upgrade.rs
+++ b/parity/upgrade.rs
@@ -27,7 +27,6 @@ use dir::{DatabaseDirectories, default_data_path};
 use helpers::replace_home;
 use journaldb::Algorithm;
 
-#[cfg_attr(feature="dev", allow(enum_variant_names))]
 #[derive(Debug)]
 pub enum Error {
 	CannotCreateConfigPath,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -60,13 +60,8 @@ vm = { path = "../ethcore/vm" }
 keccak-hash = { path = "../util/hash" }
 hardware-wallet = { path = "../hw" }
 
-clippy = { version = "0.0.103", optional = true}
-
 [dev-dependencies]
 pretty_assertions = "0.1"
 macros = { path = "../util/macros" }
 ethcore-network = { path = "../util/network" }
 kvdb-memorydb = { path = "../util/kvdb-memorydb" }
-
-[features]
-dev = ["clippy", "ethcore/dev", "ethcore-util/dev", "ethsync/dev"]

--- a/rpc/src/authcodes.rs
+++ b/rpc/src/authcodes.rs
@@ -83,7 +83,6 @@ pub struct AuthCodes<T: TimeProvider = DefaultTimeProvider> {
 impl AuthCodes<DefaultTimeProvider> {
 
 	/// Reads `AuthCodes` from file and creates new instance using `DefaultTimeProvider`.
-	#[cfg_attr(feature="dev", allow(single_char_pattern))]
 	pub fn from_file(file: &Path) -> io::Result<AuthCodes> {
 		let content = {
 			if let Ok(mut file) = fs::File::open(file) {
@@ -154,7 +153,6 @@ impl<T: TimeProvider> AuthCodes<T> {
 
 	/// Checks if given hash is correct authcode of `SignerUI`
 	/// Updates this hash last used field in case it's valid.
-	#[cfg_attr(feature="dev", allow(wrong_self_convention))]
 	pub fn is_valid(&mut self, hash: &H256, time: u64) -> bool {
 		let now = self.now.now();
 		// check time

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -17,8 +17,6 @@
 //! Parity RPC.
 
 #![warn(missing_docs)]
-#![cfg_attr(feature="dev", feature(plugin))]
-#![cfg_attr(feature="dev", plugin(clippy))]
 
 #[macro_use]
 extern crate futures;

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -20,7 +20,6 @@ keccak-hash = { path = "../util/hash" }
 triehash = { path = "../util/triehash" }
 kvdb = { path = "../util/kvdb" }
 macros = { path = "../util/macros" }
-clippy = { version = "0.0.103", optional = true}
 log = "0.3"
 env_logger = "0.4"
 time = "0.1.34"
@@ -34,7 +33,3 @@ ipnetwork = "0.12.6"
 [dev-dependencies]
 ethkey = { path = "../ethkey" }
 kvdb-memorydb = { path = "../util/kvdb-memorydb" }
-
-[features]
-default = []
-dev = ["clippy", "ethcore/dev", "ethcore-util/dev"]

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -469,7 +469,6 @@ impl ChainSync {
 		self.peers.clear();
 	}
 
-	#[cfg_attr(feature="dev", allow(for_kv_map))] // Because it's not possible to get `values_mut()`
 	/// Reset sync. Clear all downloaded data but keep the queue
 	fn reset(&mut self, io: &mut SyncIo) {
 		self.new_blocks.reset();
@@ -672,7 +671,6 @@ impl ChainSync {
 		Ok(())
 	}
 
-	#[cfg_attr(feature="dev", allow(cyclomatic_complexity, needless_borrow))]
 	/// Called by peer once it has new block headers during sync
 	fn on_peer_block_headers(&mut self, io: &mut SyncIo, peer_id: PeerId, r: &UntrustedRlp) -> Result<(), PacketDecodeError> {
 		let confirmed = match self.peers.get_mut(&peer_id) {
@@ -883,7 +881,6 @@ impl ChainSync {
 	}
 
 	/// Called by peer once it has new block bodies
-	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
 	fn on_peer_new_block(&mut self, io: &mut SyncIo, peer_id: PeerId, r: &UntrustedRlp) -> Result<(), PacketDecodeError> {
 		if !self.peers.get(&peer_id).map_or(false, |p| p.can_sync()) {
 			trace!(target: "sync", "Ignoring new block from unconfirmed peer {}", peer_id);
@@ -1333,7 +1330,6 @@ impl ChainSync {
 	}
 
 	/// Checks if there are blocks fully downloaded that can be imported into the blockchain and does the import.
-	#[cfg_attr(feature="dev", allow(block_in_if_condition_stmt))]
 	fn collect_blocks(&mut self, io: &mut SyncIo, block_set: BlockSet) {
 		match block_set {
 			BlockSet::NewBlocks => {
@@ -1353,7 +1349,6 @@ impl ChainSync {
 	}
 
 	/// Request headers from a peer by block hash
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	fn request_headers_by_hash(&mut self, sync: &mut SyncIo, peer_id: PeerId, h: &H256, count: u64, skip: u64, reverse: bool, set: BlockSet) {
 		trace!(target: "sync", "{} <- GetBlockHeaders: {} entries starting from {}, set = {:?}", peer_id, count, h, set);
 		let mut rlp = RlpStream::new_list(4);
@@ -1368,7 +1363,6 @@ impl ChainSync {
 	}
 
 	/// Request headers from a peer by block number
-	#[cfg_attr(feature="dev", allow(too_many_arguments))]
 	fn request_fork_header_by_number(&mut self, sync: &mut SyncIo, peer_id: PeerId, n: BlockNumber) {
 		trace!(target: "sync", "{} <- GetForkHeader: at {}", peer_id, n);
 		let mut rlp = RlpStream::new_list(4);
@@ -1783,7 +1777,6 @@ impl ChainSync {
 		})
 	}
 
-	#[cfg_attr(feature="dev", allow(match_same_arms))]
 	pub fn maintain_peers(&mut self, io: &mut SyncIo) {
 		let tick = time::precise_time_ns();
 		let mut aborting = Vec::new();

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -15,12 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
-#![cfg_attr(feature="dev", feature(plugin))]
-#![cfg_attr(feature="dev", plugin(clippy))]
-// Keeps consistency (all lines with `.clone()`) and helpful when changing ref to non-ref.
-#![cfg_attr(feature="dev", allow(clone_on_copy))]
-// In most cases it expresses function flow better
-#![cfg_attr(feature="dev", allow(if_not_else))]
 
 //! Blockchain sync module
 //! Implements ethereum protocol version 63 as specified here:

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -16,7 +16,6 @@ elastic-array = "0.9"
 rlp = { path = "rlp" }
 heapsize = "0.4"
 keccak-hash = { path = "hash" }
-clippy = { version = "0.0.103", optional = true}
 libc = "0.2.7"
 target_info = "0.1"
 ethcore-bigint = { path = "bigint", features = ["heapsizeof"] }
@@ -37,7 +36,6 @@ kvdb-memorydb = { path = "kvdb-memorydb" }
 
 [features]
 default = []
-dev = ["clippy"]
 final = []
 
 [build-dependencies]

--- a/util/bigint/src/hash.rs
+++ b/util/bigint/src/hash.rs
@@ -179,7 +179,6 @@ macro_rules! impl_hash {
 		}
 
 		impl Copy for $from {}
-		#[cfg_attr(feature="dev", allow(expl_impl_clone_on_copy))]
 		impl Clone for $from {
 			fn clone(&self) -> $from {
 				let mut ret = $from::new();
@@ -464,7 +463,6 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(feature="dev", allow(eq_op))]
 	fn hash() {
 		let h = H64([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
 		assert_eq!(H64::from_str("0123456789abcdef").unwrap(), h);

--- a/util/journaldb/src/archivedb.rs
+++ b/util/journaldb/src/archivedb.rs
@@ -196,8 +196,6 @@ impl JournalDB for ArchiveDB {
 
 #[cfg(test)]
 mod tests {
-	#![cfg_attr(feature="dev", allow(blacklisted_name))]
-	#![cfg_attr(feature="dev", allow(similar_names))]
 
 	use keccak::keccak;
 	use hashdb::{HashDB, DBValue};

--- a/util/journaldb/src/earlymergedb.rs
+++ b/util/journaldb/src/earlymergedb.rs
@@ -447,7 +447,6 @@ impl JournalDB for EarlyMergeDB {
 		}
 	}
 
-	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
 	fn mark_canonical(&mut self, batch: &mut DBTransaction, end_era: u64, canon_id: &H256) -> Result<u32, UtilError> {
 		let mut refs = self.refs.as_ref().unwrap().write();
 
@@ -544,8 +543,6 @@ impl JournalDB for EarlyMergeDB {
 
 #[cfg(test)]
 mod tests {
-	#![cfg_attr(feature="dev", allow(blacklisted_name))]
-	#![cfg_attr(feature="dev", allow(similar_names))]
 
 	use keccak::keccak;
 	use hashdb::{HashDB, DBValue};

--- a/util/journaldb/src/overlaydb.rs
+++ b/util/journaldb/src/overlaydb.rs
@@ -202,7 +202,6 @@ impl HashDB for OverlayDB {
 }
 
 #[test]
-#[cfg_attr(feature="dev", allow(blacklisted_name))]
 fn overlaydb_revert() {
 	let mut m = OverlayDB::new_temp();
 	let foo = m.insert(b"foo");          // insert foo.

--- a/util/journaldb/src/overlayrecentdb.rs
+++ b/util/journaldb/src/overlayrecentdb.rs
@@ -452,8 +452,6 @@ impl HashDB for OverlayRecentDB {
 
 #[cfg(test)]
 mod tests {
-	#![cfg_attr(feature="dev", allow(blacklisted_name))]
-	#![cfg_attr(feature="dev", allow(similar_names))]
 
 	use keccak::keccak;
 	use super::*;

--- a/util/journaldb/src/refcounteddb.rs
+++ b/util/journaldb/src/refcounteddb.rs
@@ -205,8 +205,6 @@ impl JournalDB for RefCountedDB {
 
 #[cfg(test)]
 mod tests {
-	#![cfg_attr(feature="dev", allow(blacklisted_name))]
-	#![cfg_attr(feature="dev", allow(similar_names))]
 
 	use keccak::keccak;
 	use hashdb::{HashDB, DBValue};

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -15,7 +15,6 @@ time = "0.1.34"
 tiny-keccak = "1.3"
 rust-crypto = "0.2.34"
 slab = "0.2"
-clippy = { version = "0.0.103", optional = true}
 igd = "0.6"
 libc = "0.2.7"
 parking_lot = "0.4"
@@ -41,4 +40,3 @@ tempdir = "0.3"
 
 [features]
 default = []
-dev = ["clippy"]

--- a/util/network/src/discovery.rs
+++ b/util/network/src/discovery.rs
@@ -281,7 +281,6 @@ impl Discovery {
 		self.send_to(packet, address.clone());
 	}
 
-	#[cfg_attr(feature="dev", allow(map_clone))]
 	fn nearest_node_entries(target: &NodeId, buckets: &[NodeBucket]) -> Vec<NodeEntry> {
 		let mut found: BTreeMap<u32, Vec<&NodeEntry>> = BTreeMap::new();
 		let mut count = 0;

--- a/util/network/src/host.rs
+++ b/util/network/src/host.rs
@@ -705,7 +705,6 @@ impl Host {
 		debug!(target: "network", "Connecting peers: {} sessions, {} pending, {} started", self.session_count(), self.handshake_count(), started);
 	}
 
-	#[cfg_attr(feature="dev", allow(single_match))]
 	fn connect_peer(&self, id: &NodeId, io: &IoContext<NetworkIoMessage>) {
 		if self.have_session(id) {
 			trace!(target: "network", "Aborted connect. Node already connected.");
@@ -744,7 +743,6 @@ impl Host {
 		}
 	}
 
-	#[cfg_attr(feature="dev", allow(block_in_if_condition_stmt))]
 	fn create_connection(&self, socket: TcpStream, id: Option<&NodeId>, io: &IoContext<NetworkIoMessage>) -> Result<(), Error> {
 		let nonce = self.info.write().next_nonce();
 		let mut sessions = self.sessions.write();
@@ -805,7 +803,6 @@ impl Host {
 		self.kill_connection(token, io, true);
 	}
 
-	#[cfg_attr(feature="dev", allow(collapsible_if))]
 	fn session_readable(&self, token: StreamToken, io: &IoContext<NetworkIoMessage>) {
 		let mut ready_data: Vec<ProtocolId> = Vec::new();
 		let mut packet_data: Vec<(ProtocolId, PacketId, Vec<u8>)> = Vec::new();

--- a/util/network/src/ip_utils.rs
+++ b/util/network/src/ip_utils.rs
@@ -365,7 +365,6 @@ fn can_map_external_address_or_fail() {
 
 #[test]
 fn ipv4_properties() {
-	#![cfg_attr(feature="dev", allow(too_many_arguments))]
 	fn check(octets: &[u8; 4], unspec: bool, loopback: bool,
 			 private: bool, link_local: bool, global: bool,
 			 multicast: bool, broadcast: bool, documentation: bool) {

--- a/util/patricia_trie/src/lib.rs
+++ b/util/patricia_trie/src/lib.rs
@@ -268,7 +268,6 @@ impl<'db> Trie for TrieKinds<'db> {
 	}
 }
 
-#[cfg_attr(feature="dev", allow(wrong_self_convention))]
 impl TrieFactory {
 	/// Creates new factory.
 	pub fn new(spec: TrieSpec) -> Self {

--- a/util/patricia_trie/src/triedb.rs
+++ b/util/patricia_trie/src/triedb.rs
@@ -57,7 +57,6 @@ pub struct TrieDB<'db> {
 	pub hash_count: usize,
 }
 
-#[cfg_attr(feature="dev", allow(wrong_self_convention))]
 impl<'db> TrieDB<'db> {
 	/// Create a new trie with the backing database `db` and `root`
 	/// Returns an error if `root` does not exist

--- a/util/patricia_trie/src/triedbmut.rs
+++ b/util/patricia_trie/src/triedbmut.rs
@@ -436,7 +436,6 @@ impl<'a> TrieDBMut<'a> {
 	}
 
 	/// the insertion inspector.
-	#[cfg_attr(feature = "dev", allow(cyclomatic_complexity))]
 	fn insert_inspector(&mut self, node: Node, partial: NibbleSlice, value: DBValue, old_val: &mut Option<DBValue>)
 		-> super::Result<InsertAction>
 	{

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -15,23 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
-#![cfg_attr(feature="dev", feature(plugin))]
-#![cfg_attr(feature="dev", plugin(clippy))]
-
-// Clippy settings
-// Most of the time much more readable
-#![cfg_attr(feature="dev", allow(needless_range_loop))]
-// Shorter than if-else
-#![cfg_attr(feature="dev", allow(match_bool))]
-// We use that to be more explicit about handled cases
-#![cfg_attr(feature="dev", allow(match_same_arms))]
-// Keeps consistency (all lines with `.clone()`).
-#![cfg_attr(feature="dev", allow(clone_on_copy))]
-// Some false positives when doing pattern matching.
-#![cfg_attr(feature="dev", allow(needless_borrow))]
-// TODO [todr] a lot of warnings to be fixed
-#![cfg_attr(feature="dev", allow(assign_op_pattern))]
-
 
 //! Ethcore-util library
 //!


### PR DESCRIPTION
We don't really use this feature any more.

I tried running clippy as cargo plugin, but unfortunatelly it failed to compile Parity on latest nightly.