### PR TITLE
Store tokens with repeatable id

### DIFF
--- a/js-old/src/redux/providers/tokensActions.js
+++ b/js-old/src/redux/providers/tokensActions.js
@@ -23,7 +23,7 @@ import { fetchTokenIds, fetchTokensBasics, fetchTokensInfo, fetchTokensImages } 
 
 import { setAddressImage } from './imagesActions';
 
-const TOKENS_CACHE_LS_KEY_PREFIX = '_parity::tokens::';
+const TOKENS_CACHE_LS_KEY_PREFIX = '_parity::tokenreg::';
 const log = getLogger(LOG_KEYS.Balances);
 
 function _setTokens (tokens) {


### PR DESCRIPTION
Closes https://github.com/paritytech/parity/issues/7194

Instead of trying to get rid of the token (which is then changed by the stored value), -

1. Store the tokens with a non-changeable id
2. On invalid tokens, set the address to empty
3. empty addresses are not queried for balances
  