### PR TITLE
Light client: randomize the peer we dispatch requests to

### DIFF
--- a/ethcore/light/src/on_demand/mod.rs
+++ b/ethcore/light/src/on_demand/mod.rs
@@ -28,6 +28,7 @@ use futures::{Poll, Future};
 use futures::sync::oneshot::{self, Receiver, Canceled};
 use network::PeerId;
 use parking_lot::{RwLock, Mutex};
+use rand;
 
 use net::{
 	self, Handler, PeerStatus, Status, Capabilities,
@@ -363,7 +364,10 @@ impl OnDemand {
 		*pending = ::std::mem::replace(&mut *pending, Vec::new()).into_iter()
 			.filter(|pending| !pending.sender.is_canceled())
 			.filter_map(|pending| {
-				for (peer_id, peer) in peers.iter() { // .shuffle?
+				// the peer we dispatch to is chosen randomly
+				let num_peers = peers.len();
+				let rng = rand::random::<usize>() % num_peers;
+				for (peer_id, peer) in peers.iter().chain(peers.iter()).skip(rng).take(num_peers) {
 					// TODO: see which requests can be answered by the cache?
 
 					if !peer.can_fulfill(&pending.required_capabilities) {


### PR DESCRIPTION
cc #6319 

The issue seems to be caused by non-responsive peers clogging the pipeline.
While this PR doesn't fix the issue entirely, it greatly mitigates it by randomly choosing a peer to query every time we do a request.

Even if we ignore #6319, I think this is a desirable change.
