### PR TITLE
Read registry_address from given block

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1827,7 +1827,7 @@ impl BlockChainClient for Client {
 		self.registrar_address.clone()
 	}
 
-	fn registry_address(&self, name: String) -> Option<Address> {
+	fn registry_address(&self, name: String, block: BlockId) -> Option<Address> {
 		let address = match self.registrar_address {
 			Some(address) => address,
 			None => return None,
@@ -1835,7 +1835,7 @@ impl BlockChainClient for Client {
 
 		self.registrar.functions()
 			.get_address()
-			.call(keccak(name.as_bytes()), "A", &|data| self.call_contract(BlockId::Latest, address, data))
+			.call(keccak(name.as_bytes()), "A", &|data| self.call_contract(block, address, data))
 			.ok()
 			.and_then(|a| if a.is_zero() {
 				None

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -785,7 +785,7 @@ impl BlockChainClient for TestBlockChainClient {
 
 	fn registrar_address(&self) -> Option<Address> { None }
 
-	fn registry_address(&self, _name: String) -> Option<Address> { None }
+	fn registry_address(&self, _name: String, _block: BlockId) -> Option<Address> { None }
 
 	fn eip86_transition(&self) -> u64 { u64::max_value() }
 }

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -279,7 +279,7 @@ pub trait BlockChainClient : Sync + Send {
 	fn registrar_address(&self) -> Option<Address>;
 
 	/// Get the address of a particular blockchain service, if available.
-	fn registry_address(&self, name: String) -> Option<Address>;
+	fn registry_address(&self, name: String, block: BlockId) -> Option<Address>;
 
 	/// Get the EIP-86 transition block number.
 	fn eip86_transition(&self) -> u64;

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1238,7 +1238,7 @@ impl ServiceTransactionAction {
 
 impl<'a> ::ethcore_miner::service_transaction_checker::ContractCaller for &'a MiningBlockChainClient {
 	fn registry_address(&self, name: &str) -> Option<Address> {
-		MiningBlockChainClient::registry_address(*self, name.into())
+		MiningBlockChainClient::registry_address(*self, name.into(), BlockId::Latest)
 	}
 
 	fn call_contract(&self, block: BlockId, address: Address, data: Vec<u8>) -> Result<Vec<u8>, String> {

--- a/secret_store/src/acl_storage.rs
+++ b/secret_store/src/acl_storage.rs
@@ -94,7 +94,7 @@ impl CachedContract {
 
 	pub fn update(&mut self) {
 		if let Some(client) = self.client.get() {
-			match client.registry_address(ACL_CHECKER_CONTRACT_REGISTRY_NAME.to_owned()) {
+			match client.registry_address(ACL_CHECKER_CONTRACT_REGISTRY_NAME.to_owned(), BlockId::Latest) {
 				Some(new_contract_addr) if Some(new_contract_addr).as_ref() != self.contract_addr.as_ref() => {
 					trace!(target: "secretstore", "Configuring for ACL checker contract from {}", new_contract_addr);
 					self.contract_addr = Some(new_contract_addr);

--- a/secret_store/src/key_server_set.rs
+++ b/secret_store/src/key_server_set.rs
@@ -325,7 +325,7 @@ impl CachedContract {
 
 	fn read_from_registry_if_required(&mut self, client: &Client, enacted: Vec<H256>, retracted: Vec<H256>) {
 		// read new contract from registry
-		let new_contract_addr = client.registry_address(KEY_SERVER_SET_CONTRACT_REGISTRY_NAME.to_owned());
+		let new_contract_addr = client.registry_address(KEY_SERVER_SET_CONTRACT_REGISTRY_NAME.to_owned(), BlockId::Latest);
 
 		// new contract installed => read nodes set from the contract
 		if self.contract_address.as_ref() != new_contract_addr.as_ref() {

--- a/secret_store/src/listener/service_contract.rs
+++ b/secret_store/src/listener/service_contract.rs
@@ -96,7 +96,7 @@ impl OnChainServiceContract {
 	/// Create new on-chain service contract.
 	pub fn new(client: TrustedClient, address: ContractAddress, self_key_pair: Arc<NodeKeyPair>) -> Self {
 		let contract_addr = match address {
-			ContractAddress::Registry => client.get().and_then(|c| c.registry_address(SERVICE_CONTRACT_REGISTRY_NAME.to_owned())
+			ContractAddress::Registry => client.get().and_then(|c| c.registry_address(SERVICE_CONTRACT_REGISTRY_NAME.to_owned(), BlockId::Latest)
 				.map(|address| {
 					trace!(target: "secretstore", "{}: installing service contract from address {}",
 						self_key_pair.public(), address);
@@ -130,7 +130,7 @@ impl ServiceContract for OnChainServiceContract {
 		if let &ContractAddress::Registry = &self.address {
 			if let Some(client) = self.client.get() {
 				// update contract address from registry
-				let service_contract_addr = client.registry_address(SERVICE_CONTRACT_REGISTRY_NAME.to_owned()).unwrap_or_default();
+				let service_contract_addr = client.registry_address(SERVICE_CONTRACT_REGISTRY_NAME.to_owned(), BlockId::Latest).unwrap_or_default();
 				if self.data.read().contract_address != service_contract_addr {
 					trace!(target: "secretstore", "{}: installing service contract from address {}",
 						self.self_key_pair.public(), service_contract_addr);

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -191,7 +191,7 @@ impl Updater {
 		}
 
 		let client = self.client.upgrade().ok_or_else(|| "Cannot obtain client")?;
-		let address = client.registry_address("operations".into()).ok_or_else(|| "Cannot get operations contract address")?;
+		let address = client.registry_address("operations".into(), BlockId::Latest).ok_or_else(|| "Cannot get operations contract address")?;
 		let do_call = |data| client.call_contract(BlockId::Latest, address, data).map_err(|e| format!("{:?}", e));
 
 		trace!(target: "updater", "Looking up this_fork for our release: {}/{:?}", CLIENT_ID, self.this.hash);


### PR DESCRIPTION
In brief: before reacting to contract events (like serving key generation requests in SS) we might want to wait for several confirmations. But the similar situation is with the contract itself - there might be a reorg to previous/other address within a few blocks. So it is a good idea to rely on the address from the same block we're reading requests from.

Original TODO: https://github.com/paritytech/parity/blob/fab03398dda7e768b1b620c07bf82cbfed662fa8/secret_store/src/listener/service_contract.rs#L128 will be fixed later if this PR will be accepted.