### PR TITLE
Problem: sending any Whisper message fails

### DIFF
--- a/parity/whisper.rs
+++ b/parity/whisper.rs
@@ -51,7 +51,7 @@ impl PoolHandle for NetPoolHandle {
 	fn relay(&self, message: Message) -> bool {
 		let mut res = false;
 		let mut message = Some(message);
-		self.net.with_proto_context(whisper_net::PROTOCOL_ID, &mut move |ctx| {
+		self.net.with_proto_context(whisper_net::PROTOCOL_ID, &mut |ctx| {
 			if let Some(message) = message.take() {
 				res = self.handle.post_message(message, ctx);
 			}


### PR DESCRIPTION
The error is "PoW too low to compete with other messages"

This has been previously reported in #7144

Solution: prevent the move semantics

The source of the error is in PoolHandle.relay
implementation for NetPoolHandle.

Because of the move semantics, `res` variable is in fact
copied (as it implements Copy) into the closure and for
that reason, the returned result is always `false.

---

I am not sure what's the best way to cover this with a test. Any suggestions?