### PR TITLE
Improve handling of RocksDB corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.4.5"
-source = "git+https://github.com/paritytech/rust-rocksdb#7adec2311d31387a832b0ef051472cdef906b480"
+source = "git+https://github.com/paritytech/rust-rocksdb#ecf06adf3148ab10f6f7686b724498382ff4f36e"
 dependencies = [
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2699,10 +2699,11 @@ dependencies = [
 [[package]]
 name = "rocksdb-sys"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/rust-rocksdb#7adec2311d31387a832b0ef051472cdef906b480"
+source = "git+https://github.com/paritytech/rust-rocksdb#ecf06adf3148ab10f6f7686b724498382ff4f36e"
 dependencies = [
  "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snappy-sys 0.1.0 (git+https://github.com/paritytech/rust-snappy)",
 ]
 

--- a/util/kvdb-rocksdb/src/lib.rs
+++ b/util/kvdb-rocksdb/src/lib.rs
@@ -262,7 +262,7 @@ fn mark_corruption<T, P: AsRef<Path>>(path: P, res: result::Result<T, String>) -
 	if let Err(ref s) = res {
 		if s.starts_with("Corruption:") {
 			warn!("DB corrupted: {}. Repair will be triggered on next restart", s);
-			let _ = fs::File::create(path.as_ref().join("CORRUPTED"));
+			let _ = fs::File::create(path.as_ref().join(Database::CORRUPTION_FILE_NAME));
 		}
 	}
 
@@ -274,6 +274,8 @@ fn is_corrupted(s: &str) -> bool {
 }
 
 impl Database {
+	const CORRUPTION_FILE_NAME: &'static str = "CORRUPTED";
+
 	/// Open database with default settings.
 	pub fn open_default(path: &str) -> Result<Database> {
 		Database::open(&DatabaseConfig::default(), path)
@@ -304,7 +306,7 @@ impl Database {
 		}
 
 		// attempt database repair if it has been previously marked as corrupted
-		let db_corrupted = Path::new(path).join("CORRUPTED");
+		let db_corrupted = Path::new(path).join(Database::CORRUPTION_FILE_NAME);
 		if db_corrupted.exists() {
 			warn!("DB has been previously marked as corrupted, attempting repair");
 			DB::repair(&opts, path)?;

--- a/util/kvdb-rocksdb/src/lib.rs
+++ b/util/kvdb-rocksdb/src/lib.rs
@@ -258,7 +258,7 @@ pub struct Database {
 }
 
 #[inline]
-fn mark_corruption<T, P: AsRef<Path>>(path: P, res: result::Result<T, String>) -> result::Result<T, String> {
+fn check_for_corruption<T, P: AsRef<Path>>(path: P, res: result::Result<T, String>) -> result::Result<T, String> {
 	if let Err(ref s) = res {
 		if s.starts_with("Corruption:") {
 			warn!("DB corrupted: {}. Repair will be triggered on next restart", s);
@@ -455,7 +455,7 @@ impl Database {
 					}
 				}
 
-				mark_corruption(
+				check_for_corruption(
 					&self.path,
 					db.write_opt(batch, &self.write_opts))?;
 
@@ -505,7 +505,7 @@ impl Database {
 					}
 				}
 
-				mark_corruption(
+				check_for_corruption(
 					&self.path,
 					db.write_opt(batch, &self.write_opts)).map_err(Into::into)
 			},


### PR DESCRIPTION
Fixes #6959.
Maybe fixes #7334.

When writing to RocksDB if it returns a corruption error we create a `CORRUPTED` file that will trigger a db repair when re-opening the database. Don’t know if the repair process will actually fix the corruption, even if it does it may do so at the cost of losing data and might cause random errors (e.g. we expect some data to exist in the db and it’s not there), if we see any of those in the future we can ask the users if there’s a `lost` folder in their RocksDB folder which indicates that a `DB::Repair` was run. Also added detection for corruption like #7623.