### PR TITLE
[beta] Token filter balances (throttle)

### DIFF
--- a/js-old/src/redux/providers/balancesActions.js
+++ b/js-old/src/redux/providers/balancesActions.js
@@ -306,7 +306,7 @@ export function fetchTokensBalances (updates, skipNotifications = false) {
         const tokenIdsToFetch = Object.values(balances)
           .reduce((tokenIds, balance) => {
             const nextTokenIds = Object.keys(balance)
-              .filter((tokenId) => balance[tokenId].gt(0));
+              .filter((tokenId) => balance[tokenId] && balance[tokenId].gt(0));
 
             return tokenIds.concat(nextTokenIds);
           }, []);
@@ -328,7 +328,7 @@ export function fetchTokensBalances (updates, skipNotifications = false) {
         dispatch(setBalances(balances, skipNotifications));
       })
       .catch((error) => {
-        console.warn('balances::fetchTokensBalances', error);
+        console.warn('v1: balances::fetchTokensBalances', error);
       });
   };
 }

--- a/js-old/src/redux/providers/tokensActions.js
+++ b/js-old/src/redux/providers/tokensActions.js
@@ -105,7 +105,7 @@ export function loadTokens (options = {}) {
 }
 
 export function loadTokensBasics (tokenIndexes, options) {
-  const limit = 64;
+  const limit = 128;
 
   return (dispatch, getState) => {
     const { api } = getState();
@@ -154,7 +154,7 @@ export function loadTokensBasics (tokenIndexes, options) {
 
 export function fetchTokens (_tokenIndexes) {
   const tokenIndexes = uniq(_tokenIndexes || []);
-  const tokenChunks = chunk(tokenIndexes, 64);
+  const tokenChunks = chunk(tokenIndexes, 128);
 
   return (dispatch, getState) => {
     const { tokenReg } = Contracts.get();

--- a/js-old/src/ui/Balance/balance.js
+++ b/js-old/src/ui/Balance/balance.js
@@ -56,7 +56,7 @@ export class Balance extends Component {
 
         const isEthToken = token.native;
         const isFullToken = !showOnlyEth || isEthToken;
-        const hasBalance = (balanceValue instanceof BigNumber) && balanceValue.gt(0);
+        const hasBalance = (balanceValue instanceof BigNumber) && balanceValue.gt(0) && !token.invalid;
 
         if (!hasBalance && !isEthToken) {
           return null;

--- a/js-old/src/ui/Balance/balance.js
+++ b/js-old/src/ui/Balance/balance.js
@@ -56,7 +56,7 @@ export class Balance extends Component {
 
         const isEthToken = token.native;
         const isFullToken = !showOnlyEth || isEthToken;
-        const hasBalance = (balanceValue instanceof BigNumber) && balanceValue.gt(0) && !token.invalid;
+        const hasBalance = (balanceValue instanceof BigNumber) && balanceValue.gt(0);
 
         if (!hasBalance && !isEthToken) {
           return null;

--- a/js-old/src/util/tokens/index.js
+++ b/js-old/src/util/tokens/index.js
@@ -79,7 +79,6 @@ export function fetchTokensBasics (api, tokenReg, start = 0, limit = 100) {
           return tokens.map((token) => {
             if (balances[token.id] && balances[token.id].gt(0)) {
               token.address = null;
-              token.invalid = true;
             }
 
             return token;

--- a/js-old/src/util/tokens/index.js
+++ b/js-old/src/util/tokens/index.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { chunk, range, uniq } from 'lodash';
+import { chunk, range } from 'lodash';
 import BigNumber from 'bignumber.js';
 
 import { hashToImageUrl } from '~/redux/util';

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -361,9 +361,9 @@
       "version": "github:parity-js/plugin-signer-qr#2d1fafad347ba53eaf58c14265d4d07631d6a45c"
     },
     "@parity/shared": {
-      "version": "2.2.21",
-      "resolved": "https://registry.npmjs.org/@parity/shared/-/shared-2.2.21.tgz",
-      "integrity": "sha512-8Xuuv/SpS+lviX3xRVvh3UUMcWYrQPQvn+KkSiKofuHlVL/IlhEnLyflk5j5FgGviXwaqBxmOllTSTPQBna4Gw==",
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/@parity/shared/-/shared-2.2.23.tgz",
+      "integrity": "sha512-I9/uk2g2V6vm1SvsopGassY5QvW/5DMNvha5isoCRdFWnAq2EKOCeSH+pbZXx0ZzHCIgSDlFXPTaaWDbvngBzA==",
       "requires": {
         "@parity/ledger": "2.1.2",
         "eventemitter3": "2.0.3",
@@ -415,37 +415,6 @@
             "loose-envify": "1.3.1",
             "symbol-observable": "1.1.0"
           }
-        },
-        "solc": {
-          "version": "github:ngotchac/solc-js#04eb38cc3003fba8cb3656653a7941ed36408818",
-          "requires": {
-            "memorystream": "0.3.1",
-            "require-from-string": "1.2.1",
-            "yargs": "4.8.1"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "4.8.1",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-              "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "lodash.assign": "4.2.0",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "2.4.1"
-              }
-            }
-          }
         }
       }
     },
@@ -457,7 +426,7 @@
         "@parity/api": "2.1.15",
         "@parity/etherscan": "2.1.3",
         "@parity/mobx": "1.0.4",
-        "@parity/shared": "2.2.21",
+        "@parity/shared": "2.2.23",
         "babel-runtime": "6.26.0",
         "bignumber.js": "4.1.0",
         "brace": "0.11.0",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -45,11 +45,11 @@
       "dev": true
     },
     "@parity/dapp-dapp-methods": {
-      "version": "github:js-dist-paritytech/dapp-dapp-methods#b4dce52a09303fddf55172bb0d2e6bb83f12e196",
+      "version": "github:js-dist-paritytech/dapp-dapp-methods#b649fb9056d49bbf4fde719f91a4cfcaf529f9f6",
       "dev": true,
       "requires": {
         "@parity/api": "2.1.15",
-        "@parity/mobx": "1.0.6",
+        "@parity/mobx": "1.0.7",
         "@parity/ui": "3.0.22",
         "mobx": "3.4.1",
         "mobx-react": "4.3.5",
@@ -63,9 +63,9 @@
       },
       "dependencies": {
         "@parity/mobx": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/@parity/mobx/-/mobx-1.0.6.tgz",
-          "integrity": "sha512-yVTB3r/2Uel20aUBgt/x+dlxXrdNuzFjRyo86uR3vWTSFQq5A0H/LzIhlR5JBMuhkGwT6i+t7r1JFG4CoynJew==",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@parity/mobx/-/mobx-1.0.7.tgz",
+          "integrity": "sha512-HC9VFcFnZ+h/YZWSiA2vIJcXK2yhLNFipPxAIMkDMClgNX9sOxrItmjmTfETAlHVM/axO2FIluLCd3VO/Xze8w==",
           "dev": true,
           "requires": {
             "@parity/ledger": "2.1.2"
@@ -128,11 +128,11 @@
       }
     },
     "@parity/dapp-dapp-visible": {
-      "version": "github:js-dist-paritytech/dapp-dapp-visible#19f0b7d3de7bcc9859ac5d8059e866e1f5804366",
+      "version": "github:js-dist-paritytech/dapp-dapp-visible#28546f312ea9877ebeea9c52afea1e7ec943cd0d",
       "dev": true,
       "requires": {
         "@parity/api": "2.1.15",
-        "@parity/mobx": "1.0.6",
+        "@parity/mobx": "1.0.7",
         "@parity/ui": "3.0.22",
         "mobx": "3.4.1",
         "mobx-react": "4.3.5",
@@ -146,9 +146,9 @@
       },
       "dependencies": {
         "@parity/mobx": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/@parity/mobx/-/mobx-1.0.6.tgz",
-          "integrity": "sha512-yVTB3r/2Uel20aUBgt/x+dlxXrdNuzFjRyo86uR3vWTSFQq5A0H/LzIhlR5JBMuhkGwT6i+t7r1JFG4CoynJew==",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@parity/mobx/-/mobx-1.0.7.tgz",
+          "integrity": "sha512-HC9VFcFnZ+h/YZWSiA2vIJcXK2yhLNFipPxAIMkDMClgNX9sOxrItmjmTfETAlHVM/axO2FIluLCd3VO/Xze8w==",
           "dev": true,
           "requires": {
             "@parity/ledger": "2.1.2"
@@ -231,11 +231,11 @@
       "dev": true
     },
     "@parity/dapp-status": {
-      "version": "github:js-dist-paritytech/dapp-status#90c6425804800b1d3599f602cd257e8e4cfa6428",
+      "version": "github:js-dist-paritytech/dapp-status#ea6a3c01d64bd57c5fadf2264efa719a61e70a29",
       "dev": true,
       "requires": {
         "@parity/api": "2.1.15",
-        "@parity/mobx": "1.0.6",
+        "@parity/mobx": "1.0.7",
         "@parity/ui": "3.0.22",
         "format-number": "3.0.0",
         "mobx": "3.4.1",
@@ -251,9 +251,9 @@
       },
       "dependencies": {
         "@parity/mobx": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/@parity/mobx/-/mobx-1.0.6.tgz",
-          "integrity": "sha512-yVTB3r/2Uel20aUBgt/x+dlxXrdNuzFjRyo86uR3vWTSFQq5A0H/LzIhlR5JBMuhkGwT6i+t7r1JFG4CoynJew==",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@parity/mobx/-/mobx-1.0.7.tgz",
+          "integrity": "sha512-HC9VFcFnZ+h/YZWSiA2vIJcXK2yhLNFipPxAIMkDMClgNX9sOxrItmjmTfETAlHVM/axO2FIluLCd3VO/Xze8w==",
           "dev": true,
           "requires": {
             "@parity/ledger": "2.1.2"

--- a/js/package.json
+++ b/js/package.json
@@ -146,7 +146,7 @@
     "@parity/plugin-signer-default": "parity-js/plugin-signer-default#9a47bded9d6d70b69bb2f719732bd6f7854d1842",
     "@parity/plugin-signer-hardware": "parity-js/plugin-signer-hardware#4320d818a053d4efae890b74a7476e4c8dc6ba10",
     "@parity/plugin-signer-qr": "parity-js/plugin-signer-qr#2d1fafad347ba53eaf58c14265d4d07631d6a45c",
-    "@parity/shared": "2.2.21",
+    "@parity/shared": "2.2.23",
     "@parity/ui": "3.0.22",
     "keythereum": "1.0.2",
     "lodash.flatten": "4.4.0",


### PR DESCRIPTION
- Split token retrievals into 128-item sized chunks.
- Align `parity-js/shared` for shell
- Tested with `cargo build --release --=no-default-features --features ui`

<img width="645" alt="parity 2018-01-31 10-22-00" src="https://user-images.githubusercontent.com/1424473/35614848-b306c4ee-0670-11e8-8d77-15bdf27a9ba6.png">
