### PR TITLE
Beta: Change snapcraft grade to stable

### DIFF
--- a/scripts/gitlab-build.sh
+++ b/scripts/gitlab-build.sh
@@ -314,7 +314,7 @@ case $BUILD_PLATFORM in
     sed -i 's/git/'"$VER"'/g' snap/snapcraft.yaml
     if [[ "$CI_BUILD_REF_NAME" = "beta" || "$VER" == *1.9* ]];
       then
-        sed -i -e 's/grade: devel/grade: beta/' snap/snapcraft.yaml;
+        sed -i -e 's/grade: devel/grade: stable/' snap/snapcraft.yaml;
     fi
     mv -f snap/snapcraft.yaml snapcraft.yaml
     snapcraft -d


### PR DESCRIPTION
It appears snaps can only be "devel" or "stable", assuming "stable" for the beta track here.

https://docs.snapcraft.io/build-snaps/syntax#grade