### PR TITLE
Fix libssl1.1 package name for debian

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ linux-stable-debian:
     - stable
     - triggers
   script:
-    - export LIBSSL="libssl1.1.0 (>=1.1.0)"
+    - export LIBSSL="libssl1.1 (>=1.1.0)"
     - scripts/gitlab-build.sh x86_64-unknown-debian-gnu x86_64-unknown-linux-gnu amd64 gcc g++
   tags:
     - rust-debian

--- a/scripts/gitlab-build.sh
+++ b/scripts/gitlab-build.sh
@@ -195,8 +195,8 @@ case $BUILD_PLATFORM in
   x86_64-unknown-debian-gnu)
     STRIP_BIN="strip"
     EXT="deb"
-    LIBSSL="libssl1.1.0 (>=1.1.0)"
-    echo "Use libssl1.1.0 (>=1.1.0) for Debian builds"
+    LIBSSL="libssl1.1 (>=1.1.0)"
+    echo "Use libssl1.1 (>=1.1.0) for Debian builds"
     build
     strip_md5
     make_deb


### PR DESCRIPTION
package is actually called `libssl1.1`

    openssl is already the newest version (1.1.0f-3+deb9u1).
    The following packages have unmet dependencies:
     parity : Depends: libssl1.1.0 (>= 1.1.0) but it is not installable

---

     $ apt search libssl1.1
    Sorting... Done
    Full Text Search... Done
    libssl1.1/stable,stable,now 1.1.0f-3+deb9u1 amd64 [installed]
      Secure Sockets Layer toolkit - shared libraries
