### PR TITLE
Removes redundant parentheses

### DIFF
--- a/ethcore/native_contracts/src/key_server_set.rs
+++ b/ethcore/native_contracts/src/key_server_set.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Secret store Key Server set contract.
 

--- a/ethcore/native_contracts/src/peer_set.rs
+++ b/ethcore/native_contracts/src/peer_set.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Peer set contract.
 

--- a/ethcore/native_contracts/src/registry.rs
+++ b/ethcore/native_contracts/src/registry.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Registrar contract: maps names to addresses and data.
 // TODO: testing.

--- a/ethcore/native_contracts/src/secretstore_acl_storage.rs
+++ b/ethcore/native_contracts/src/secretstore_acl_storage.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Secret store ACL storage contract.
 // TODO: testing.

--- a/ethcore/native_contracts/src/secretstore_service.rs
+++ b/ethcore/native_contracts/src/secretstore_service.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Secret store service contract.
 

--- a/ethcore/native_contracts/src/service_transaction.rs
+++ b/ethcore/native_contracts/src/service_transaction.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Service transaction contract.
 // TODO: testing.

--- a/ethcore/native_contracts/src/test_contracts/validator_set.rs
+++ b/ethcore/native_contracts/src/test_contracts/validator_set.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Test validator set contract.
 

--- a/ethcore/native_contracts/src/tx_acl.rs
+++ b/ethcore/native_contracts/src/tx_acl.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Transact permissions contract.
 

--- a/ethcore/native_contracts/src/validator_set.rs
+++ b/ethcore/native_contracts/src/validator_set.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(unused_mut, unused_variables, unused_imports)]
+#![allow(unused_mut, unused_variables, unused_imports, unused_parens)]
 
 //! Validator set contract.
 // TODO: testing.

--- a/ethcrypto/src/lib.rs
+++ b/ethcrypto/src/lib.rs
@@ -225,7 +225,7 @@ pub mod ecies {
 		hasher.result(&mut mkey);
 		let ekey = &key[0..16];
 
-		let mut msg = vec![0u8; (1 + 64 + 16 + plain.len() + 32)];
+		let mut msg = vec![0u8; 1 + 64 + 16 + plain.len() + 32];
 		msg[0] = 0x04u8;
 		{
 			let msgd = &mut msg[1..];
@@ -262,7 +262,7 @@ pub mod ecies {
 		hasher.result(&mut mkey);
 		let ekey = &key[0..16];
 
-		let mut msgd = vec![0u8; (64 + plain.len())];
+		let mut msgd = vec![0u8; 64 + plain.len()];
 		{
 			r.public().copy_to(&mut msgd[0..64]);
 			let iv = H128::from_slice(&z.keccak256()[0..16]);

--- a/rpc/src/v1/impls/signing_unsafe.rs
+++ b/rpc/src/v1/impls/signing_unsafe.rs
@@ -129,7 +129,7 @@ impl<D: Dispatcher + 'static> ParitySigning for SigningUnsafeClient<D> {
 
 	fn post_transaction(&self, _: Metadata, _: RpcTransactionRequest) -> BoxFuture<RpcEither<RpcU256, RpcConfirmationResponse>> {
 		// We don't support this in non-signer mode.
-		Box::new(future::err((errors::signer_disabled())))
+		Box::new(future::err(errors::signer_disabled()))
 	}
 
 	fn check_request(&self, _: RpcU256) -> Result<Option<RpcConfirmationResponse>> {

--- a/updater/src/operations.rs
+++ b/updater/src/operations.rs
@@ -42,7 +42,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_bool().ok_or("Invalid type returned")?; r }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_bool().ok_or("Invalid type returned")?; r })
 	}
 
 	/// Auto-generated from: `{"constant":false,"inputs":[{"name":"_txid","type":"bytes32"}],"name":"rejectTransaction","outputs":[],"payable":false,"type":"function"}`
@@ -186,7 +186,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()) }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()) })
 	}
 
 	/// Auto-generated from: `{"constant":true,"inputs":[{"name":"","type":"bytes32"}],"name":"proxy","outputs":[{"name":"requiredCount","type":"uint256"},{"name":"to","type":"address"},{"name":"data","type":"bytes"},{"name":"value","type":"uint256"},{"name":"gas","type":"uint256"}],"payable":false,"type":"function"}`
@@ -222,7 +222,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_fixed_bytes().ok_or("Invalid type returned")?; ethereum_types::H256::from_slice(r.as_ref()) }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_fixed_bytes().ok_or("Invalid type returned")?; ethereum_types::H256::from_slice(r.as_ref()) })
 	}
 
 	/// Auto-generated from: `{"constant":false,"inputs":[{"name":"_txid","type":"bytes32"},{"name":"_to","type":"address"},{"name":"_data","type":"bytes"},{"name":"_value","type":"uint256"},{"name":"_gas","type":"uint256"}],"name":"proposeTransaction","outputs":[{"name":"txSuccess","type":"uint256"}],"payable":false,"type":"function"}`
@@ -234,7 +234,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()) }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()) })
 	}
 
 	/// Auto-generated from: `{"constant":true,"inputs":[],"name":"grandOwner","outputs":[{"name":"","type":"address"}],"payable":false,"type":"function"}`
@@ -246,7 +246,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_address().ok_or("Invalid type returned")?; ethereum_types::Address::from(r) }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_address().ok_or("Invalid type returned")?; ethereum_types::Address::from(r) })
 	}
 
 	/// Auto-generated from: `{"constant":false,"inputs":[{"name":"_release","type":"bytes32"},{"name":"_forkBlock","type":"uint32"},{"name":"_track","type":"uint8"},{"name":"_semver","type":"uint24"},{"name":"_critical","type":"bool"}],"name":"addRelease","outputs":[],"payable":false,"type":"function"}`
@@ -282,7 +282,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u32 }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u32 })
 	}
 
 	/// Auto-generated from: `{"constant":true,"inputs":[{"name":"_client","type":"bytes32"},{"name":"_release","type":"bytes32"}],"name":"track","outputs":[{"name":"","type":"uint8"}],"payable":false,"type":"function"}`
@@ -294,7 +294,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u8 }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u8 })
 	}
 
 	/// Auto-generated from: `{"constant":false,"inputs":[{"name":"_client","type":"bytes32"},{"name":"_r","type":"bool"}],"name":"setClientRequired","outputs":[],"payable":false,"type":"function"}`
@@ -316,7 +316,7 @@ impl Operations {
 		let data = call.encode_input(&[]).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u32 }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u32 })
 	}
 
 	/// Auto-generated from: `{"constant":true,"inputs":[{"name":"_client","type":"bytes32"},{"name":"_track","type":"uint8"}],"name":"latestInTrack","outputs":[{"name":"","type":"bytes32"}],"payable":false,"type":"function"}`
@@ -328,7 +328,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_fixed_bytes().ok_or("Invalid type returned")?; ethereum_types::H256::from_slice(r.as_ref()) }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_fixed_bytes().ok_or("Invalid type returned")?; ethereum_types::H256::from_slice(r.as_ref()) })
 	}
 
 	/// Auto-generated from: `{"constant":true,"inputs":[{"name":"_client","type":"bytes32"},{"name":"_release","type":"bytes32"},{"name":"_platform","type":"bytes32"}],"name":"checksum","outputs":[{"name":"","type":"bytes32"}],"payable":false,"type":"function"}`
@@ -340,7 +340,7 @@ impl Operations {
 		).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_fixed_bytes().ok_or("Invalid type returned")?; ethereum_types::H256::from_slice(r.as_ref()) }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_fixed_bytes().ok_or("Invalid type returned")?; ethereum_types::H256::from_slice(r.as_ref()) })
 	}
 
 	/// Auto-generated from: `{"constant":true,"inputs":[],"name":"proposedFork","outputs":[{"name":"","type":"uint32"}],"payable":false,"type":"function"}`
@@ -350,6 +350,6 @@ impl Operations {
 		let data = call.encode_input(&[]).map_err(Self::as_string)?;
 		let output = call.decode_output(&(self.do_call)(self.address.clone(), data)?).map_err(Self::as_string)?;
 		let mut result = output.into_iter().rev().collect::<Vec<_>>();
-		Ok(({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u32 }))
+		Ok({ let r = result.pop().ok_or("Invalid return arity")?; let r = r.to_uint().ok_or("Invalid type returned")?; ethereum_types::U256::from(r.as_ref()).as_u64() as u32 })
 	}
 }

--- a/util/kvdb-rocksdb/src/lib.rs
+++ b/util/kvdb-rocksdb/src/lib.rs
@@ -379,7 +379,7 @@ impl Database {
 			write_opts: write_opts,
 			overlay: RwLock::new((0..(num_cols + 1)).map(|_| HashMap::new()).collect()),
 			flushing: RwLock::new((0..(num_cols + 1)).map(|_| HashMap::new()).collect()),
-			flushing_lock: Mutex::new((false)),
+			flushing_lock: Mutex::new(false),
 			path: path.to_owned(),
 			read_opts: read_opts,
 			block_opts: block_opts,

--- a/util/network/src/connection.rs
+++ b/util/network/src/connection.rs
@@ -366,7 +366,7 @@ impl EncryptedConnection {
 		let padding = (16 - (payload.len() % 16)) % 16;
 		header.resize(16, 0u8);
 
-		let mut packet = vec![0u8; (32 + payload.len() + padding + 16)];
+		let mut packet = vec![0u8; 32 + payload.len() + padding + 16];
 		self.encoder.encrypt(&mut RefReadBuffer::new(&header), &mut RefWriteBuffer::new(&mut packet), false).expect("Invalid length or padding");
 		EncryptedConnection::update_mac(&mut self.egress_mac, &mut self.mac_encoder,  &packet[0..16]);
 		self.egress_mac.clone().finalize(&mut packet[16..32]);

--- a/util/rlp/src/untrusted_rlp.rs
+++ b/util/rlp/src/untrusted_rlp.rs
@@ -276,7 +276,7 @@ impl<'a, 'view> UntrustedRlp<'a> where 'a: 'view {
 		let mut result = bytes;
 		for _ in 0..items {
 			let i = BasicDecoder::payload_info(result)?;
-			result = UntrustedRlp::consume(result, (i.header_len + i.value_len))?;
+			result = UntrustedRlp::consume(result, i.header_len + i.value_len)?;
 		}
 		Ok(result)
 	}


### PR DESCRIPTION
Recent nightly contains lint for redundant parentheses in expressions, that typically looks like this:

```
warning: unnecessary parentheses around function argument
   --> util/rlp/src/untrusted_rlp.rs:279:43
    |
279 |             result = UntrustedRlp::consume(result, (i.header_len + i.value_len))?;
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: #[warn(unused_parens)] on by default
```

Entries in normal sources were modified accordingly. However, there are a lot of generated files, where n-tuple is returned as `Ok` part of a function's `Result`. In case of 1-tuple it looks like `Ok((x))` which makes rustc nervous.

In order to calm the compiler down, I've added `#![allow(unused_parens)]` in generated modules and simplified the expressions in normal code (where applicable).

Also, `updater/src/operations.rs` seems to be autogenerated, but since it was in the repo, I decided to fix it by hand as well.