### PR TITLE
bump to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "parity"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Parity Ethereum client"
 name = "parity"
-version = "1.9.0"
+version = "1.10.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"

--- a/mac/Parity.pkgproj
+++ b/mac/Parity.pkgproj
@@ -462,7 +462,7 @@
 				<key>OVERWRITE_PERMISSIONS</key>
 				<false/>
 				<key>VERSION</key>
-				<string>1.9.0</string>
+				<string>1.10.0</string>
 			</dict>
 			<key>UUID</key>
 			<string>2DCD5B81-7BAF-4DA1-9251-6274B089FD36</string>

--- a/nsis/installer.nsi
+++ b/nsis/installer.nsi
@@ -9,7 +9,7 @@
 !define COMPANYNAME "Parity"
 !define DESCRIPTION "Fast, light, robust Ethereum implementation"
 !define VERSIONMAJOR 1
-!define VERSIONMINOR 9
+!define VERSIONMINOR 10
 !define VERSIONBUILD 0
 !define ARGS ""
 !define FIRST_START_ARGS "--mode=passive ui"


### PR DESCRIPTION
- bumped only absolutely necessary files to `1.10.0`
- also moved current `master` to `staging` branch ([link](https://github.com/paritytech/parity/tree/staging))
