### PR TITLE
SecretStore: secretstore_generateDocumentKey RPC

### DIFF
--- a/rpc/src/v1/helpers/secretstore.rs
+++ b/rpc/src/v1/helpers/secretstore.rs
@@ -16,16 +16,25 @@
 
 use std::collections::BTreeSet;
 use rand::{Rng, OsRng};
-use ethkey::{Public, Secret, math};
+use ethkey::{Public, Secret, Random, Generator, math};
 use crypto;
 use bytes::Bytes;
 use jsonrpc_core::Error;
 use v1::helpers::errors;
-use v1::types::{H256, H512};
+use v1::types::{H256, H512, EncryptedDocumentKey};
 use tiny_keccak::Keccak;
 
 /// Initialization vector length.
 const INIT_VEC_LEN: usize = 16;
+
+/// Generate document key to store in secret store.
+pub fn generate_document_key(server_key_public: Public) -> Result<EncryptedDocumentKey, Error> {
+	// generate random plain document key
+	let document_key = Random.generate().map_err(errors::encryption)?;
+
+	// encrypt this key using server key
+	encrypt_secret(document_key.public(), &server_key_public)
+}
 
 /// Encrypt document with distributely generated key.
 pub fn encrypt_document(key: Bytes, document: Bytes) -> Result<Bytes, Error> {
@@ -112,6 +121,31 @@ fn decrypt_with_shadow_coefficients(mut decrypted_shadow: Public, mut common_sha
 	math::public_add(&mut decrypted_shadow, &common_shadow_point)
 		.map_err(errors::encryption)?;
 	Ok(decrypted_shadow)
+}
+
+fn encrypt_secret(secret: &Public, joint_public: &Public) -> Result<EncryptedDocumentKey, Error> {
+	// TODO: it is copypaste of `encrypt_secret` from secret_store/src/key_server_cluster/math.rs
+	// use shared version from SS math library, when it'll be available
+
+	let key_pair = Random.generate()
+		.map_err(errors::encryption)?;
+
+	// k * T
+	let mut common_point = math::generation_point();
+	math::public_mul_secret(&mut common_point, key_pair.secret())
+		.map_err(errors::encryption)?;
+
+	// M + k * y
+	let mut encrypted_point = joint_public.clone();
+	math::public_mul_secret(&mut encrypted_point, key_pair.secret())
+		.map_err(errors::encryption)?;
+	math::public_add(&mut encrypted_point, secret)
+		.map_err(errors::encryption)?;
+
+	Ok(EncryptedDocumentKey {
+		common_point: common_point.into(),
+		encrypted_point: encrypted_point.into(),
+	})
 }
 
 #[cfg(test)]

--- a/rpc/src/v1/impls/secretstore.rs
+++ b/rpc/src/v1/impls/secretstore.rs
@@ -65,8 +65,11 @@ impl SecretStoreClient {
 }
 
 impl SecretStore for SecretStoreClient {
-	fn generate_document_key(&self, server_key_public: H512) -> Result<EncryptedDocumentKey> {
-		generate_document_key(server_key_public.into())
+	fn generate_document_key(&self, address: H160, password: String, server_key_public: H512) -> Result<EncryptedDocumentKey> {
+		let store = self.account_provider()?;
+		let account_public = store.account_public(address.into(), &password)
+			.map_err(|e| errors::account("Could not read account public.", e))?;
+		generate_document_key(account_public, server_key_public.into())
 	}
 
 	fn encrypt(&self, address: H160, password: String, key: Bytes, data: Bytes) -> Result<Bytes> {

--- a/rpc/src/v1/impls/secretstore.rs
+++ b/rpc/src/v1/impls/secretstore.rs
@@ -26,9 +26,10 @@ use ethcore::account_provider::AccountProvider;
 use jsonrpc_core::Result;
 use v1::helpers::errors;
 use v1::helpers::accounts::unwrap_provider;
-use v1::helpers::secretstore::{encrypt_document, decrypt_document, decrypt_document_with_shadow, ordered_servers_keccak};
+use v1::helpers::secretstore::{generate_document_key, encrypt_document,
+	decrypt_document, decrypt_document_with_shadow, ordered_servers_keccak};
 use v1::traits::SecretStore;
-use v1::types::{H160, H256, H512, Bytes};
+use v1::types::{H160, H256, H512, Bytes, EncryptedDocumentKey};
 
 /// Parity implementation.
 pub struct SecretStoreClient {
@@ -64,6 +65,10 @@ impl SecretStoreClient {
 }
 
 impl SecretStore for SecretStoreClient {
+	fn generate_document_key(&self, server_key_public: H512) -> Result<EncryptedDocumentKey> {
+		generate_document_key(server_key_public.into())
+	}
+
 	fn encrypt(&self, address: H160, password: String, key: Bytes, data: Bytes) -> Result<Bytes> {
 		encrypt_document(self.decrypt_key(address, password, key)?, data.0)
 			.map(Into::into)

--- a/rpc/src/v1/tests/mocked/secretstore.rs
+++ b/rpc/src/v1/tests/mocked/secretstore.rs
@@ -144,3 +144,17 @@ fn rpc_secretstore_sign_raw_hash() {
 	let hash = "0000000000000000000000000000000000000000000000000000000000000001".parse().unwrap();
 	assert!(verify_public(key_pair.public(), &signature, &hash).unwrap());
 }
+
+#[test]
+fn rpc_secretstore_generate_document_key() {
+	let deps = Dependencies::new();
+	let io = deps.default_client();
+
+	// execute generation request
+	let generation_request = r#"{"jsonrpc": "2.0", "method": "secretstore_generateDocumentKey", "params":[
+		"0x843645726384530ffb0c52f175278143b5a93959af7864460f5a4fec9afd1450cfb8aef63dec90657f43f55b13e0a73c7524d4e9a13c051b4e5f1e53f39ecd91"
+	], "id": 1}"#;
+	let _ = io.handle_request_sync(&generation_request).unwrap();
+
+	// the only thing we can check is that key is generated without errors, because generation is randomized
+}

--- a/rpc/src/v1/tests/mocked/secretstore.rs
+++ b/rpc/src/v1/tests/mocked/secretstore.rs
@@ -16,6 +16,7 @@
 
 use std::sync::Arc;
 
+use crypto::DEFAULT_MAC;
 use ethcore::account_provider::AccountProvider;
 use ethkey::{KeyPair, Signature, verify_public};
 
@@ -25,7 +26,7 @@ use v1::metadata::Metadata;
 use v1::SecretStoreClient;
 use v1::traits::secretstore::SecretStore;
 use v1::helpers::secretstore::ordered_servers_keccak;
-use v1::types::H256;
+use v1::types::{H256, EncryptedDocumentKey};
 
 struct Dependencies {
 	pub accounts: Arc<AccountProvider>,
@@ -150,11 +151,25 @@ fn rpc_secretstore_generate_document_key() {
 	let deps = Dependencies::new();
 	let io = deps.default_client();
 
+	// insert new account
+	let secret = "82758356bf46b42710d3946a8efa612b7bf5e125e4d49f28facf1139db4a46f4".parse().unwrap();
+	let key_pair = KeyPair::from_secret(secret).unwrap();
+	deps.accounts.insert_account(key_pair.secret().clone(), "password").unwrap();
+
 	// execute generation request
 	let generation_request = r#"{"jsonrpc": "2.0", "method": "secretstore_generateDocumentKey", "params":[
+		"0x00dfE63B22312ab4329aD0d28CaD8Af987A01932", "password",
 		"0x843645726384530ffb0c52f175278143b5a93959af7864460f5a4fec9afd1450cfb8aef63dec90657f43f55b13e0a73c7524d4e9a13c051b4e5f1e53f39ecd91"
 	], "id": 1}"#;
-	let _ = io.handle_request_sync(&generation_request).unwrap();
+	let generation_response = io.handle_request_sync(&generation_request).unwrap();
+	let generation_response = generation_response.replace(r#"{"jsonrpc":"2.0","result":"#, "");
+	let generation_response = generation_response.replace(r#","id":1}"#, "");
+	let generation_response: EncryptedDocumentKey = serde_json::from_str(&generation_response).unwrap();
 
-	// the only thing we can check is that key is generated without errors, because generation is randomized
+	// the only thing we can check is that 'encrypted_key' can be decrypted by passed account
+	assert!(deps.accounts.decrypt(
+		"00dfE63B22312ab4329aD0d28CaD8Af987A01932".parse().unwrap(),
+		Some("password".into()),
+		&DEFAULT_MAC,
+		&generation_response.encrypted_key.0).is_ok());
 }

--- a/rpc/src/v1/traits/secretstore.rs
+++ b/rpc/src/v1/traits/secretstore.rs
@@ -25,9 +25,9 @@ build_rpc_trait! {
 	/// Parity-specific rpc interface.
 	pub trait SecretStore {
 		/// Generate document key to store in secret store.
-		/// Arguments: `server_key_public`.
+		/// Arguments: `account`, `password`, `server_key_public`.
 		#[rpc(name = "secretstore_generateDocumentKey")]
-		fn generate_document_key(&self, H512) -> Result<EncryptedDocumentKey>;
+		fn generate_document_key(&self, H160, String, H512) -> Result<EncryptedDocumentKey>;
 
 		/// Encrypt data with key, received from secret store.
 		/// Arguments: `account`, `password`, `key`, `data`.

--- a/rpc/src/v1/traits/secretstore.rs
+++ b/rpc/src/v1/traits/secretstore.rs
@@ -19,11 +19,16 @@
 use std::collections::BTreeSet;
 use jsonrpc_core::Result;
 
-use v1::types::{H160, H256, H512, Bytes};
+use v1::types::{H160, H256, H512, Bytes, EncryptedDocumentKey};
 
 build_rpc_trait! {
 	/// Parity-specific rpc interface.
 	pub trait SecretStore {
+		/// Generate document key to store in secret store.
+		/// Arguments: `server_key_public`.
+		#[rpc(name = "secretstore_generateDocumentKey")]
+		fn generate_document_key(&self, H512) -> Result<EncryptedDocumentKey>;
+
 		/// Encrypt data with key, received from secret store.
 		/// Arguments: `account`, `password`, `key`, `data`.
 		#[rpc(name = "secretstore_encrypt")]

--- a/rpc/src/v1/types/mod.rs
+++ b/rpc/src/v1/types/mod.rs
@@ -35,6 +35,7 @@ mod node_kind;
 mod provenance;
 mod receipt;
 mod rpc_settings;
+mod secretstore;
 mod sync;
 mod trace;
 mod trace_filter;
@@ -67,6 +68,7 @@ pub use self::node_kind::{NodeKind, Availability, Capability};
 pub use self::provenance::{Origin, DappId};
 pub use self::receipt::Receipt;
 pub use self::rpc_settings::RpcSettings;
+pub use self::secretstore::EncryptedDocumentKey;
 pub use self::sync::{
 	SyncStatus, SyncInfo, Peers, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo,
 	TransactionStats, ChainStatus, EthProtocolInfo, PipProtocolInfo,

--- a/rpc/src/v1/types/secretstore.rs
+++ b/rpc/src/v1/types/secretstore.rs
@@ -14,15 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use v1::types::H512;
+use v1::types::{Bytes, H512};
 
-/// Sync info
+/// Encrypted document key.
 #[derive(Default, Debug, Serialize, PartialEq)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct EncryptedDocumentKey {
-	/// Common encryption point.
+	/// Common encryption point. Pass this to Secret Store 'Document key storing session'
 	pub common_point: H512,
-	/// Ecnrypted point.
+	/// Ecnrypted point. Pass this to Secret Store 'Document key storing session'.
 	pub encrypted_point: H512,
+	/// Document key itself, encrypted with passed account public. Pass this to 'secretstore_encrypt'.
+	pub encrypted_key: Bytes,
 }
 
 #[cfg(test)]
@@ -35,9 +38,15 @@ mod tests {
 		let initial = EncryptedDocumentKey {
 			common_point: 1.into(),
 			encrypted_point: 2.into(),
+			encrypted_key: vec![3].into(),
 		};
 
 		let serialized = serde_json::to_string(&initial).unwrap();
-		assert_eq!(serialized, r#"{"common_point":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001","encrypted_point":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002"}"#);
+		assert_eq!(serialized, r#"{"common_point":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001","encrypted_point":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002","encrypted_key":"0x03"}"#);
+
+		let deserialized: EncryptedDocumentKey = serde_json::from_str(&serialized).unwrap();
+		assert_eq!(deserialized.common_point, 1.into());
+		assert_eq!(deserialized.encrypted_point, 2.into());
+		assert_eq!(deserialized.encrypted_key, vec![3].into());
 	}
 }

--- a/rpc/src/v1/types/secretstore.rs
+++ b/rpc/src/v1/types/secretstore.rs
@@ -1,0 +1,43 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use v1::types::H512;
+
+/// Sync info
+#[derive(Default, Debug, Serialize, PartialEq)]
+pub struct EncryptedDocumentKey {
+	/// Common encryption point.
+	pub common_point: H512,
+	/// Ecnrypted point.
+	pub encrypted_point: H512,
+}
+
+#[cfg(test)]
+mod tests {
+	use serde_json;
+	use super::EncryptedDocumentKey;
+
+	#[test]
+	fn test_serialize_encrypted_document_key() {
+		let initial = EncryptedDocumentKey {
+			common_point: 1.into(),
+			encrypted_point: 2.into(),
+		};
+
+		let serialized = serde_json::to_string(&initial).unwrap();
+		assert_eq!(serialized, r#"{"common_point":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001","encrypted_point":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002"}"#);
+	}
+}


### PR DESCRIPTION
Brief overview:
1) this is needed to support encryption/decryption in service contract
2) this is required to actually use [Document key storing session](https://paritytech.github.io/wiki/Secret-Store#document-key-storing-session) by only calling Parity RPCs and SS API
3) using [Document key storing session](https://paritytech.github.io/wiki/Secret-Store#document-key-storing-session) via HTTP API is not safe now (it is vulnerable to MITM attack and HTTP API will be changed later). It should be OK to use it via service contract, though

Usage example (in this example document key is both generated and restored at the Parity node, which executes RPC requests - it is not known to any SS node):
1) generate signature for key id:
```bash
curl --data-binary '{"jsonrpc": "2.0", "method": "secretstore_signRawHash", "params": ["0x00a329c0648769A73afAc7F9381E08FB43dBEA72", "", "0x0000000000000000000000000000000000000000000000000000000000000009"], "id":1 }' -H 'content-type: application/json' http://127.0.0.1:8545/

{"jsonrpc":"2.0","result":"0xae42e6f9efdba7e3e33b8aa7edf46da4a36094725d6d86e8905515d5b713b81b6958e09ba5c8dfe5fe4f6d705d8968bed73f27a638edfff75b6d76a48a98514901","id":1}
```
2) generate server key:
```bash
curl -X POST http://localhost:8082/shadow/0000000000000000000000000000000000000000000000000000000000000009/ae42e6f9efdba7e3e33b8aa7edf46da4a36094725d6d86e8905515d5b713b81b6958e09ba5c8dfe5fe4f6d705d8968bed73f27a638edfff75b6d76a48a98514901/${1:-1}

"0x2eabc29df5b62c75011bf1016237212b6305f8bae0f979b7b92250cfea06c20fe1689fc6d98964be64532598e3db7fc5712ad24b95e161f95bcfe1c6f859da3a"
```
3) **generate document key (this PR)**:
```bash
curl --data-binary '{"jsonrpc": "2.0", "method": "secretstore_generateDocumentKey", "params": ["0x00a329c0648769A73afAc7F9381E08FB43dBEA72", "","0x2eabc29df5b62c75011bf1016237212b6305f8bae0f979b7b92250cfea06c20fe1689fc6d98964be64532598e3db7fc5712ad24b95e161f95bcfe1c6f859da3a"], "id":1 }' -H 'content-type: application/json' http://127.0.0.1:8545/

{"jsonrpc":"2.0","result":{"common_point":"0x18b8eb0ce96d3bb53141be03b7c411b6a5c506329bae2b10f5844134ca14207e0bb835155b38d649aab87f85e0e155e154f7c1e20143467d4a2890f8d9c08dc0","encrypted_key":"0x04300287a477e08dfe6e8202f56671ce9398063aee90ba54bdf6c03da924544637b260b9aae0bef9b779890e1885a2e67de636ee0fc6e2bcfb46aeda12c9e684979dd16d0d496b932f169e5a859516f9ac46a2575583162c357357f29aa525641ab6a5ddb898ff6b89b899a67c37833ccd7574fea76717005655ea7d6543e5ae4c56d6d088036a7e84b46dd18d2f8867bd351a8e2eddf24790544347c80727541b822dd351ed99d53b9a4fc88944908236","encrypted_point":"0x35457eeb38f9f3c2538492a5740f96cc70ea343210675d9821935dfa9e32a678ae260a2ae45df48c9fadb2abcc1be88dc2fcb15b3ddfa9db51d9a0e298a0cefd"},"id":1}
```

4) encrypt document using `encrypted_key` field from `secretstore_generateDocumentKey` call:
```bash
curl --data-binary '{"jsonrpc": "2.0", "method": "secretstore_encrypt", "params": ["0x00a329c0648769A73afAc7F9381E08FB43dBEA72", "", "0x04300287a477e08dfe6e8202f56671ce9398063aee90ba54bdf6c03da924544637b260b9aae0bef9b779890e1885a2e67de636ee0fc6e2bcfb46aeda12c9e684979dd16d0d496b932f169e5a859516f9ac46a2575583162c357357f29aa525641ab6a5ddb898ff6b89b899a67c37833ccd7574fea76717005655ea7d6543e5ae4c56d6d088036a7e84b46dd18d2f8867bd351a8e2eddf24790544347c80727541b822dd351ed99d53b9a4fc88944908236", "0xdeadbeef"], "id":1 }' -H 'content-type: application/json' http://127.0.0.1:8545/

{"jsonrpc":"2.0","result":"0xd2e72c288778658a73cee7d7eb6d2b2bcb5fcc3d","id":1}
```

5) store document key in SS:
```bash
curl -X POST http://localhost:8082/shadow/0000000000000000000000000000000000000000000000000000000000000009/ae42e6f9efdba7e3e33b8aa7edf46da4a36094725d6d86e8905515d5b713b81b6958e09ba5c8dfe5fe4f6d705d8968bed73f27a638edfff75b6d76a48a98514901/18b8eb0ce96d3bb53141be03b7c411b6a5c506329bae2b10f5844134ca14207e0bb835155b38d649aab87f85e0e155e154f7c1e20143467d4a2890f8d9c08dc0/35457eeb38f9f3c2538492a5740f96cc70ea343210675d9821935dfa9e32a678ae260a2ae45df48c9fadb2abcc1be88dc2fcb15b3ddfa9db51d9a0e298a0cefd
```

6) query document key shadow:
```bash
curl http://localhost:8082/shadow/0000000000000000000000000000000000000000000000000000000000000009/ae42e6f9efdba7e3e33b8aa7edf46da4a36094725d6d86e8905515d5b713b81b6958e09ba5c8dfe5fe4f6d705d8968bed73f27a638edfff75b6d76a48a98514901

{"decrypted_secret":"0x02f3b9ebfef040947e556b2751e44e8ea7a116f0cb63bd5b65fd010f42e5f593ab11cbddd329dca762bfd2c799315232308a7ec5d1e488e3015d46d2af7ef14f","common_point":"0x18b8eb0ce96d3bb53141be03b7c411b6a5c506329bae2b10f5844134ca14207ef447caeaa4c729b65547807a1f1eaa1eab083e1dfebcb982b5d76f06263f6e6f","decrypt_shadows":["0x04bd1ad33241a2647629003b8093d08ee60f1c2042e5e923572485bc6e0cde1c2ecbe5a5b6fc7ce5732958ae4d2e824b2017cb4f69ff622237c72b62d3b05fa78e26e025507c383d2a9affc502ce86284caed3ed310d232dcd9794b97145ffc58bdc8c96b44a578b4d0ba2fc48610982bc6c3e214c338e27170e628f27670cc4d234bffbfe5388054cd3c710c30b89cc99","0x04add58de09275090905507af45d3367c25ac225769cc669a7e1b8e39368f61574067846148ffd7066339d367a87170609720bf57b1d61f61d19260e18a4ab0da0a1eb5e7f2790d34ac591bafb8f02409038d1ab2ad4233aae6132d64409f5898d8194e453f2d965f044740238d4911618bf2879492b84fbf0635d235cc4211f10e2ea71412cb0c5fe37de42d8e7fefd1b"]}
```

7) decrypt document using document key shadow:
```bash
curl --data-binary '{"jsonrpc": "2.0", "method": "secretstore_shadowDecrypt", "params": ["0x00a329c0648769A73afAc7F9381E08FB43dBEA72", "", "0x02f3b9ebfef040947e556b2751e44e8ea7a116f0cb63bd5b65fd010f42e5f593ab11cbddd329dca762bfd2c799315232308a7ec5d1e488e3015d46d2af7ef14f", "0x18b8eb0ce96d3bb53141be03b7c411b6a5c506329bae2b10f5844134ca14207ef447caeaa4c729b65547807a1f1eaa1eab083e1dfebcb982b5d76f06263f6e6f", ["0x04bd1ad33241a2647629003b8093d08ee60f1c2042e5e923572485bc6e0cde1c2ecbe5a5b6fc7ce5732958ae4d2e824b2017cb4f69ff622237c72b62d3b05fa78e26e025507c383d2a9affc502ce86284caed3ed310d232dcd9794b97145ffc58bdc8c96b44a578b4d0ba2fc48610982bc6c3e214c338e27170e628f27670cc4d234bffbfe5388054cd3c710c30b89cc99","0x04add58de09275090905507af45d3367c25ac225769cc669a7e1b8e39368f61574067846148ffd7066339d367a87170609720bf57b1d61f61d19260e18a4ab0da0a1eb5e7f2790d34ac591bafb8f02409038d1ab2ad4233aae6132d64409f5898d8194e453f2d965f044740238d4911618bf2879492b84fbf0635d235cc4211f10e2ea71412cb0c5fe37de42d8e7fefd1b"], "0xd2e72c288778658a73cee7d7eb6d2b2bcb5fcc3d"], "id":1 }' -H 'content-type: application/json' http://127.0.0.1:8545/

{"jsonrpc":"2.0","result":"0xdeadbeef","id":1}
```

I'll make a PR in wiki repo after/if this PR will be accepted.