### PR TITLE
Increase max download limit to 64MB

### DIFF
--- a/util/fetch/src/client.rs
+++ b/util/fetch/src/client.rs
@@ -150,8 +150,8 @@ impl Fetch for Client {
 	type Result = CpuFuture<Response, Error>;
 
 	fn new() -> Result<Self, Error> {
-		// Max 50MB will be downloaded.
-		Self::with_limit(Some(50*1024*1024))
+		// Max 64MB will be downloaded.
+		Self::with_limit(Some(64 * 1024 * 1024))
 	}
 
 	fn process<F, I, E>(&self, f: F) -> BoxFuture<I, E> where


### PR DESCRIPTION
On macOS the `parity` binary is larger than 50MB and the auto-update failed because of this.

`2018-02-21 10:16:50 UTC Unable to fetch update (1.9.3-beta-804d…b95b): IO(Error { repr: Custom(Custom { kind: PermissionDenied, error: StringError("Size limit reached.") }) })`