### PR TITLE
Show all accounts on Topbar

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -365,9 +365,9 @@
       "version": "github:paritytech/plugin-signer-qr#c16423de5b8a8f68ebd5f1e78e084fa959329a9f"
     },
     "@parity/shared": {
-      "version": "2.2.20",
-      "resolved": "https://registry.npmjs.org/@parity/shared/-/shared-2.2.20.tgz",
-      "integrity": "sha512-qOD+3TtZ9cbRSugl12VKmsjJKUfejG208Lugzfrs1irrkB3S7jHhYAYa+tkMrHafQX9MbsfpmkDT6jToh5iOIg==",
+      "version": "2.2.21",
+      "resolved": "https://registry.npmjs.org/@parity/shared/-/shared-2.2.21.tgz",
+      "integrity": "sha512-8Xuuv/SpS+lviX3xRVvh3UUMcWYrQPQvn+KkSiKofuHlVL/IlhEnLyflk5j5FgGviXwaqBxmOllTSTPQBna4Gw==",
       "requires": {
         "@parity/ledger": "2.1.2",
         "eventemitter3": "2.0.3",
@@ -419,6 +419,37 @@
             "loose-envify": "1.3.1",
             "symbol-observable": "1.1.0"
           }
+        },
+        "solc": {
+          "version": "github:ngotchac/solc-js#04eb38cc3003fba8cb3656653a7941ed36408818",
+          "requires": {
+            "memorystream": "0.3.1",
+            "require-from-string": "1.2.1",
+            "yargs": "4.8.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "4.8.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+              "requires": {
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "lodash.assign": "4.2.0",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "window-size": "0.2.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "2.4.1"
+              }
+            }
+          }
         }
       }
     },
@@ -430,7 +461,7 @@
         "@parity/api": "2.1.14",
         "@parity/etherscan": "2.1.3",
         "@parity/mobx": "1.0.4",
-        "@parity/shared": "2.2.20",
+        "@parity/shared": "2.2.21",
         "babel-runtime": "6.26.0",
         "bignumber.js": "4.1.0",
         "brace": "0.11.0",
@@ -2610,7 +2641,7 @@
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
@@ -3491,7 +3522,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -4343,9 +4374,9 @@
       }
     },
     "doctrine": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -5301,9 +5332,9 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -5363,7 +5394,7 @@
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
+        "eslint-import-resolver-node": "0.3.2",
         "eslint-module-utils": "2.1.1",
         "has": "1.0.1",
         "lodash.cond": "4.5.2",
@@ -8225,9 +8256,9 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -8729,7 +8760,7 @@
             "callsites": "2.0.0",
             "chalk": "1.1.3",
             "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
+            "is-ci": "1.1.0",
             "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
@@ -13423,7 +13454,7 @@
             "concat-stream": "1.6.0",
             "cross-spawn": "5.1.0",
             "debug": "3.1.0",
-            "doctrine": "2.0.2",
+            "doctrine": "2.1.0",
             "eslint-scope": "3.7.1",
             "espree": "3.5.2",
             "esquery": "1.0.0",
@@ -13490,7 +13521,7 @@
           "integrity": "sha512-tvjU9u3VqmW2vVuYnE8Qptq+6ji4JltjOjJ9u7VAOxVYkUkyBZWRvNYKbDv5fN+L6wiA+4we9+qQahZ0m63XEA==",
           "dev": true,
           "requires": {
-            "doctrine": "2.0.2",
+            "doctrine": "2.1.0",
             "has": "1.0.1",
             "jsx-ast-utils": "2.0.1",
             "prop-types": "15.5.10"
@@ -13683,7 +13714,7 @@
           "dev": true,
           "requires": {
             "loader-utils": "1.1.0",
-            "postcss": "6.0.14",
+            "postcss": "6.0.16",
             "postcss-load-config": "1.2.0",
             "schema-utils": "0.3.0"
           },
@@ -13697,6 +13728,17 @@
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
                 "supports-color": "4.5.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "4.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                  "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
               }
             },
             "has-flag": {
@@ -13706,14 +13748,14 @@
               "dev": true
             },
             "postcss": {
-              "version": "6.0.14",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-              "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+              "version": "6.0.16",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+              "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
               "dev": true,
               "requires": {
                 "chalk": "2.3.0",
                 "source-map": "0.6.1",
-                "supports-color": "4.5.0"
+                "supports-color": "5.1.0"
               }
             },
             "source-map": {
@@ -13723,9 +13765,9 @@
               "dev": true
             },
             "supports-color": {
-              "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+              "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
               "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
@@ -14202,7 +14244,7 @@
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
       "requires": {
@@ -16093,7 +16135,7 @@
       "requires": {
         "del": "2.2.2",
         "sw-precache": "5.2.0",
-        "uglify-js": "3.2.2"
+        "uglify-js": "3.3.5"
       },
       "dependencies": {
         "source-map": {
@@ -16103,9 +16145,9 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
-          "integrity": "sha512-++1NO/zZIEdWf6cDIGceSJQPX31SqIpbVAHwFG5+240MtZqPG/NIPoinj8zlXQtAfMBqEt1Jyv2FiLP3n9gVhQ==",
+          "version": "3.3.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.5.tgz",
+          "integrity": "sha512-ZebM2kgBL/UI9rKeAbsS2J0UPPv7SBy5hJNZml/YxB1zC6JK8IztcPs+cxilE4pu0li6vadVSFqiO7xFTKuSrg==",
           "dev": true,
           "requires": {
             "commander": "2.12.2",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -44,10 +44,6 @@
       "version": "github:paritytech/dapp-console#7dc791af2943ddc949ec501726dc36161279eac1",
       "dev": true
     },
-    "@parity/dapp-dapp-accounts": {
-      "version": "github:paritytech/dapp-dapp-accounts#47384068f07331f0a843a6f609bd048955dac041",
-      "dev": true
-    },
     "@parity/dapp-dapp-methods": {
       "version": "github:js-dist-paritytech/dapp-dapp-methods#b4dce52a09303fddf55172bb0d2e6bb83f12e196",
       "dev": true,
@@ -132,7 +128,7 @@
       }
     },
     "@parity/dapp-dapp-visible": {
-      "version": "github:js-dist-paritytech/dapp-dapp-visible#2621fc479b52948cbce2d468fcb7b4da51039fc9",
+      "version": "github:js-dist-paritytech/dapp-dapp-visible#19f0b7d3de7bcc9859ac5d8059e866e1f5804366",
       "dev": true,
       "requires": {
         "@parity/api": "2.1.14",

--- a/js/package.json
+++ b/js/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@parity/dapp-console": "paritytech/dapp-console",
-    "@parity/dapp-dapp-accounts": "paritytech/dapp-dapp-accounts",
     "@parity/dapp-dapp-methods": "js-dist-paritytech/dapp-dapp-methods",
     "@parity/dapp-dapp-visible": "js-dist-paritytech/dapp-dapp-visible",
     "@parity/dapp-dappreg": "paritytech/dapp-dappreg",

--- a/js/package.json
+++ b/js/package.json
@@ -147,7 +147,7 @@
     "@parity/plugin-signer-default": "paritytech/plugin-signer-default",
     "@parity/plugin-signer-hardware": "paritytech/plugin-signer-hardware",
     "@parity/plugin-signer-qr": "paritytech/plugin-signer-qr",
-    "@parity/shared": "2.2.20",
+    "@parity/shared": "2.2.21",
     "@parity/ui": "3.0.22",
     "keythereum": "1.0.2",
     "lodash.flatten": "4.4.0",

--- a/js/src/ParityBar/accountStore.js
+++ b/js/src/ParityBar/accountStore.js
@@ -23,7 +23,7 @@ export default class AccountStore {
   @observable defaultAccount = null;
   @observable isLoading = false;
 
-  whitelist = [];
+  whitelist = []; // Whitelist of account addresses visible by dapps, i.e. parity_getNewDappsAddresses
 
   constructor (api) {
     this._api = api;
@@ -33,6 +33,9 @@ export default class AccountStore {
       .then(() => this.loadAccounts());
   }
 
+  /**
+   * Accounts that are whitelisted to be shown to dapps
+   */
   @computed get accounts () {
     return this.allAccounts.filter(account => this.whitelist.includes(account.address));
   }

--- a/js/src/ParityBar/accountStore.spec.js
+++ b/js/src/ParityBar/accountStore.spec.js
@@ -42,10 +42,10 @@ describe('ParityBar/AccountStore', () => {
   });
 
   describe('@action', () => {
-    describe('setAccounts', () => {
+    describe('setAllAccounts', () => {
       it('sets the accounts', () => {
-        store.setAccounts('testing');
-        expect(store.accounts).to.equal('testing');
+        store.setAllAccounts('testing');
+        expect(store.allAccounts).to.equal('testing');
       });
     });
 
@@ -67,13 +67,13 @@ describe('ParityBar/AccountStore', () => {
   describe('operations', () => {
     describe('loadAccounts', () => {
       beforeEach(() => {
-        sinon.spy(store, 'setAccounts');
+        sinon.spy(store, 'setAllAccounts');
 
         return store.loadAccounts();
       });
 
       afterEach(() => {
-        store.setAccounts.restore();
+        store.setAllAccounts.restore();
       });
 
       it('calls into parity_getNewDappsAddresses', () => {
@@ -85,7 +85,7 @@ describe('ParityBar/AccountStore', () => {
       });
 
       it('sets the accounts', () => {
-        expect(store.setAccounts).to.have.been.called;
+        expect(store.setAllAccounts).to.have.been.called;
       });
     });
 

--- a/js/src/Status/DefaultAccount/defaultAccount.js
+++ b/js/src/Status/DefaultAccount/defaultAccount.js
@@ -50,10 +50,10 @@ class DefaultAccount extends Component {
   }
 
   render () {
-    const { accounts, defaultAccount: defaultAddress } = this.props.accountStore;
-    const defaultAccount = accounts.find(({ address }) => address === defaultAddress);
+    const { allAccounts, defaultAccount: defaultAddress } = this.props.accountStore;
+    const defaultAccount = allAccounts.find(({ address }) => address === defaultAddress);
 
-    if (!accounts || !defaultAccount) { return null; }
+    if (!allAccounts || !defaultAccount) { return null; }
 
     return (
       <Popup
@@ -68,15 +68,15 @@ class DefaultAccount extends Component {
         }
         content={
           <div>
-            <List relaxed='very' selection className={ [styles.list, styles.isDefault, accounts.length > 1 && styles.hasOtherAccounts].join(' ') }>
+            <List relaxed='very' selection className={ [styles.list, styles.isDefault, allAccounts.length > 1 && styles.hasOtherAccounts].join(' ') }>
               <AccountItem
                 isDefault
                 account={ defaultAccount }
               />
             </List>
-            {accounts.length > 1 &&
+            {allAccounts.length > 1 &&
               <List relaxed='very' selection className={ styles.list } divided>
-                {accounts
+                {allAccounts
                   .filter(({ address }) => address !== defaultAddress)
                   .map(account => (
                     <AccountItem


### PR DESCRIPTION
- The topbar account selector used to only show accounts from `parity_getNewDappsAddresses`. Now we show all of them.
- The updated js-shared also removes `dapp-dapp-accounts`, whose functionalities are 100% replaced by the topbar account selector.