### PR TITLE
SecretStore: return HTTP 403 (access denied) if consensus is unreachable

### DIFF
--- a/secret_store/src/types/all.rs
+++ b/secret_store/src/types/all.rs
@@ -152,7 +152,8 @@ impl From<kvdb::Error> for Error {
 impl From<key_server_cluster::Error> for Error {
 	fn from(err: key_server_cluster::Error) -> Self {
 		match err {
-			key_server_cluster::Error::AccessDenied => Error::AccessDenied,
+			key_server_cluster::Error::ConsensusUnreachable
+				| key_server_cluster::Error::AccessDenied => Error::AccessDenied,
 			key_server_cluster::Error::MissingKeyShare => Error::DocumentNotFound,
 			_ => Error::Internal(err.into()),
 		}


### PR DESCRIPTION
In SS there are two similar errors - the one is `AccessDenied` and the other is `ConsensusUnreachable`. `AccessDenied` was used when it was 100% clear that access to given key for requester is prohibited && the latter when nodes haven't agreed on key access (like < t+1 have responded with OK or < t+1 nodes are online).
In HTTP response, `AccessDenied` was mapped to 403 and `ConsensusUnreachable` to 500. After this PR both are mapped to 403. I guess this is fine, because technically at this moment access is actually denied (assuming that if < t+1 are agreed upon access, it is access denied).
By @grbIzl request