### PR TITLE
Validate gasLimitBoundDivisor != 0

### DIFF
--- a/json/src/spec/error.rs
+++ b/json/src/spec/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/json/src/spec/error.rs
+++ b/json/src/spec/error.rs
@@ -1,0 +1,44 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Spec-related errors.
+
+use serde_json::Error as SerdeError;
+use std::fmt::{Display, Formatter, Error as FmtError};
+
+/// Spec-related errors.
+#[derive(Debug)]
+pub enum Error {
+	/// An error with the deserialization of the Spec.
+	Parse(SerdeError),
+	/// A divisor has value 0.
+	ZeroValueDivisor,
+}
+
+impl Display for Error {
+	fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+		match *self {
+			Error::Parse(ref err) => write!(f, "{}", err),
+			Error::ZeroValueDivisor => write!(f, "Divisor cannot be 0"),
+		}
+	}
+}
+
+impl From<SerdeError> for Error {
+	fn from(err: SerdeError) -> Error {
+		Error::Parse(err)
+	}
+}

--- a/json/src/spec/mod.rs
+++ b/json/src/spec/mod.rs
@@ -30,6 +30,7 @@ pub mod basic_authority;
 pub mod authority_round;
 pub mod tendermint;
 pub mod null_engine;
+pub mod error;
 
 pub use self::account::Account;
 pub use self::builtin::{Builtin, Pricing, Linear};
@@ -45,3 +46,4 @@ pub use self::basic_authority::{BasicAuthority, BasicAuthorityParams};
 pub use self::authority_round::{AuthorityRound, AuthorityRoundParams};
 pub use self::tendermint::{Tendermint, TendermintParams};
 pub use self::null_engine::{NullEngine, NullEngineParams};
+pub use self::error::Error;

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -19,7 +19,8 @@
 use std::io::Read;
 use serde_json;
 use serde_json::Error;
-use spec::{Params, Genesis, Engine, State};
+
+use spec::{Params, Genesis, Engine, State, Error};
 
 /// Spec deserialization.
 #[derive(Debug, PartialEq, Deserialize)]
@@ -44,7 +45,15 @@ pub struct Spec {
 impl Spec {
 	/// Loads test from json.
 	pub fn load<R>(reader: R) -> Result<Self, Error> where R: Read {
-		serde_json::from_reader(reader)
+		let spec: Self = serde_json::from_reader(reader)?;
+
+		let divisor: u64 = spec.params.gas_limit_bound_divisor.into();
+
+		if divisor == 0 {
+			return Err(Error::ZeroValueDivisor)
+		}
+
+		Ok(spec)
 	}
 }
 

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -46,13 +46,13 @@ impl Spec {
 	pub fn load<R>(reader: R) -> Result<Self, Error> where R: Read {
 		let spec: Self = serde_json::from_reader(reader)?;
 
-		Self::validate(&spec)?;
+		spec.validate()?;
 
 		Ok(spec)
 	}
 
-	fn validate(spec: &Self) -> Result<(), Error> {
-		let divisor: u64 = spec.params.gas_limit_bound_divisor.into();
+	fn validate(&self) -> Result<(), Error> {
+		let divisor: u64 = self.params.gas_limit_bound_divisor.into();
 
 		if divisor == 0 {
 			return Err(Error::ZeroValueDivisor)

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -125,6 +125,70 @@ mod tests {
 	}
 
 	#[test]
+	fn test_missing_name() {
+		let s = r#"{
+	"dataDir": "morden",
+	"engine": {
+		"Ethash": {
+			"params": {
+				"minimumDifficulty": "0x020000",
+				"difficultyBoundDivisor": "0x0800",
+				"durationLimit": "0x0d",
+				"homesteadTransition" : "0x",
+				"daoHardforkTransition": "0xffffffffffffffff",
+				"daoHardforkBeneficiary": "0x0000000000000000000000000000000000000000",
+				"daoHardforkAccounts": []
+			}
+		}
+	},
+	"params": {
+		"accountStartNonce": "0x0100000",
+		"homesteadTransition": "0x789b0",
+		"maximumExtraDataSize": "0x20",
+		"minGasLimit": "0x1388",
+		"networkID" : "0x2",
+		"forkBlock": "0xffffffffffffffff",
+		"forkCanonHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"gasLimitBoundDivisor": "0x20"
+	},
+	"genesis": {
+		"seal": {
+			"ethereum": {
+				"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+				"nonce": "0x00006d6f7264656e"
+			}
+		},
+		"difficulty": "0x20000",
+		"author": "0x0000000000000000000000000000000000000000",
+		"timestamp": "0x00",
+		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"extraData": "0x",
+		"gasLimit": "0x2fefd8"
+	},
+	"nodes": [
+		"enode://b1217cbaa440e35ed471157123fe468e19e8b5ad5bedb4b1fdbcbdab6fb2f5ed3e95dd9c24a22a79fdb2352204cea207df27d92bfd21bfd41545e8b16f637499@104.44.138.37:30303"
+	],
+	"accounts": {
+		"0000000000000000000000000000000000000001": { "balance": "1", "nonce": "1048576", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
+		"0000000000000000000000000000000000000002": { "balance": "1", "nonce": "1048576", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
+		"0000000000000000000000000000000000000003": { "balance": "1", "nonce": "1048576", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
+		"0000000000000000000000000000000000000004": { "balance": "1", "nonce": "1048576", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"102e61f5d8f9bc71d0ad4a084df4e65e05ce0e1c": { "balance": "1606938044258990275541962092341162602522202993782792835301376", "nonce": "1048576" }
+	}
+		}"#;
+
+		match Spec::load(s.as_bytes()) {
+			Err(e) => {
+				match e {
+					Error::Parse(ref err) => { assert!(err.to_string().contains("missing field `name`")) },
+					wrong => panic!("Unexpected error returned: {}", wrong),
+				}
+			},
+			Ok(_) => panic!("Spec should fail to load"),
+		}
+	}
+
+	#[test]
 	fn test_zero_valued_divisor() {
 		let s = r#"{
 	"name": "Morden",

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -18,7 +18,6 @@
 
 use std::io::Read;
 use serde_json;
-use serde_json::Error;
 
 use spec::{Params, Genesis, Engine, State, Error};
 

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -65,7 +65,7 @@ impl Spec {
 #[cfg(test)]
 mod tests {
 	use serde_json;
-	use spec::spec::Spec;
+	use spec::spec::{Spec, Error};
 
 	#[test]
 	fn spec_deserialization() {
@@ -122,5 +122,70 @@ mod tests {
 		}"#;
 		let _deserialized: Spec = serde_json::from_str(s).unwrap();
 		// TODO: validate all fields
+	}
+
+	#[test]
+	fn test_zero_valued_divisor() {
+		let s = r#"{
+	"name": "Morden",
+	"dataDir": "morden",
+	"engine": {
+		"Ethash": {
+			"params": {
+				"minimumDifficulty": "0x020000",
+				"difficultyBoundDivisor": "0x0800",
+				"durationLimit": "0x0d",
+				"homesteadTransition" : "0x",
+				"daoHardforkTransition": "0xffffffffffffffff",
+				"daoHardforkBeneficiary": "0x0000000000000000000000000000000000000000",
+				"daoHardforkAccounts": []
+			}
+		}
+	},
+	"params": {
+		"accountStartNonce": "0x0100000",
+		"homesteadTransition": "0x789b0",
+		"maximumExtraDataSize": "0x20",
+		"minGasLimit": "0x1388",
+		"networkID" : "0x2",
+		"forkBlock": "0xffffffffffffffff",
+		"forkCanonHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"gasLimitBoundDivisor": "0x0"
+	},
+	"genesis": {
+		"seal": {
+			"ethereum": {
+				"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+				"nonce": "0x00006d6f7264656e"
+			}
+		},
+		"difficulty": "0x20000",
+		"author": "0x0000000000000000000000000000000000000000",
+		"timestamp": "0x00",
+		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"extraData": "0x",
+		"gasLimit": "0x2fefd8"
+	},
+	"nodes": [
+		"enode://b1217cbaa440e35ed471157123fe468e19e8b5ad5bedb4b1fdbcbdab6fb2f5ed3e95dd9c24a22a79fdb2352204cea207df27d92bfd21bfd41545e8b16f637499@104.44.138.37:30303"
+	],
+	"accounts": {
+		"0000000000000000000000000000000000000001": { "balance": "1", "nonce": "1048576", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
+		"0000000000000000000000000000000000000002": { "balance": "1", "nonce": "1048576", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
+		"0000000000000000000000000000000000000003": { "balance": "1", "nonce": "1048576", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
+		"0000000000000000000000000000000000000004": { "balance": "1", "nonce": "1048576", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"102e61f5d8f9bc71d0ad4a084df4e65e05ce0e1c": { "balance": "1606938044258990275541962092341162602522202993782792835301376", "nonce": "1048576" }
+	}
+		}"#;
+
+		match Spec::load(s.as_bytes()) {
+			Err(e) => {
+				match e {
+					Error::ZeroValueDivisor => {},
+					wrong => panic!("Unexpected error returned: {}", wrong),
+				}
+			},
+			Ok(_) => panic!("Spec should fail to load"),
+		}
 	}
 }

--- a/json/src/spec/spec.rs
+++ b/json/src/spec/spec.rs
@@ -46,13 +46,19 @@ impl Spec {
 	pub fn load<R>(reader: R) -> Result<Self, Error> where R: Read {
 		let spec: Self = serde_json::from_reader(reader)?;
 
+		Self::validate(&spec)?;
+
+		Ok(spec)
+	}
+
+	fn validate(spec: &Self) -> Result<(), Error> {
 		let divisor: u64 = spec.params.gas_limit_bound_divisor.into();
 
 		if divisor == 0 {
 			return Err(Error::ZeroValueDivisor)
 		}
 
-		Ok(spec)
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
This PR adds a few things:

* validation against the `gasLimitBoundDivisor` being 0.
* a `spec::Error` type that wraps both parsing errors and semantic ones. 
* a couple of tests, one for the above case, another one for a missing field in the Spec.

Closes #7482.