### PR TITLE
[stable] Fix tokenAddress reference

### DIFF
--- a/js/src/util/tokens/index.js
+++ b/js/src/util/tokens/index.js
@@ -62,7 +62,7 @@ export function fetchTokensBasics (api, tokenReg, start = 0, limit = 100) {
         const tokenIndex = start + index;
 
         return {
-          id: getTokenId(tokenAddress, tokenIndex),
+          id: getTokenId(address, tokenIndex),
           address,
           index: tokenIndex,
           fetched: false


### PR DESCRIPTION
Issue with the 1.9 -> 1.8 backport merge of https://github.com/paritytech/parity/pull/7755.