### PR TITLE
removed not working blocks compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,6 @@ version = "0.1.0"
 dependencies = [
  "kvdb 0.1.0",
  "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rlp 0.2.1",
 ]
 
 [[package]]
@@ -1418,7 +1417,6 @@ dependencies = [
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rlp 0.2.1",
  "rocksdb 0.4.5 (git+https://github.com/paritytech/rust-rocksdb)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ethcore/src/views/block.rs
+++ b/ethcore/src/views/block.rs
@@ -19,9 +19,9 @@
 use hash::keccak;
 use ethereum_types::H256;
 use bytes::Bytes;
-use header::*;
+use header::Header;
 use transaction::*;
-use super::{TransactionView, HeaderView};
+use views::{TransactionView, HeaderView};
 use rlp::Rlp;
 
 /// View onto block rlp.

--- a/util/kvdb-memorydb/Cargo.toml
+++ b/util/kvdb-memorydb/Cargo.toml
@@ -5,5 +5,4 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 parking_lot = "0.5"
-rlp = { path = "../rlp" }
 kvdb = { path = "../kvdb" }

--- a/util/kvdb-memorydb/src/lib.rs
+++ b/util/kvdb-memorydb/src/lib.rs
@@ -16,12 +16,10 @@
 
 extern crate parking_lot;
 extern crate kvdb;
-extern crate rlp;
 
 use std::collections::{BTreeMap, HashMap};
 use parking_lot::RwLock;
 use kvdb::{DBValue, DBTransaction, KeyValueDB, DBOp, Result};
-use rlp::{RlpType, UntrustedRlp, Compressible};
 
 /// A key-value database fulfilling the `KeyValueDB` trait, living in memory.
 /// This is generally intended for tests and is not particularly optimized.
@@ -72,14 +70,6 @@ impl KeyValueDB for InMemory {
 			match op {
 				DBOp::Insert { col, key, value } => {
 					if let Some(col) = columns.get_mut(&col) {
-						col.insert(key.into_vec(), value);
-					}
-				},
-				DBOp::InsertCompressed { col, key, value } => {
-					if let Some(col) = columns.get_mut(&col) {
-						let compressed = UntrustedRlp::new(&value).compress(RlpType::Blocks);
-						let mut value = DBValue::new();
-						value.append_slice(&compressed);
 						col.insert(key.into_vec(), value);
 					}
 				},

--- a/util/kvdb-rocksdb/Cargo.toml
+++ b/util/kvdb-rocksdb/Cargo.toml
@@ -11,7 +11,6 @@ log = "0.3"
 num_cpus = "1.0"
 parking_lot = "0.5"
 regex = "0.2"
-rlp = { path = "../rlp" }
 rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }
 interleaved-ordered = "0.1.0"
 

--- a/util/kvdb-rocksdb/src/lib.rs
+++ b/util/kvdb-rocksdb/src/lib.rs
@@ -26,7 +26,6 @@ extern crate rocksdb;
 
 extern crate ethereum_types;
 extern crate kvdb;
-extern crate rlp;
 
 use std::cmp;
 use std::collections::HashMap;
@@ -42,7 +41,6 @@ use rocksdb::{
 use interleaved_ordered::{interleave_ordered, InterleaveOrdered};
 
 use elastic_array::ElasticArray32;
-use rlp::{UntrustedRlp, RlpType, Compressible};
 use kvdb::{KeyValueDB, DBTransaction, DBValue, DBOp, Result};
 
 #[cfg(target_os = "linux")]
@@ -56,7 +54,6 @@ const DB_DEFAULT_MEMORY_BUDGET_MB: usize = 128;
 
 enum KeyState {
 	Insert(DBValue),
-	InsertCompressed(DBValue),
 	Delete,
 }
 
@@ -406,10 +403,6 @@ impl Database {
 					let c = Self::to_overlay_column(col);
 					overlay[c].insert(key, KeyState::Insert(value));
 				},
-				DBOp::InsertCompressed { col, key, value } => {
-					let c = Self::to_overlay_column(col);
-					overlay[c].insert(key, KeyState::InsertCompressed(value));
-				},
 				DBOp::Delete { col, key } => {
 					let c = Self::to_overlay_column(col);
 					overlay[c].insert(key, KeyState::Delete);
@@ -442,14 +435,6 @@ impl Database {
 										batch.put(&key, &value)?;
 									}
 								},
-								KeyState::InsertCompressed(ref value) => {
-									let compressed = UntrustedRlp::new(&value).compress(RlpType::Blocks);
-									if c > 0 {
-										batch.put_cf(cfs[c - 1], &key, &compressed)?;
-									} else {
-										batch.put(&key, &value)?;
-									}
-								}
 							}
 						}
 					}
@@ -495,10 +480,6 @@ impl Database {
 						DBOp::Insert { col, key, value } => {
 							col.map_or_else(|| batch.put(&key, &value), |c| batch.put_cf(cfs[c as usize], &key, &value))?
 						},
-						DBOp::InsertCompressed { col, key, value } => {
-							let compressed = UntrustedRlp::new(&value).compress(RlpType::Blocks);
-							col.map_or_else(|| batch.put(&key, &compressed), |c| batch.put_cf(cfs[c as usize], &key, &compressed))?
-						},
 						DBOp::Delete { col, key } => {
 							col.map_or_else(|| batch.delete(&key), |c| batch.delete_cf(cfs[c as usize], &key))?
 						},
@@ -519,12 +500,12 @@ impl Database {
 			Some(DBAndColumns { ref db, ref cfs }) => {
 				let overlay = &self.overlay.read()[Self::to_overlay_column(col)];
 				match overlay.get(key) {
-					Some(&KeyState::Insert(ref value)) | Some(&KeyState::InsertCompressed(ref value)) => Ok(Some(value.clone())),
+					Some(&KeyState::Insert(ref value)) => Ok(Some(value.clone())),
 					Some(&KeyState::Delete) => Ok(None),
 					None => {
 						let flushing = &self.flushing.read()[Self::to_overlay_column(col)];
 						match flushing.get(key) {
-							Some(&KeyState::Insert(ref value)) | Some(&KeyState::InsertCompressed(ref value)) => Ok(Some(value.clone())),
+							Some(&KeyState::Insert(ref value)) => Ok(Some(value.clone())),
 							Some(&KeyState::Delete) => Ok(None),
 							None => {
 								col.map_or_else(
@@ -559,8 +540,7 @@ impl Database {
 				let overlay = &self.overlay.read()[Self::to_overlay_column(col)];
 				let mut overlay_data = overlay.iter()
 					.filter_map(|(k, v)| match *v {
-						KeyState::Insert(ref value) |
-						KeyState::InsertCompressed(ref value) =>
+						KeyState::Insert(ref value) =>
 							Some((k.clone().into_vec().into_boxed_slice(), value.clone().into_vec().into_boxed_slice())),
 						KeyState::Delete => None,
 					}).collect::<Vec<_>>();

--- a/util/kvdb/src/lib.rs
+++ b/util/kvdb/src/lib.rs
@@ -56,11 +56,6 @@ pub enum DBOp {
 		key: ElasticArray32<u8>,
 		value: DBValue,
 	},
-	InsertCompressed {
-		col: Option<u32>,
-		key: ElasticArray32<u8>,
-		value: DBValue,
-	},
 	Delete {
 		col: Option<u32>,
 		key: ElasticArray32<u8>,
@@ -96,18 +91,6 @@ impl DBTransaction {
 		let mut ekey = ElasticArray32::new();
 		ekey.append_slice(key);
 		self.ops.push(DBOp::Insert {
-			col: col,
-			key: ekey,
-			value: DBValue::from_vec(value),
-		});
-	}
-
-	/// Insert a key-value pair in the transaction. Any existing value will be overwritten upon write.
-	/// Value will be RLP-compressed on flush
-	pub fn put_compressed(&mut self, col: Option<u32>, key: &[u8], value: Bytes) {
-		let mut ekey = ElasticArray32::new();
-		ekey.append_slice(key);
-		self.ops.push(DBOp::InsertCompressed {
 			col: col,
 			key: ekey,
 			value: DBValue::from_vec(value),


### PR DESCRIPTION
there're several inconsistencies in blockchain block insertion. blocks are inserted 

a) without compression:

https://github.com/paritytech/parity/blob/b77771171d8f5d185bc35b60b8bc9e47d4dfcae3/ethcore/src/blockchain/blockchain.rs#L532-L533

b) with manual compression:

https://github.com/paritytech/parity/blob/b77771171d8f5d185bc35b60b8bc9e47d4dfcae3/ethcore/src/blockchain/blockchain.rs#L731-L736

c) with compression happening elsewhere:

https://github.com/paritytech/parity/blob/b77771171d8f5d185bc35b60b8bc9e47d4dfcae3/ethcore/src/blockchain/blockchain.rs#L932-L933

Which made me come to conclusion that block insertion is either not working or we have a critical bug. It's probably the first one, cause blocks compression was introduced for full blocks and now we store headers and bodies separately:

https://github.com/paritytech/parity/blob/c220631842bf47cded1550d5fe26e9cba8531c72/ethcore/src/blockchain/blockchain.rs#L513-L517