### PR TITLE
spec: Validate required divisor fields are not 0

### DIFF
--- a/json/src/spec/ethash.rs
+++ b/json/src/spec/ethash.rs
@@ -31,11 +31,11 @@ pub struct EthashParams {
 	pub difficulty_bound_divisor: Uint,
 	/// See main EthashParams docs.
 	#[serde(rename="difficultyIncrementDivisor")]
-	#[serde(deserialize_with="uint::validate_optional_non_zero")]
+	#[serde(default, deserialize_with="uint::validate_optional_non_zero")]
 	pub difficulty_increment_divisor: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="metropolisDifficultyIncrementDivisor")]
-	#[serde(deserialize_with="uint::validate_optional_non_zero")]
+	#[serde(default, deserialize_with="uint::validate_optional_non_zero")]
 	pub metropolis_difficulty_increment_divisor: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="durationLimit")]
@@ -63,7 +63,7 @@ pub struct EthashParams {
 	pub difficulty_hardfork_transition: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="difficultyHardforkBoundDivisor")]
-	#[serde(deserialize_with="uint::validate_optional_non_zero")]
+	#[serde(default, deserialize_with="uint::validate_optional_non_zero")]
 	pub difficulty_hardfork_bound_divisor: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="bombDefuseTransition")]

--- a/json/src/spec/ethash.rs
+++ b/json/src/spec/ethash.rs
@@ -16,7 +16,7 @@
 
 //! Ethash params deserialization.
 
-use uint::Uint;
+use uint::{self, Uint};
 use hash::Address;
 
 /// Deserializable doppelganger of EthashParams.
@@ -27,6 +27,7 @@ pub struct EthashParams {
 	pub minimum_difficulty: Uint,
 	/// See main EthashParams docs.
 	#[serde(rename="difficultyBoundDivisor")]
+	#[serde(deserialize_with="uint::validate_non_zero")]
 	pub difficulty_bound_divisor: Uint,
 	/// See main EthashParams docs.
 	#[serde(rename="difficultyIncrementDivisor")]
@@ -301,5 +302,18 @@ mod tests {
 				expip2_duration_limit: None,
 			}
 		});
+	}
+
+	#[test]
+	#[should_panic(expected = "a non-zero value")]
+	fn test_zero_value_divisor() {
+		let s = r#"{
+			"params": {
+				"difficultyBoundDivisor": "0x0",
+				"minimumDifficulty": "0x020000"
+			}
+		}"#;
+
+		let _deserialized: Ethash = serde_json::from_str(s).unwrap();
 	}
 }

--- a/json/src/spec/ethash.rs
+++ b/json/src/spec/ethash.rs
@@ -31,9 +31,11 @@ pub struct EthashParams {
 	pub difficulty_bound_divisor: Uint,
 	/// See main EthashParams docs.
 	#[serde(rename="difficultyIncrementDivisor")]
+	#[serde(deserialize_with="uint::validate_optional_non_zero")]
 	pub difficulty_increment_divisor: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="metropolisDifficultyIncrementDivisor")]
+	#[serde(deserialize_with="uint::validate_optional_non_zero")]
 	pub metropolis_difficulty_increment_divisor: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="durationLimit")]
@@ -61,6 +63,7 @@ pub struct EthashParams {
 	pub difficulty_hardfork_transition: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="difficultyHardforkBoundDivisor")]
+	#[serde(deserialize_with="uint::validate_optional_non_zero")]
 	pub difficulty_hardfork_bound_divisor: Option<Uint>,
 	/// See main EthashParams docs.
 	#[serde(rename="bombDefuseTransition")]

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -16,7 +16,7 @@
 
 //! Spec params deserialization.
 
-use uint::Uint;
+use uint::{self, Uint};
 use hash::{H256, Address};
 use bytes::Bytes;
 
@@ -102,6 +102,7 @@ pub struct Params {
 	pub wasm: Option<bool>,
 	/// See `CommonParams` docs.
 	#[serde(rename="gasLimitBoundDivisor")]
+	#[serde(deserialize_with="uint::validate_non_zero")]
 	pub gas_limit_bound_divisor: Uint,
 	/// See `CommonParams` docs.
 	pub registrar: Option<Address>,
@@ -148,5 +149,22 @@ mod tests {
 		assert_eq!(deserialized.account_start_nonce, Some(Uint(U256::from(0x01))));
 		assert_eq!(deserialized.gas_limit_bound_divisor, Uint(U256::from(0x20)));
 		assert_eq!(deserialized.max_code_size, Some(Uint(U256::from(0x1000))));
+	}
+
+	#[test]
+	#[should_panic(expected = "a non-zero value")]
+	fn test_zero_value_divisor() {
+		let s = r#"{
+			"maximumExtraDataSize": "0x20",
+			"networkID" : "0x1",
+			"chainID" : "0x15",
+			"subprotocolName" : "exp",
+			"minGasLimit": "0x1388",
+			"accountStartNonce": "0x01",
+			"gasLimitBoundDivisor": "0x0",
+			"maxCodeSize": "0x1000"
+		}"#;
+
+		let _deserialized: Params = serde_json::from_str(s).unwrap();
 	}
 }

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -100,6 +100,18 @@ pub fn validate_non_zero<'de, D>(d: D) -> Result<Uint, D::Error> where D: Deseri
 	Ok(value)
 }
 
+pub fn validate_optional_non_zero<'de, D>(d: D) -> Result<Option<Uint>, D::Error> where D: Deserializer<'de> {
+	let value: Option<Uint> = Option::deserialize(d)?;
+
+	if let Some(value) = value {
+		if value == Uint(U256::from(0)) {
+			return Err(Error::invalid_value(Unexpected::Unsigned(value.into()), &"a non-zero value"))
+		}
+	}
+
+	Ok(value)
+}
+
 #[cfg(test)]
 mod test {
 	use serde_json;

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -19,7 +19,7 @@
 use std::fmt;
 use std::str::FromStr;
 use serde::{Deserialize, Deserializer};
-use serde::de::{Error, Visitor};
+use serde::de::{Error, Visitor, Unexpected};
 use ethereum_types::U256;
 
 /// Lenient uint json deserialization for test json files.
@@ -88,6 +88,16 @@ impl<'a> Visitor<'a> for UintVisitor {
 	fn visit_string<E>(self, value: String) -> Result<Self::Value, E> where E: Error {
 		self.visit_str(value.as_ref())
 	}
+}
+
+pub fn validate_non_zero<'de, D>(d: D) -> Result<Uint, D::Error> where D: Deserializer<'de> {
+	let value = Uint::deserialize(d)?;
+
+	if value == Uint(U256::from(0)) {
+		return Err(Error::invalid_value(Unexpected::Unsigned(value.into()), &"a non-zero value"))
+	}
+
+	Ok(value)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a replacement for https://github.com/paritytech/parity/pull/7882, implementing the check at the the deserialization level with the addition of a `#[serde(deserialize_with)` attribute on the required `Uint` divisor fields.

~`Optional<Uint>` divisor fields are not checked at the moment, since I was having trouble getting that to work.~

/cc @andreasilva @rphmeier

Closes #7482.
Closes #7882.