### PR TITLE
update back-references more aggressively after answering from cache

### DIFF
--- a/ethcore/light/src/on_demand/mod.rs
+++ b/ethcore/light/src/on_demand/mod.rs
@@ -90,7 +90,14 @@ impl Pending {
 			match self.requests[idx].respond_local(cache) {
 				Some(response) => {
 					self.requests.supply_response_unchecked(&response);
+
+					// update header and back-references after each from-cache
+					// response to ensure that the requests are left in a consistent
+					// state and increase the likelihood of being able to answer
+					// the next request from cache.
 					self.update_header_refs(idx, &response);
+					self.fill_unanswered();
+
 					self.responses.push(response);
 				}
 				None => break,


### PR DESCRIPTION
The issue was that answering a request places request outputs into a pool of "outputs we know about", but those outputs didn't fill unresolved inputs to later requests until a call to `fill_unanswered`. After answering a request from cache, this function was not being called and thus led to inconsistency.

Should fix #7416 

