### PR TITLE
Problem: AttachedProtocols don't get registered

### DIFF
--- a/sync/src/api.rs
+++ b/sync/src/api.rs
@@ -169,7 +169,18 @@ pub struct AttachedProtocol {
 }
 
 impl AttachedProtocol {
-	fn register(&self, _network: &NetworkService) {}
+	fn register(&self, network: &NetworkService) {
+		let res = network.register_protocol(
+			self.handler.clone(),
+			self.protocol_id,
+			self.packet_count,
+			self.versions
+		);
+
+		if let Err(e) = res {
+			warn!(target: "sync", "Error attaching protocol {:?}: {:?}", self.protocol_id, e);
+		}
+	}
 }
 
 /// EthSync initialization parameters.


### PR DESCRIPTION
I was investigating issues I am having with Whisper support. I've
enabled Whisper on a custom test network and inserted traces into
Whisper handler implementation (Network<T> and NetworkProtocolHandler
for Network<T>) and I noticed that the handler was never invoked.

After further research on this matter, I found out that
AttachedProtocol's register function does nothing:
https://github.com/paritytech/parity/blob/master/sync/src/api.rs#L172
but there was an implementation originally:
99075ad#diff-5212acb6bcea60e9804ba7b50f6fe6ec and it did the actual
expected logic of registering the protocol in the NetworkService.

However, as of 16d84f8#diff-5212acb6bcea60e9804ba7b50f6fe6ec ("finished
removing ipc") this implementation is gone and only the no-op function
is left.

Which leads me to a conclusion that in fact Whisper's handler never gets
registered in the service and therefore two nodes won't communicate
using it.

Solution: Resurrect original non-empty `AttachedProtocols.register`
implementation

Resolves #7566