### PR TITLE
SecretStore: 'broadcast' decryption session

### DIFF
--- a/secret_store/src/key_server_cluster/admin_sessions/servers_set_change_session.rs
+++ b/secret_store/src/key_server_cluster/admin_sessions/servers_set_change_session.rs
@@ -337,7 +337,7 @@ impl SessionImpl {
 		}
 
 		let unknown_sessions_job = UnknownSessionsJob::new_on_master(self.core.key_storage.clone(), self.core.meta.self_node_id.clone());
-		consensus_session.disseminate_jobs(unknown_sessions_job, self.unknown_sessions_transport())
+		consensus_session.disseminate_jobs(unknown_sessions_job, self.unknown_sessions_transport(), false)
 	}
 
 	/// When unknown sessions are requested.

--- a/secret_store/src/key_server_cluster/client_sessions/signing_session.rs
+++ b/secret_store/src/key_server_cluster/client_sessions/signing_session.rs
@@ -734,7 +734,7 @@ impl SessionCore {
 
 		let key_version = key_share.version(version).map_err(|e| Error::KeyStorage(e.into()))?.hash.clone();
 		let signing_job = SigningJob::new_on_master(self.meta.self_node_id.clone(), key_share.clone(), key_version, session_public, session_secret_share, message_hash)?;
-		consensus_session.disseminate_jobs(signing_job, self.signing_transport())
+		consensus_session.disseminate_jobs(signing_job, self.signing_transport(), false)
 	}
 }
 

--- a/secret_store/src/key_server_cluster/cluster.rs
+++ b/secret_store/src/key_server_cluster/cluster.rs
@@ -474,9 +474,9 @@ impl ClusterCore {
 					Ok((version, master)) => match session.continue_action() {
 						Some(ContinueAction::Decrypt(session, is_shadow_decryption)) => {
 							let initialization_error = if data.self_key_pair.public() == &master {
-								session.initialize(version, is_shadow_decryption)
+								session.initialize(version, is_shadow_decryption, false)
 							} else {
-								session.delegate(master, version, is_shadow_decryption)
+								session.delegate(master, version, is_shadow_decryption, false)
 							};
 
 							if let Err(error) = initialization_error {
@@ -920,7 +920,7 @@ impl ClusterClient for ClusterClientImpl {
 		let session = self.data.sessions.decryption_sessions.insert(cluster, self.data.self_key_pair.public().clone(), session_id.clone(), None, false, Some(requestor_signature))?;
 
 		let initialization_result = match version {
-			Some(version) => session.initialize(version, is_shadow_decryption),
+			Some(version) => session.initialize(version, is_shadow_decryption, false),
 			None => {
 				self.create_key_version_negotiation_session(session_id.id.clone())
 					.map(|version_session| {

--- a/secret_store/src/key_server_cluster/jobs/decryption_job.rs
+++ b/secret_store/src/key_server_cluster/jobs/decryption_job.rs
@@ -39,6 +39,8 @@ pub struct DecryptionJob {
 	request_id: Option<Secret>,
 	/// Is shadow decryption requested.
 	is_shadow_decryption: Option<bool>,
+	/// Is broadcast decryption requested.
+	is_broadcast_session: Option<bool>,
 }
 
 /// Decryption job partial request.
@@ -47,11 +49,14 @@ pub struct PartialDecryptionRequest {
 	pub id: Secret,
 	/// Is shadow decryption requested.
 	pub is_shadow_decryption: bool,
+	/// Is broadcast decryption requested.
+	pub is_broadcast_session: bool,
 	/// Id of other nodes, participating in decryption.
 	pub other_nodes_ids: BTreeSet<NodeId>,
 }
 
 /// Decryption job partial response.
+#[derive(Clone)]
 pub struct PartialDecryptionResponse {
 	/// Request id.
 	pub request_id: Secret,
@@ -72,10 +77,11 @@ impl DecryptionJob {
 			key_version: key_version,
 			request_id: None,
 			is_shadow_decryption: None,
+			is_broadcast_session: None,
 		})
 	}
 
-	pub fn new_on_master(self_node_id: NodeId, access_key: Secret, requester: Public, key_share: DocumentKeyShare, key_version: H256, is_shadow_decryption: bool) -> Result<Self, Error> {
+	pub fn new_on_master(self_node_id: NodeId, access_key: Secret, requester: Public, key_share: DocumentKeyShare, key_version: H256, is_shadow_decryption: bool, is_broadcast_session: bool) -> Result<Self, Error> {
 		debug_assert!(key_share.common_point.is_some() && key_share.encrypted_point.is_some());
 		Ok(DecryptionJob {
 			self_node_id: self_node_id,
@@ -85,7 +91,16 @@ impl DecryptionJob {
 			key_version: key_version,
 			request_id: Some(math::generate_random_scalar()?),
 			is_shadow_decryption: Some(is_shadow_decryption),
+			is_broadcast_session: Some(is_broadcast_session),
 		})
+	}
+
+	pub fn request_id(&self) -> &Option<Secret> {
+		&self.request_id
+	}
+
+	pub fn set_request_id(&mut self, request_id: Secret) {
+		self.request_id = Some(request_id);
 	}
 }
 
@@ -101,12 +116,15 @@ impl JobExecutor for DecryptionJob {
 			.expect("prepare_partial_request is only called on master nodes; request_id is filed in constructor on master nodes; qed");
 		let is_shadow_decryption = self.is_shadow_decryption
 			.expect("prepare_partial_request is only called on master nodes; is_shadow_decryption is filed in constructor on master nodes; qed");
+		let is_broadcast_session = self.is_broadcast_session
+			.expect("prepare_partial_request is only called on master nodes; is_broadcast_session is filed in constructor on master nodes; qed");
 		let mut other_nodes_ids = nodes.clone();
 		other_nodes_ids.remove(node);
 
 		Ok(PartialDecryptionRequest {
 			id: request_id.clone(),
 			is_shadow_decryption: is_shadow_decryption,
+			is_broadcast_session: is_broadcast_session,
 			other_nodes_ids: other_nodes_ids,
 		})
 	}

--- a/secret_store/src/key_server_cluster/jobs/job_session.rs
+++ b/secret_store/src/key_server_cluster/jobs/job_session.rs
@@ -40,7 +40,7 @@ pub enum JobPartialRequestAction<PartialJobResponse> {
 /// Job executor.
 pub trait JobExecutor {
 	type PartialJobRequest;
-	type PartialJobResponse;
+	type PartialJobResponse: Clone;
 	type JobResponse;
 
 	/// Prepare job request for given node.
@@ -175,6 +175,14 @@ impl<Executor, Transport> JobSession<Executor, Transport> where Executor: JobExe
 			.responses
 	}
 
+	/// Returns true if enough responses are ready to compute result.
+	pub fn is_result_ready(&self) -> bool {
+		debug_assert!(self.meta.self_node_id == self.meta.master_node_id);
+		self.data.active_data.as_ref()
+			.expect("is_result_ready is only called on master nodes after initialization; on master nodes active_data is filled during initialization; qed")
+			.responses.len() >= self.meta.threshold + 1
+	}
+
 	/// Get job result.
 	pub fn result(&self) -> Result<Executor::JobResponse, Error> {
 		debug_assert!(self.meta.self_node_id == self.meta.master_node_id);
@@ -189,7 +197,7 @@ impl<Executor, Transport> JobSession<Executor, Transport> where Executor: JobExe
 	}
 
 	/// Initialize.
-	pub fn initialize(&mut self, nodes: BTreeSet<NodeId>) -> Result<(), Error> {		
+	pub fn initialize(&mut self, nodes: BTreeSet<NodeId>, broadcast_self_response: bool) -> Result<(), Error> {		
 		debug_assert!(self.meta.self_node_id == self.meta.master_node_id);
 
 		if nodes.len() < self.meta.threshold + 1 {
@@ -213,24 +221,31 @@ impl<Executor, Transport> JobSession<Executor, Transport> where Executor: JobExe
 		} else {
 			None
 		};
+		let self_response = match self_response {
+			Some(JobPartialRequestAction::Respond(self_response)) => Some(self_response),
+			Some(JobPartialRequestAction::Reject(self_response)) => Some(self_response),
+			None => None,
+		};
 
 		// update state
 		self.data.active_data = Some(active_data);
 		self.data.state = JobSessionState::Active;
 
 		// if we are waiting for response from self => do it
-		if let Some(self_response) = self_response {
+		if let Some(self_response) = self_response.clone() {
 			let self_node_id = self.meta.self_node_id.clone();
-			match self_response {
-				JobPartialRequestAction::Respond(self_response) => self.on_partial_response(&self_node_id, self_response)?,
-				JobPartialRequestAction::Reject(self_response) => self.on_partial_response(&self_node_id, self_response)?,
-			}
+			self.on_partial_response(&self_node_id, self_response)?;
 		}
 
 		// send requests to save nodes. we only send requests if session is still active.
-		if self.data.state == JobSessionState::Active {
-			for node in nodes.iter().filter(|n| **n != self.meta.self_node_id) {
+		for node in nodes.iter().filter(|n| **n != self.meta.self_node_id) {
+			if self.data.state == JobSessionState::Active {
 				self.transport.send_partial_request(node, self.executor.prepare_partial_request(node, &nodes)?)?;
+			}
+			if broadcast_self_response {
+				if let Some(self_response) = self_response.clone() {
+					self.transport.send_partial_response(node, self_response)?;
+				}
 			}
 		}
 
@@ -372,6 +387,10 @@ pub mod tests {
 	}
 
 	impl<T, U> DummyJobTransport<T, U> {
+		pub fn is_empty_response(&self) -> bool {
+			self.responses.lock().is_empty()
+		}
+
 		pub fn response(&self) -> (NodeId, U) {
 			self.responses.lock().pop_front().unwrap()
 		}
@@ -396,22 +415,23 @@ pub mod tests {
 	#[test]
 	fn job_initialize_fails_if_not_inactive() {
 		let mut job = JobSession::new(make_master_session_meta(0), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1)].into_iter().collect()).unwrap();
-		assert_eq!(job.initialize(vec![Public::from(1)].into_iter().collect()).unwrap_err(), Error::InvalidStateForRequest);
+		job.initialize(vec![Public::from(1)].into_iter().collect(), false).unwrap();
+		assert_eq!(job.initialize(vec![Public::from(1)].into_iter().collect(), false).unwrap_err(), Error::InvalidStateForRequest);
 	}
 
 	#[test]
 	fn job_initialization_leads_to_finish_if_single_node_is_required() {
 		let mut job = JobSession::new(make_master_session_meta(0), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Finished);
+		assert!(job.is_result_ready());
 		assert_eq!(job.result(), Ok(4));
 	}
 
 	#[test]
 	fn job_initialization_does_not_leads_to_finish_if_single_other_node_is_required() {
 		let mut job = JobSession::new(make_master_session_meta(0), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(2)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(2)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
 	}
 
@@ -454,7 +474,7 @@ pub mod tests {
 	#[test]
 	fn job_response_fails_if_comes_to_failed_state() {
 		let mut job = JobSession::new(make_master_session_meta(0), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(2)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(2)].into_iter().collect(), false).unwrap();
 		job.on_session_timeout().unwrap_err();
 		assert_eq!(job.on_partial_response(&NodeId::from(2), 2).unwrap_err(), Error::InvalidStateForRequest);
 	}
@@ -462,14 +482,14 @@ pub mod tests {
 	#[test]
 	fn job_response_fails_if_comes_from_unknown_node() {
 		let mut job = JobSession::new(make_master_session_meta(0), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(2)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(2)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.on_partial_response(&NodeId::from(3), 2).unwrap_err(), Error::InvalidNodeForRequest);
 	}
 
 	#[test]
 	fn job_response_leads_to_failure_if_too_few_nodes_left() {
 		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
 		assert_eq!(job.on_partial_response(&NodeId::from(2), 3).unwrap_err(), Error::ConsensusUnreachable);
 		assert_eq!(job.state(), JobSessionState::Failed);
@@ -478,16 +498,18 @@ pub mod tests {
 	#[test]
 	fn job_response_succeeds() {
 		let mut job = JobSession::new(make_master_session_meta(2), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1), Public::from(2), Public::from(3)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1), Public::from(2), Public::from(3)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
+		assert!(!job.is_result_ready());
 		job.on_partial_response(&NodeId::from(2), 2).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
+		assert!(!job.is_result_ready());
 	}
 
 	#[test]
 	fn job_response_leads_to_finish() {
 		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
 		job.on_partial_response(&NodeId::from(2), 2).unwrap();
 		assert_eq!(job.state(), JobSessionState::Finished);
@@ -512,7 +534,7 @@ pub mod tests {
 	#[test]
 	fn job_node_error_ignored_when_disconnects_from_rejected() {
 		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1), Public::from(2), Public::from(3)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1), Public::from(2), Public::from(3)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
 		job.on_partial_response(&NodeId::from(2), 3).unwrap();
 		job.on_node_error(&NodeId::from(2)).unwrap();
@@ -522,7 +544,7 @@ pub mod tests {
 	#[test]
 	fn job_node_error_ignored_when_disconnects_from_unknown() {
 		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
 		job.on_node_error(&NodeId::from(3)).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
@@ -531,7 +553,7 @@ pub mod tests {
 	#[test]
 	fn job_node_error_ignored_when_disconnects_from_requested_and_enough_nodes_left() {
 		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1), Public::from(2), Public::from(3)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1), Public::from(2), Public::from(3)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
 		job.on_node_error(&NodeId::from(3)).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
@@ -540,9 +562,25 @@ pub mod tests {
 	#[test]
 	fn job_node_error_leads_to_fail_when_disconnects_from_requested_and_not_enough_nodes_left() {
 		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
-		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect()).unwrap();
+		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect(), false).unwrap();
 		assert_eq!(job.state(), JobSessionState::Active);
 		assert_eq!(job.on_node_error(&NodeId::from(2)).unwrap_err(), Error::ConsensusUnreachable);
 		assert_eq!(job.state(), JobSessionState::Failed);
+	}
+
+	#[test]
+	fn job_broadcasts_self_response() {
+		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
+		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect(), true).unwrap();
+		assert_eq!(job.state(), JobSessionState::Active);
+		assert_eq!(job.transport().response(), (NodeId::from(2), 4));
+	}
+
+	#[test]
+	fn job_does_not_broadcasts_self_response() {
+		let mut job = JobSession::new(make_master_session_meta(1), SquaredSumJobExecutor, DummyJobTransport::default());
+		job.initialize(vec![Public::from(1), Public::from(2)].into_iter().collect(), false).unwrap();
+		assert_eq!(job.state(), JobSessionState::Active);
+		assert!(job.transport().is_empty_response());
 	}
 }

--- a/secret_store/src/key_server_cluster/jobs/signing_job.rs
+++ b/secret_store/src/key_server_cluster/jobs/signing_job.rs
@@ -50,6 +50,7 @@ pub struct PartialSigningRequest {
 }
 
 /// Signing job partial response.
+#[derive(Clone)]
 pub struct PartialSigningResponse {
 	/// Request id.
 	pub request_id: Secret,

--- a/secret_store/src/key_server_cluster/message.rs
+++ b/secret_store/src/key_server_cluster/message.rs
@@ -548,6 +548,9 @@ pub struct RequestPartialDecryption {
 	/// Is shadow decryption requested? When true, decryption result
 	/// will be visible to the owner of requestor public key only.
 	pub is_shadow_decryption: bool,
+	/// Decryption result must be reconstructed on all participating nodes. This is useful
+	/// for service contract API so that all nodes from consensus group can confirm decryption.
+	pub is_broadcast_session: bool,
 	/// Nodes that are agreed to do a decryption.
 	pub nodes: BTreeSet<MessageNodeId>,
 }
@@ -609,6 +612,9 @@ pub struct DecryptionSessionDelegation {
 	/// Is shadow decryption requested? When true, decryption result
 	/// will be visible to the owner of requestor public key only.
 	pub is_shadow_decryption: bool,
+	/// Decryption result must be reconstructed on all participating nodes. This is useful
+	/// for service contract API so that all nodes from consensus group can confirm decryption.
+	pub is_broadcast_session: bool,
 }
 
 /// When delegated decryption session is completed.

--- a/secret_store/src/listener/service_contract_listener.rs
+++ b/secret_store/src/listener/service_contract_listener.rs
@@ -583,7 +583,7 @@ mod tests {
 	}
 
 	#[test]
-	fn server_key_generation_is_scheduled_when_requested_key_is_unknnown() {
+	fn server_key_generation_is_scheduled_when_requested_key_is_unknown() {
 		let mut contract = DummyServiceContract::default();
 		contract.logs.push(vec![Default::default(), Default::default(), Default::default()]);
 		let listener = make_service_contract_listener(Some(Arc::new(contract)), None, None);
@@ -605,7 +605,7 @@ mod tests {
 	}
 
 	#[test]
-	fn server_key_restore_is_scheduled_when_requested_key_is_knnown() {
+	fn server_key_restore_is_scheduled_when_requested_key_is_known() {
 		let mut contract = DummyServiceContract::default();
 		contract.logs.push(vec![Default::default(), Default::default(), Default::default()]);
 		let listener = make_service_contract_listener(Some(Arc::new(contract)), None, None);


### PR DESCRIPTION
This is a (one of) preliminary PR for adding encryption/decryption support to SS service contract. Besides checking this PR, please try to read && criticize my approach.

So there exists [Document key shadow retrieval session](https://paritytech.github.io/wiki/Secret-Store#document-key-shadow-retrieval-session), which is currently used to read document key without reconstructing it on any Key Server. When used via HTTP API, it returns three items: 64-bytes `decrypted_secret`, 64-bytes `common_point` and an **array** of ECIES-encrypted EC scalars (each is 145 bytes). Each entry in array is generated by one KS and there are `t+1` entries, where t is the key threshold.

Previously this session had only gathered all required data on single key server (the one which was asked to restore the document key). In service contract PR there's another approach - we need to confirm decryption by every participating key server. So **this PR is about** this - in special mode (when `is_broadcast_session == true`) all data is broadcasted by every KS &&  at the end of session it is known by every consensus group node.

Life after this PR: the idea is that every KS will call a service contract method, which in turn will raise a *big* event like this: `event RestoredByKeyServer(bytes32 keyId, uint threshold, 64-bytes blob, 64-bytes blob, 145-bytes blob);`. Yet the number of events could also be huge (if we're dealing with a big SecretStore and key threshold is big). The requester should wait for enough events and pass events data to [`secretstore_shadowDecrypt`](https://paritytech.github.io/wiki/JSONRPC-secretstore-module#secretstore_shadowdecrypt).

So the question is - do you think if this approach (described in previous section) is viable, or not? If not, we can now start with [Document key retrieval session](https://paritytech.github.io/wiki/Secret-Store#document-key-retrieval-session) which is not as secure, as previous (document key will be restored on one of key servers before encrypting and publishing via log events). And later try to find a way to generate less spam (maybe will finally find a way to use commutative encryption in SS).