### PR TITLE
Hardware-wallet/usb-subscribe-refactor

### DIFF
--- a/hw/src/ledger.rs
+++ b/hw/src/ledger.rs
@@ -63,8 +63,8 @@ pub enum Error {
 	KeyNotFound,
 	/// Signing has been cancelled by user.
 	UserCancel,
-	/// Invalid Product
-	InvalidProduct,
+	/// Invalid Device
+	InvalidDevice,
 }
 
 impl fmt::Display for Error {
@@ -75,7 +75,7 @@ impl fmt::Display for Error {
 			Error::LibUsb(ref e) => write!(f, "LibUSB communication error: {}", e),
 			Error::KeyNotFound => write!(f, "Key not found"),
 			Error::UserCancel => write!(f, "Operation has been cancelled"),
-			Error::InvalidProduct=> write!(f, "Unsupported product was entered"),
+			Error::InvalidDevice => write!(f, "Unsupported product was entered"),
 		}
 	}
 }
@@ -354,10 +354,14 @@ impl EventHandler {
 	}
 
 	fn is_valid_product(&self, device: &libusb::Device) -> Result<(), Error> {
-		let product_id = device.device_descriptor()?.product_id();
-		match LEDGER_PIDS.contains(&product_id) {
-			true => Ok(()),
-			false => Err(Error::InvalidProduct),
+		let desc = device.device_descriptor()?;
+		let vendor_id = desc.vendor_id();
+		let product_id = desc.product_id();
+
+		if vendor_id == LEDGER_VID && LEDGER_PIDS.contains(&product_id) {
+			Ok(())
+		} else {
+			Err(Error::InvalidDevice)
 		}
 	}
 }

--- a/hw/src/ledger.rs
+++ b/hw/src/ledger.rs
@@ -372,20 +372,20 @@ impl EventHandler {
 impl libusb::Hotplug for EventHandler {
 	fn device_arrived(&mut self, device: libusb::Device) {
 		if let (Some(ledger), Ok(_)) = (self.ledger.upgrade(), Manager::is_valid_ledger(&device)) {
-			debug!("Ledger arrived");
+			debug!(target: "hw", "Ledger arrived");
 			// Wait for the device to boot up
 			thread::sleep(Duration::from_millis(1000));
 			if let Err(e) = ledger.update_devices() {
-				debug!("Ledger connect error: {:?}", e);
+				debug!(target: "hw", "Ledger connect error: {:?}", e);
 			}
 		}
 	}
 
 	fn device_left(&mut self, device: libusb::Device) {
 		if let (Some(ledger), Ok(_)) = (self.ledger.upgrade(), Manager::is_valid_ledger(&device)) {
-			debug!("Ledger left");
+			debug!(target: "hw", "Ledger left");
 			if let Err(e) = ledger.update_devices() {
-				debug!("Ledger disconnect error: {:?}", e);
+				debug!(target: "hw", "Ledger disconnect error: {:?}", e);
 			}
 		}
 	}

--- a/hw/src/lib.rs
+++ b/hw/src/lib.rs
@@ -148,16 +148,16 @@ impl HardwareWalletManager {
 		let trezor = Arc::new(trezor::Manager::new(hidapi.clone()));
 
 		// Subscribe to TREZOR V1
-		// Note this support only TREZOR V1 becasue TREZOR V2 has another vendorID for some reason
-		// Because we now only support one product only subscribe to it as the second argument `Some(1)` specifies
+		// Note, this support only TREZOR V1 becasue TREZOR V2 has another vendorID for some reason
+		// Also, we now only support one product as the second argument specifies
 		usb_context_trezor.register_callback(
 			Some(trezor::TREZOR_VID), Some(trezor::TREZOR_PIDS[0]), Some(USB_DEVICE_CLASS_DEVICE),
 			Box::new(trezor::EventHandler::new(Arc::downgrade(&trezor))))?;
 
 		// Subscribe to all Ledger Devices
 		// This means that we need to check that the given productID is supported
-		// None -> LIBUSB_HOTPLUG_MATCH_ANY
-		// http://libusb.sourceforge.net/api-1.0/group__hotplug.html#gae6c5f1add6cc754005549c7259dc35ea
+		// None => LIBUSB_HOTPLUG_MATCH_ANY, in other words that all are subscribed to
+		// More info can be found: http://libusb.sourceforge.net/api-1.0/group__hotplug.html#gae6c5f1add6cc754005549c7259dc35ea
 		usb_context_ledger.register_callback(
 			Some(ledger::LEDGER_VID), None, Some(USB_DEVICE_CLASS_DEVICE),
 			Box::new(ledger::EventHandler::new(Arc::downgrade(&ledger))))?;

--- a/hw/src/lib.rs
+++ b/hw/src/lib.rs
@@ -147,12 +147,17 @@ impl HardwareWalletManager {
 		let ledger = Arc::new(ledger::Manager::new(hidapi.clone()));
 		let trezor = Arc::new(trezor::Manager::new(hidapi.clone()));
 
-		// Note this support only TREZOR V1 becasue TREZOR V2 has both different vendorID and		  // productID
+		// Subscribe to TREZOR V1
+		// Note this support only TREZOR V1 becasue TREZOR V2 has another vendorID for some reason
+		// Because we now only support one product only subscribe to it as the second argument `Some(1)` specifies
 		usb_context_trezor.register_callback(
 			Some(trezor::TREZOR_VID), Some(trezor::TREZOR_PIDS[0]), Some(USB_DEVICE_CLASS_DEVICE),
 			Box::new(trezor::EventHandler::new(Arc::downgrade(&trezor))))?;
 
-		// Only specify vendorID and usb device class  to start with (unsure if 1 listens for both 0 and 1 or only 1)
+		// Subscribe to all Ledger Devices
+		// This means that we need to check that the given productID is supported
+		// None -> LIBUSB_HOTPLUG_MATCH_ANY
+		// http://libusb.sourceforge.net/api-1.0/group__hotplug.html#gae6c5f1add6cc754005549c7259dc35ea
 		usb_context_ledger.register_callback(
 			Some(ledger::LEDGER_VID), None, Some(USB_DEVICE_CLASS_DEVICE),
 			Box::new(ledger::EventHandler::new(Arc::downgrade(&ledger))))?;

--- a/hw/src/lib.rs
+++ b/hw/src/lib.rs
@@ -33,12 +33,15 @@ use ethkey::{Address, Signature};
 
 use parking_lot::Mutex;
 use std::fmt;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 use std::sync::atomic;
 use std::sync::atomic::AtomicBool;
 use std::thread;
 use std::time::Duration;
 use ethereum_types::U256;
+
+const USB_DEVICE_CLASS_DEVICE: u8 = 0;
+
 
 /// Hardware wallet error.
 #[derive(Debug)]
@@ -128,84 +131,76 @@ impl From<libusb::Error> for Error {
 
 /// Hardware wallet management interface.
 pub struct HardwareWalletManager {
-	update_thread: Option<thread::JoinHandle<()>>,
+	active_threads: Vec<Option<thread::JoinHandle<()>>>,
 	exiting: Arc<AtomicBool>,
 	ledger: Arc<ledger::Manager>,
 	trezor: Arc<trezor::Manager>,
 }
 
-struct EventHandler {
-	ledger: Weak<ledger::Manager>,
-	trezor: Weak<trezor::Manager>,
-}
-
-impl libusb::Hotplug for EventHandler {
-	fn device_arrived(&mut self, _device: libusb::Device) {
-		debug!("USB Device arrived");
-		if let (Some(l), Some(t)) = (self.ledger.upgrade(), self.trezor.upgrade()) {
-			for _ in 0..10 {
-				let l_devices = l.update_devices().unwrap_or_else(|e| {
-					debug!("Error enumerating Ledger devices: {}", e);
-					0
-				});
-				let t_devices = t.update_devices().unwrap_or_else(|e| {
-					debug!("Error enumerating Trezor devices: {}", e);
-					0
-				});
-				if l_devices + t_devices > 0 {
-					break;
-				}
-				thread::sleep(Duration::from_millis(200));
-			}
-		}
-	}
-
-	fn device_left(&mut self, _device: libusb::Device) {
-		debug!("USB Device lost");
-		if let (Some(l), Some(t)) = (self.ledger.upgrade(), self.trezor.upgrade()) {
-			l.update_devices().unwrap_or_else(|e| {debug!("Error enumerating Ledger devices: {}", e); 0});
-			t.update_devices().unwrap_or_else(|e| {debug!("Error enumerating Trezor devices: {}", e); 0});
-		}
-	}
-}
 
 impl HardwareWalletManager {
 	pub fn new() -> Result<HardwareWalletManager, Error> {
-		let usb_context = Arc::new(libusb::Context::new()?);
+		let usb_context_trezor = Arc::new(libusb::Context::new()?);
+		let usb_context_ledger = Arc::new(libusb::Context::new()?);
+		let mut active_threads: Vec<Option<thread::JoinHandle<()>>> = Vec::with_capacity(10);
 		let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new().map_err(|e| Error::Hid(e.to_string().clone()))?));
 		let ledger = Arc::new(ledger::Manager::new(hidapi.clone()));
 		let trezor = Arc::new(trezor::Manager::new(hidapi.clone()));
-		usb_context.register_callback(
-			None, None, None,
-			Box::new(EventHandler {
-				ledger: Arc::downgrade(&ledger),
-				trezor: Arc::downgrade(&trezor),
-			}),
-		)?;
+
+		// Note this support only TREZOR V1 becasue TREZOR V2 has both different vendorID and		  // productID
+		usb_context_trezor.register_callback(
+			Some(trezor::TREZOR_VID), Some(trezor::TREZOR_PIDS[0]), Some(USB_DEVICE_CLASS_DEVICE),
+			Box::new(trezor::EventHandler::new(Arc::downgrade(&trezor))))?;
+
+		// Only specify vendorID and usb device class  to start with (unsure if 1 listens for both 0 and 1 or only 1)
+		usb_context_ledger.register_callback(
+			Some(ledger::LEDGER_VID), None, Some(USB_DEVICE_CLASS_DEVICE),
+			Box::new(ledger::EventHandler::new(Arc::downgrade(&ledger))))?;
+
 		let exiting = Arc::new(AtomicBool::new(false));
-		let thread_exiting = exiting.clone();
+		let thread_exiting_ledger = exiting.clone();
+		let thread_exiting_trezor = exiting.clone();
 		let l = ledger.clone();
 		let t = trezor.clone();
-		let thread = thread::Builder::new()
-			.name("hw_wallet".to_string())
+
+		// Ledger event thread
+		// FIXME: check if we can move it to ledger.rs (lifetime issue)
+		active_threads.push(thread::Builder::new()
+			.name("hw_wallet_ledger".to_string())
 			.spawn(move || {
 				if let Err(e) = l.update_devices() {
 					debug!("Error updating ledger devices: {}", e);
 				}
-				if let Err(e) = t.update_devices() {
-					debug!("Error updating trezor devices: {}", e);
-				}
 				loop {
-					usb_context.handle_events(Some(Duration::from_millis(500)))
+					usb_context_ledger.handle_events(Some(Duration::from_millis(500)))
 					           .unwrap_or_else(|e| debug!("Error processing USB events: {}", e));
-					if thread_exiting.load(atomic::Ordering::Acquire) {
+					if thread_exiting_ledger.load(atomic::Ordering::Acquire) {
 						break;
 					}
 				}
 			})
-			.ok();
+			.ok());
+
+		// Trezor event thread
+		// FIXME: check if we can move it to trezor.rs (lifetime issue)
+		active_threads.push(thread::Builder::new()
+			.name("hw_wallet_trezor".to_string())
+			.spawn(move || {
+				if let Err(e) = t.update_devices() {
+					debug!("Error updating ledger devices: {}", e);
+				}
+				loop {
+					usb_context_trezor.handle_events(Some(Duration::from_millis(500)))
+					           .unwrap_or_else(|e| debug!("Error processing USB events: {}", e));
+					if thread_exiting_trezor.load(atomic::Ordering::Acquire) {
+						break;
+					}
+				}
+			})
+			.ok());
+
 		Ok(HardwareWalletManager {
-			update_thread: thread,
+			active_threads: active_threads,
 			exiting: exiting,
 			ledger: ledger,
 			trezor: trezor,
@@ -260,9 +255,11 @@ impl HardwareWalletManager {
 impl Drop for HardwareWalletManager {
 	fn drop(&mut self) {
 		self.exiting.store(true, atomic::Ordering::Release);
-		if let Some(thread) = self.update_thread.take() {
-			thread.thread().unpark();
-			thread.join().ok();
+		for thread in self.active_threads.iter_mut() {
+			if let Some(thread) = thread.take() {
+				thread.thread().unpark();
+				thread.join().ok();
+			}
 		}
 	}
 }

--- a/hw/src/lib.rs
+++ b/hw/src/lib.rs
@@ -173,11 +173,12 @@ impl HardwareWalletManager {
 			.name("hw_wallet_ledger".to_string())
 			.spawn(move || {
 				if let Err(e) = l.update_devices() {
-					debug!("Ledger could not connect at startup, error: {}", e);
+					debug!(target: "hw", "Ledger couldn't connect at startup, error: {}", e);
+					//debug!("Ledger could not connect at startup, error: {}", e);
 				}
 				loop {
 					usb_context_ledger.handle_events(Some(Duration::from_millis(500)))
-					           .unwrap_or_else(|e| debug!("Ledger event handler error: {}", e));
+					           .unwrap_or_else(|e| debug!(target: "hw", "Ledger event handler error: {}", e));
 					if thread_exiting_ledger.load(atomic::Ordering::Acquire) {
 						break;
 					}
@@ -190,11 +191,11 @@ impl HardwareWalletManager {
 			.name("hw_wallet_trezor".to_string())
 			.spawn(move || {
 				if let Err(e) = t.update_devices() {
-					debug!("Trezor could not connect at startup, error: {}", e);
+					debug!(target: "hw", "Trezor couldn't connect at startup, error: {}", e);
 				}
 				loop {
 					usb_context_trezor.handle_events(Some(Duration::from_millis(500)))
-					           .unwrap_or_else(|e| debug!("Trezor event handler error: {}", e));
+					           .unwrap_or_else(|e| debug!(target: "hw", "Trezor event handler error: {}", e));
 					if thread_exiting_trezor.load(atomic::Ordering::Acquire) {
 						break;
 					}

--- a/hw/src/trezor.rs
+++ b/hw/src/trezor.rs
@@ -417,22 +417,22 @@ impl EventHandler {
 
 impl libusb::Hotplug for EventHandler {
 	fn device_arrived(&mut self, _device: libusb::Device) {
-		debug!("Trezor V1 arrived");
+		debug!(target: "hw", "Trezor V1 arrived");
 		if let Some(trezor) = self.trezor.upgrade() {
 			// Wait for the device to boot up
 			thread::sleep(Duration::from_millis(1000));
 			if let Err(e) = trezor.update_devices() {
-				debug!("Trezor V1 connect error: {:?}", e);
+				debug!(target: "hw", "Trezor V1 connect error: {:?}", e);
 			}
 
 		}
 	}
 
 	fn device_left(&mut self, _device: libusb::Device) {
-		debug!("Trezor V1 left");
+		debug!(target: "hw", "Trezor V1 left");
 		if let Some(trezor) = self.trezor.upgrade() {
 			if let Err(e) = trezor.update_devices() {
-				debug!("Trezor V1 disconnect error: {:?}", e);
+				debug!(target: "hw", "Trezor V1 disconnect error: {:?}", e);
 			}
 		}
 	}


### PR DESCRIPTION
Hi,

This PR changes how events from ```libusb/Hotplug``` are subscribed in more fine-grained manner i.e, by manufacturer_id, product_id and USB class. 

By doing this it fixes [#7516](https://github.com/paritytech/parity/issues/7516) & [#7793](https://github.com/paritytech/parity/issues/7793) it seems to be Windows only issue because we tested it earlier on both Linux/Ubuntu and OSX