### PR TITLE
Add binary identifiers and sha256sum to builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,8 +23,8 @@ linux-stable:
     - triggers
   script:
     - rustup default stable
-    # ARGUMENTS: 1. BUILD_PLATFORM (target for binaries) 2. PLATFORM (target for cargo) 3. ARC (architecture) 4. & 5. CC & CXX flags
-    - scripts/gitlab-build.sh x86_64-unknown-linux-gnu x86_64-unknown-linux-gnu amd64 gcc g++
+    # ARGUMENTS: 1. BUILD_PLATFORM (target for binaries) 2. PLATFORM (target for cargo) 3. ARC (architecture) 4. & 5. CC & CXX flags 6. binary identifier
+    - scripts/gitlab-build.sh x86_64-unknown-linux-gnu x86_64-unknown-linux-gnu amd64 gcc g++ ubuntu
   tags:
     - rust-stable
   artifacts:
@@ -41,7 +41,7 @@ linux-stable-debian:
     - triggers
   script:
     - export LIBSSL="libssl1.1 (>=1.1.0)"
-    - scripts/gitlab-build.sh x86_64-unknown-debian-gnu x86_64-unknown-linux-gnu amd64 gcc g++
+    - scripts/gitlab-build.sh x86_64-unknown-debian-gnu x86_64-unknown-linux-gnu amd64 gcc g++ debian
   tags:
     - rust-debian
   artifacts:
@@ -57,7 +57,7 @@ linux-centos:
     - stable
     - triggers
   script:
-    - scripts/gitlab-build.sh x86_64-unknown-centos-gnu x86_64-unknown-linux-gnu x86_64 gcc g++
+    - scripts/gitlab-build.sh x86_64-unknown-centos-gnu x86_64-unknown-linux-gnu x86_64 gcc g++ centos
   tags:
     - rust-centos
   artifacts:
@@ -73,7 +73,7 @@ linux-i686:
     - stable
     - triggers
   script:
-    - scripts/gitlab-build.sh i686-unknown-linux-gnu i686-unknown-linux-gnu i386 gcc g++
+    - scripts/gitlab-build.sh i686-unknown-linux-gnu i686-unknown-linux-gnu i386 gcc g++ ubuntu
   tags:
     - rust-i686
   artifacts:
@@ -89,7 +89,7 @@ linux-armv7:
     - stable
     - triggers
   script:
-    - scripts/gitlab-build.sh armv7-unknown-linux-gnueabihf armv7-unknown-linux-gnueabihf armhf arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++
+    - scripts/gitlab-build.sh armv7-unknown-linux-gnueabihf armv7-unknown-linux-gnueabihf armhf arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ ubuntu
   tags:
     - rust-arm
   artifacts:
@@ -105,7 +105,7 @@ linux-arm:
     - stable
     - triggers
   script:
-    - scripts/gitlab-build.sh arm-unknown-linux-gnueabihf arm-unknown-linux-gnueabihf armhf arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++
+    - scripts/gitlab-build.sh arm-unknown-linux-gnueabihf arm-unknown-linux-gnueabihf armhf arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ ubuntu
   tags:
     - rust-arm
   artifacts:
@@ -121,7 +121,7 @@ linux-aarch64:
     - stable
     - triggers
   script:
-    - scripts/gitlab-build.sh aarch64-unknown-linux-gnu aarch64-unknown-linux-gnu arm64 aarch64-linux-gnu-gcc aarch64-linux-gnu-g++
+    - scripts/gitlab-build.sh aarch64-unknown-linux-gnu aarch64-unknown-linux-gnu arm64 aarch64-linux-gnu-gcc aarch64-linux-gnu-g++ ubuntu
   tags:
     - rust-arm
   artifacts:
@@ -137,7 +137,7 @@ linux-snap:
     - tags
     - triggers
   script:
-    - scripts/gitlab-build.sh x86_64-unknown-snap-gnu x86_64-unknown-linux-gnu amd64 gcc g++
+    - scripts/gitlab-build.sh x86_64-unknown-snap-gnu x86_64-unknown-linux-gnu amd64 gcc g++ snap
   tags:
     - rust-stable
   artifacts:
@@ -153,7 +153,7 @@ darwin:
     - stable
     - triggers
   script:
-    - scripts/gitlab-build.sh x86_64-apple-darwin x86_64-apple-darwin macos gcc g++
+    - scripts/gitlab-build.sh x86_64-apple-darwin x86_64-apple-darwin macos gcc g++ macos
   tags:
     - osx
   artifacts:
@@ -171,7 +171,7 @@ windows:
     - stable
     - triggers
   script:
-    - sh scripts/gitlab-build.sh x86_64-pc-windows-msvc x86_64-pc-windows-msvc installer "" "" ""
+    - sh scripts/gitlab-build.sh x86_64-pc-windows-msvc x86_64-pc-windows-msvc installer "" "" "" windows
   tags:
    - rust-windows
   artifacts:

--- a/scripts/gitlab-build.sh
+++ b/scripts/gitlab-build.sh
@@ -13,6 +13,7 @@ VER="$(grep -m 1 version Cargo.toml | awk '{print $3}' | tr -d '"' | tr -d "\n")
 S3WIN=""
 echo "--------------------"
 echo "Build for platform: " $BUILD_PLATFORM
+echo "Build identifier:   " $IDENT
 echo "Cargo target:       " $PLATFORM
 echo "CC&CXX flags:       " $CC ", " $CXX
 echo "Architecture:       " $ARC

--- a/scripts/gitlab-build.sh
+++ b/scripts/gitlab-build.sh
@@ -2,12 +2,13 @@
 
 set -e # fail on any error
 set -u # treat unset variables as error
-#ARGUMENTS: 1. BUILD_PLATFORM (target for binaries) 2. PLATFORM (target for cargo) 3. ARC (architecture) 4. & 5. CC & CXX flags
+#ARGUMENTS: 1. BUILD_PLATFORM (target for binaries) 2. PLATFORM (target for cargo) 3. ARC (architecture) 4. & 5. CC & CXX flags 6. binary identifier
 BUILD_PLATFORM=$1
 PLATFORM=$2
 ARC=$3
 CC=$4
 CXX=$5
+IDENT=$6
 VER="$(grep -m 1 version Cargo.toml | awk '{print $3}' | tr -d '"' | tr -d "\n")"
 S3WIN=""
 echo "--------------------"
@@ -59,12 +60,17 @@ strip_md5 () {
   export SHA3=$(rhash --sha3-256 target/$PLATFORM/release/parity -p %h)
   echo "Checksum calculation:"
   rm -rf *.md5
+  rm -rf *.sha256
   export SHA3=$(rhash --sha3-256 target/$PLATFORM/release/parity -p %h)
   echo "Parity file SHA3:" $SHA3
   md5sum target/$PLATFORM/release/parity > parity.md5
+  sha256sum target/$PLATFORM/release/parity > parity.sha256
   md5sum target/$PLATFORM/release/parity-evm > parity-evm.md5
+  sha256sum target/$PLATFORM/release/parity-evm > parity-evm.sha256
   md5sum target/$PLATFORM/release/ethstore > ethstore.md5
+  sha256sum target/$PLATFORM/release/ethstore > ethstore.sha256
   md5sum target/$PLATFORM/release/ethkey > ethkey.md5
+  sha256sum target/$PLATFORM/release/ethkey > ethkey.sha256
 }
 make_deb () {
   rm -rf deb
@@ -98,8 +104,9 @@ make_deb () {
   cp target/$PLATFORM/release/parity-evm deb/usr/bin/parity-evm
   cp target/$PLATFORM/release/ethstore deb/usr/bin/ethstore
   cp target/$PLATFORM/release/ethkey deb/usr/bin/ethkey
-  dpkg-deb -b deb "parity_"$VER"_"$ARC".deb"
-  md5sum "parity_"$VER"_"$ARC".deb" > "parity_"$VER"_"$ARC".deb.md5"
+  dpkg-deb -b deb "parity_"$VER"_"$IDENT"_"$ARC".deb"
+  md5sum "parity_"$VER"_"$IDENT"_"$ARC".deb" > "parity_"$VER"_"$IDENT"_"$ARC".deb.md5"
+  sha256sum "parity_"$VER"_"$IDENT"_"$ARC".deb" > "parity_"$VER"_"$IDENT"_"$ARC".deb.sha256"
 }
 make_rpm () {
   rm -rf /install
@@ -109,8 +116,9 @@ make_rpm () {
   cp target/$PLATFORM/release/ethstore /install/usr/bin/ethstore
   cp target/$PLATFORM/release/ethkey /install/usr/bin/ethkey
   fpm -s dir -t rpm -n parity -v $VER --epoch 1 --license GPLv3 -d openssl --provides parity --url https://parity.io --vendor "Parity Technologies" -a x86_64 -m "<devops@parity.io>" --description "Ethereum network client by Parity Technologies" -C /install/
-  cp "parity-"$VER"-1."$ARC".rpm" "parity_"$VER"_"$ARC".rpm"
-  md5sum "parity_"$VER"_"$ARC".rpm" > "parity_"$VER"_"$ARC".rpm.md5"
+  cp "parity-"$VER"-1."$ARC".rpm" "parity_"$VER"_"$IDENT"_"$ARC".rpm"
+  md5sum "parity_"$VER"_"$IDENT"_"$ARC".rpm" > "parity_"$VER"_"$IDENT"_"$ARC".rpm.md5"
+  sha256sum "parity_"$VER"_"$IDENT"_"$ARC".rpm" > "parity_"$VER"_"$IDENT"_"$ARC".rpm.sha256"
 }
 make_pkg () {
   echo "make PKG"
@@ -123,19 +131,25 @@ make_pkg () {
   cd ..
   packagesbuild -v mac/Parity.pkgproj
   productsign --sign 'Developer ID Installer: PARITY TECHNOLOGIES LIMITED (P2PX3JU8FT)' target/release/Parity\ Ethereum.pkg target/release/Parity\ Ethereum-signed.pkg
-  mv target/release/Parity\ Ethereum-signed.pkg "parity_"$VER"_"$ARC".pkg"
-  md5sum "parity_"$VER"_"$ARC"."$EXT >> "parity_"$VER"_"$ARC".pkg.md5"
+  mv target/release/Parity\ Ethereum-signed.pkg "parity_"$VER"_"$IDENT"_"$ARC".pkg"
+  md5sum "parity_"$VER"_"$IDENT"_"$ARC"."$EXT >> "parity_"$VER"_"$IDENT"_"$ARC".pkg.md5"
+  sha256sum "parity_"$VER"_"$IDENT"_"$ARC"."$EXT >> "parity_"$VER"_"$IDENT"_"$ARC".pkg.sha256"
 }
 make_exe () {
   ./sign.cmd $keyfile $certpass "target/$PLATFORM/release/parity.exe"
   SHA3=$(rhash --sha3-256 target/$PLATFORM/release/parity.exe -p %h)
   echo "Checksum calculation:"
   rm -rf *.md5
+  rm -rf *.sha256
   echo "Parity file SHA3:" $SHA3
   rhash --md5 target/$PLATFORM/release/parity.exe -p %h > parity.exe.md5
+  rhash --sha256 target/$PLATFORM/release/parity.exe -p %h > parity.exe.sha256
   rhash --md5 target/$PLATFORM/release/parity-evm.exe -p %h > parity-evm.exe.md5
+  rhash --sha256 target/$PLATFORM/release/parity-evm.exe -p %h > parity-evm.exe.sha256
   rhash --md5 target/$PLATFORM/release/ethstore.exe -p %h > ethstore.exe.md5
+  rhash --sha256 target/$PLATFORM/release/ethstore.exe -p %h > ethstore.exe.sha256
   rhash --md5 target/$PLATFORM/release/ethkey.exe -p %h > ethkey.exe.md5
+  rhash --sha256 target/$PLATFORM/release/ethkey.exe -p %h > ethkey.exe.sha256
   ./msbuild.cmd
   ./sign.cmd $keyfile $certpass windows/ptray/x64/release/ptray.exe
   cd nsis
@@ -143,9 +157,10 @@ make_exe () {
   echo "makensis.exe installer.nsi" > nsis.cmd
   ./nsis.cmd
   cd ..
-  cp nsis/installer.exe "parity_"$VER"_"$ARC"."$EXT
-  ./sign.cmd $keyfile $certpass "parity_"$VER"_"$ARC"."$EXT
-  rhash --md5 "parity_"$VER"_"$ARC"."$EXT -p %h > "parity_"$VER"_"$ARC"."$EXT".md5"
+  cp nsis/installer.exe "parity_"$VER"_"$IDENT"_"$ARC"."$EXT
+  ./sign.cmd $keyfile $certpass "parity_"$VER"_"$IDENT"_"$ARC"."$EXT
+  rhash --md5 "parity_"$VER"_"$IDENT"_"$ARC"."$EXT -p %h > "parity_"$VER"_"$IDENT"_"$ARC"."$EXT".md5"
+  rhash --sha256 "parity_"$VER"_"$IDENT"_"$ARC"."$EXT -p %h > "parity_"$VER"_"$IDENT"_"$ARC"."$EXT".sha256"
 }
 push_binaries () {
   echo "Push binaries to AWS S3"
@@ -160,19 +175,24 @@ push_binaries () {
   aws s3 rm --recursive s3://$S3_BUCKET/$CI_BUILD_REF_NAME/$BUILD_PLATFORM
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/parity$S3WIN --body target/$PLATFORM/release/parity$S3WIN
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/parity$S3WIN.md5 --body parity$S3WIN.md5
+  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/parity$S3WIN.sha256 --body parity$S3WIN.sha256
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/parity-evm$S3WIN --body target/$PLATFORM/release/parity-evm$S3WIN
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/parity-evm$S3WIN.md5 --body parity-evm$S3WIN.md5
+  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/parity-evm$S3WIN.sha256 --body parity-evm$S3WIN.sha256
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/ethstore$S3WIN --body target/$PLATFORM/release/ethstore$S3WIN
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/ethstore$S3WIN.md5 --body ethstore$S3WIN.md5
+  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/ethstore$S3WIN.sha256 --body ethstore$S3WIN.sha256
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/ethkey$S3WIN --body target/$PLATFORM/release/ethkey$S3WIN
   aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/ethkey$S3WIN.md5 --body ethkey$S3WIN.md5
-  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/"parity_"$VER"_"$ARC"."$EXT --body "parity_"$VER"_"$ARC"."$EXT
-  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/"parity_"$VER"_"$ARC"."$EXT".md5" --body "parity_"$VER"_"$ARC"."$EXT".md5"
+  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/ethkey$S3WIN.sha256 --body ethkey$S3WIN.sha256
+  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/"parity_"$VER"_"$IDENT"_"$ARC"."$EXT --body "parity_"$VER"_"$IDENT"_"$ARC"."$EXT
+  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/"parity_"$VER"_"$IDENT"_"$ARC"."$EXT".md5" --body "parity_"$VER"_"$IDENT"_"$ARC"."$EXT".md5"
+  aws s3api put-object --bucket $S3_BUCKET --key $CI_BUILD_REF_NAME/$BUILD_PLATFORM/"parity_"$VER"_"$IDENT"_"$ARC"."$EXT".sha256" --body "parity_"$VER"_"$IDENT"_"$ARC"."$EXT".sha256"
 }
 make_archive () {
   echo "add artifacts to archive"
   rm -rf parity.zip
-  zip -r parity.zip target/$PLATFORM/release/parity$S3WIN target/$PLATFORM/release/parity-evm$S3WIN target/$PLATFORM/release/ethstore$S3WIN target/$PLATFORM/release/ethkey$S3WIN parity$S3WIN.md5 parity-evm$S3WIN.md5 ethstore$S3WIN.md5 ethkey$S3WIN.md5
+  zip -r parity.zip target/$PLATFORM/release/parity$S3WIN target/$PLATFORM/release/parity-evm$S3WIN target/$PLATFORM/release/ethstore$S3WIN target/$PLATFORM/release/ethkey$S3WIN parity$S3WIN.md5 parity-evm$S3WIN.md5 ethstore$S3WIN.md5 ethkey$S3WIN.md5 parity$S3WIN.sha256 parity-evm$S3WIN.sha256 ethstore$S3WIN.sha256 ethkey$S3WIN.sha256
 }
 push_release () {
   echo "push release"
@@ -278,6 +298,7 @@ case $BUILD_PLATFORM in
     snapcraft
     cp "parity_"$CI_BUILD_REF_NAME"_amd64.snap" "parity_"$VER"_amd64.snap"
     md5sum "parity_"$VER"_amd64.snap" > "parity_"$VER"_amd64.snap.md5"
+    sha256sum "parity_"$VER"_amd64.snap" > "parity_"$VER"_amd64.snap.sha256"
     push_binaries
     ;;
   x86_64-pc-windows-msvc)


### PR DESCRIPTION
- calculates and provides sha256 checksums (finally), to be used in vanity service later
- adds binary identifiers, e.g., debian, ubuntu to distinguish between distros

ref #7792 

This only bridges the gap until we remove libssl references #7829 
