### PR TITLE
Remove Option from database the column numbers

### DIFF
--- a/ethcore/light/src/client/header_chain.rs
+++ b/ethcore/light/src/client/header_chain.rs
@@ -187,7 +187,7 @@ pub struct HeaderChain {
 	best_block: RwLock<BlockDescriptor>,
 	live_epoch_proofs: RwLock<H256FastMap<EpochTransition>>,
 	db: Arc<KeyValueDB>,
-	col: Option<u32>,
+	col: u32,
 	cache: Arc<Mutex<Cache>>,
 }
 
@@ -195,7 +195,7 @@ impl HeaderChain {
 	/// Create a new header chain given this genesis block and database to read from.
 	pub fn new(
 		db: Arc<KeyValueDB>,
-		col: Option<u32>,
+		col: u32,
 		spec: &Spec,
 		cache: Arc<Mutex<Cache>>,
 	) -> Result<Self, kvdb::Error> {

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -181,7 +181,7 @@ impl<T: ChainDataFetcher> Client<T> {
 	pub fn new(
 		config: Config,
 		db: Arc<KeyValueDB>,
-		chain_col: Option<u32>,
+		chain_col: u32,
 		spec: &Spec,
 		fetcher: T,
 		io_channel: IoChannel<ClientIoMessage>,
@@ -219,7 +219,7 @@ impl<T: ChainDataFetcher> Client<T> {
 		Client::new(
 			config,
 			Arc::new(db),
-			None,
+			0,
 			spec,
 			fetcher,
 			io_channel,

--- a/ethcore/light/src/client/service.rs
+++ b/ethcore/light/src/client/service.rs
@@ -76,7 +76,7 @@ impl<T: ChainDataFetcher> Service<T> {
 		let io_service = IoService::<ClientIoMessage>::start().map_err(Error::Io)?;
 		let client = Arc::new(Client::new(config,
 			db,
-			Some(db::COL_LIGHT_CHAIN),
+			db::COL_LIGHT_CHAIN,
 			spec,
 			fetcher,
 			io_service.channel(),

--- a/ethcore/light/src/client/service.rs
+++ b/ethcore/light/src/client/service.rs
@@ -62,7 +62,7 @@ impl<T: ChainDataFetcher> Service<T> {
 	pub fn start(config: ClientConfig, spec: &Spec, fetcher: T, path: &Path, cache: Arc<Mutex<Cache>>) -> Result<Self, Error> {
 
 		// initialize database.
-		let mut db_config = DatabaseConfig::with_columns(db::NUM_COLUMNS);
+		let mut db_config = DatabaseConfig::with_columns(Some(db::NUM_COLUMNS));
 
 		db_config.memory_budget = config.db_cache_size;
 		db_config.compaction = config.db_compaction;
@@ -76,7 +76,7 @@ impl<T: ChainDataFetcher> Service<T> {
 		let io_service = IoService::<ClientIoMessage>::start().map_err(Error::Io)?;
 		let client = Arc::new(Client::new(config,
 			db,
-			db::COL_LIGHT_CHAIN,
+			Some(db::COL_LIGHT_CHAIN),
 			spec,
 			fetcher,
 			io_service.channel(),

--- a/ethcore/migrations/src/v10.rs
+++ b/ethcore/migrations/src/v10.rs
@@ -59,7 +59,7 @@ pub fn generate_bloom(source: Arc<Database>, dest: &mut Database) -> Result<(), 
 		let state_db = journaldb::new(
 			source.clone(),
 			journaldb::Algorithm::OverlayRecent,
-			Some(COL_STATE));
+			COL_STATE);
 		let account_trie = TrieDB::new(state_db.as_hashdb(), &state_root).chain_err(|| "Cannot open trie")?;
 		for item in account_trie.iter().map_err(|_| ErrorKind::MigrationImpossible)? {
 			let (ref account_key, _) = item.map_err(|_| ErrorKind::MigrationImpossible)?;

--- a/ethcore/migrations/src/v10.rs
+++ b/ethcore/migrations/src/v10.rs
@@ -34,7 +34,7 @@ use kvdb_rocksdb::Database;
 /// Can be called on upgraded database with no issues (will do nothing).
 pub fn generate_bloom(source: Arc<Database>, dest: &mut Database) -> Result<(), Error> {
 	trace!(target: "migration", "Account bloom upgrade started");
-	let best_block_hash = match source.get(COL_EXTRA, b"best")? {
+	let best_block_hash = match source.get(Some(COL_EXTRA), b"best")? {
 		// no migration needed
 		None => {
 			trace!(target: "migration", "No best block hash, skipping");
@@ -42,7 +42,7 @@ pub fn generate_bloom(source: Arc<Database>, dest: &mut Database) -> Result<(), 
 		},
 		Some(hash) => hash,
 	};
-	let best_block_header = match source.get(COL_HEADERS, &best_block_hash)? {
+	let best_block_header = match source.get(Some(COL_HEADERS), &best_block_hash)? {
 		// no best block, nothing to do
 		None => {
 			trace!(target: "migration", "No best block header, skipping");
@@ -59,7 +59,7 @@ pub fn generate_bloom(source: Arc<Database>, dest: &mut Database) -> Result<(), 
 		let state_db = journaldb::new(
 			source.clone(),
 			journaldb::Algorithm::OverlayRecent,
-			COL_STATE);
+			Some(COL_STATE));
 		let account_trie = TrieDB::new(state_db.as_hashdb(), &state_root).chain_err(|| "Cannot open trie")?;
 		for item in account_trie.iter().map_err(|_| ErrorKind::MigrationImpossible)? {
 			let (ref account_key, _) = item.map_err(|_| ErrorKind::MigrationImpossible)?;
@@ -110,7 +110,7 @@ impl Migration for ToV10 {
 		}
 		batch.commit(dest)?;
 
-		if col == COL_STATE {
+		if col == Some(COL_STATE) {
 			generate_bloom(source, dest)?;
 		}
 

--- a/ethcore/node_filter/src/lib.rs
+++ b/ethcore/node_filter/src/lib.rs
@@ -133,7 +133,7 @@ mod test {
 		let contract_addr = Address::from_str("0000000000000000000000000000000000000005").unwrap();
 		let data = include_bytes!("../res/node_filter.json");
 		let spec = Spec::load(&::std::env::temp_dir(), &data[..]).unwrap();
-		let client_db = Arc::new(::kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS.unwrap_or(0)));
+		let client_db = Arc::new(::kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS));
 
 		let client = Client::new(
 			ClientConfig::default(),

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -170,7 +170,7 @@ enum CacheId {
 impl bc::group::BloomGroupDatabase for BlockChain {
 	fn blooms_at(&self, position: &bc::group::GroupPosition) -> Option<bc::group::BloomGroup> {
 		let position = GroupPosition::from(position.clone());
-		let result = self.db.read_with_cache(db::COL_EXTRA, &self.blocks_blooms, &position).map(Into::into);
+		let result = self.db.read_with_cache(Some(db::COL_EXTRA), &self.blocks_blooms, &position).map(Into::into);
 		self.cache_man.lock().note_used(CacheId::BlocksBlooms(position));
 		result
 	}
@@ -216,7 +216,7 @@ impl BlockProvider for BlockChain {
 	/// Returns true if the given block is known
 	/// (though not necessarily a part of the canon chain).
 	fn is_known(&self, hash: &H256) -> bool {
-		self.db.exists_with_cache(db::COL_EXTRA, &self.block_details, hash)
+		self.db.exists_with_cache(Some(db::COL_EXTRA), &self.block_details, hash)
 	}
 
 	fn first_block(&self) -> Option<H256> {
@@ -267,7 +267,7 @@ impl BlockProvider for BlockChain {
 		}
 
 		// Read from DB and populate cache
-		let opt = self.db.get(db::COL_HEADERS, hash)
+		let opt = self.db.get(Some(db::COL_HEADERS), hash)
 			.expect("Low level database error. Some issue with disk?");
 
 		let result = match opt {
@@ -303,7 +303,7 @@ impl BlockProvider for BlockChain {
 		}
 
 		// Read from DB and populate cache
-		let opt = self.db.get(db::COL_BODIES, hash)
+		let opt = self.db.get(Some(db::COL_BODIES), hash)
 			.expect("Low level database error. Some issue with disk?");
 
 		let result = match opt {
@@ -323,28 +323,28 @@ impl BlockProvider for BlockChain {
 
 	/// Get the familial details concerning a block.
 	fn block_details(&self, hash: &H256) -> Option<BlockDetails> {
-		let result = self.db.read_with_cache(db::COL_EXTRA, &self.block_details, hash);
+		let result = self.db.read_with_cache(Some(db::COL_EXTRA), &self.block_details, hash);
 		self.cache_man.lock().note_used(CacheId::BlockDetails(*hash));
 		result
 	}
 
 	/// Get the hash of given block's number.
 	fn block_hash(&self, index: BlockNumber) -> Option<H256> {
-		let result = self.db.read_with_cache(db::COL_EXTRA, &self.block_hashes, &index);
+		let result = self.db.read_with_cache(Some(db::COL_EXTRA), &self.block_hashes, &index);
 		self.cache_man.lock().note_used(CacheId::BlockHashes(index));
 		result
 	}
 
 	/// Get the address of transaction with given hash.
 	fn transaction_address(&self, hash: &H256) -> Option<TransactionAddress> {
-		let result = self.db.read_with_cache(db::COL_EXTRA, &self.transaction_addresses, hash);
+		let result = self.db.read_with_cache(Some(db::COL_EXTRA), &self.transaction_addresses, hash);
 		self.cache_man.lock().note_used(CacheId::TransactionAddresses(*hash));
 		result
 	}
 
 	/// Get receipts of block with given hash.
 	fn block_receipts(&self, hash: &H256) -> Option<BlockReceipts> {
-		let result = self.db.read_with_cache(db::COL_EXTRA, &self.block_receipts, hash);
+		let result = self.db.read_with_cache(Some(db::COL_EXTRA), &self.block_receipts, hash);
 		self.cache_man.lock().note_used(CacheId::BlockReceipts(*hash));
 		result
 	}
@@ -510,7 +510,7 @@ impl BlockChain {
 		};
 
 		// load best block
-		let best_block_hash = match bc.db.get(db::COL_EXTRA, b"best").unwrap() {
+		let best_block_hash = match bc.db.get(Some(db::COL_EXTRA), b"best").unwrap() {
 			Some(best) => {
 				H256::from_slice(&best)
 			}
@@ -529,13 +529,13 @@ impl BlockChain {
 				};
 
 				let mut batch = DBTransaction::new();
-				batch.put(db::COL_HEADERS, &hash, block.header_rlp().as_raw());
-				batch.put(db::COL_BODIES, &hash, &Self::block_to_body(genesis));
+				batch.put(Some(db::COL_HEADERS), &hash, block.header_rlp().as_raw());
+				batch.put(Some(db::COL_BODIES), &hash, &Self::block_to_body(genesis));
 
-				batch.write(db::COL_EXTRA, &hash, &details);
-				batch.write(db::COL_EXTRA, &header.number(), &hash);
+				batch.write(Some(db::COL_EXTRA), &hash, &details);
+				batch.write(Some(db::COL_EXTRA), &header.number(), &hash);
 
-				batch.put(db::COL_EXTRA, b"best", &hash);
+				batch.put(Some(db::COL_EXTRA), b"best", &hash);
 				bc.db.write(batch).expect("Low level database error. Some issue with disk?");
 				hash
 			}
@@ -548,8 +548,8 @@ impl BlockChain {
 			let best_block_rlp = bc.block(&best_block_hash).unwrap().into_inner();
 			let best_block_timestamp = BlockView::new(&best_block_rlp).header().timestamp();
 
-			let raw_first = bc.db.get(db::COL_EXTRA, b"first").unwrap().map(|v| v.into_vec());
-			let mut best_ancient = bc.db.get(db::COL_EXTRA, b"ancient").unwrap().map(|h| H256::from_slice(&h));
+			let raw_first = bc.db.get(Some(db::COL_EXTRA), b"first").unwrap().map(|v| v.into_vec());
+			let mut best_ancient = bc.db.get(Some(db::COL_EXTRA), b"ancient").unwrap().map(|h| H256::from_slice(&h));
 			let best_ancient_number;
 			if best_ancient.is_none() && best_block_number > 1 && bc.block_hash(1).is_none() {
 				best_ancient = Some(bc.genesis_hash());
@@ -579,7 +579,7 @@ impl BlockChain {
 					if hash != bc.genesis_hash() {
 						trace!("First block calculated: {:?}", hash);
 						let mut batch = db.transaction();
-						batch.put(db::COL_EXTRA, b"first", &hash);
+						batch.put(Some(db::COL_EXTRA), b"first", &hash);
 						db.write(batch).expect("Low level database error.");
 						bc.first_block = Some(hash);
 					}
@@ -614,7 +614,7 @@ impl BlockChain {
 	/// Returns true if the given parent block has given child
 	/// (though not necessarily a part of the canon chain).
 	fn is_known_child(&self, parent: &H256, hash: &H256) -> bool {
-		self.db.read_with_cache(db::COL_EXTRA, &self.block_details, parent).map_or(false, |d| d.children.contains(hash))
+		self.db.read_with_cache(Some(db::COL_EXTRA), &self.block_details, parent).map_or(false, |d| d.children.contains(hash))
 	}
 
 	/// Returns a tree route between `from` and `to`, which is a tuple of:
@@ -732,8 +732,8 @@ impl BlockChain {
 		let compressed_body = UntrustedRlp::new(&Self::block_to_body(bytes)).compress(RlpType::Blocks);
 
 		// store block in db
-		batch.put(db::COL_HEADERS, &hash, &compressed_header);
-		batch.put(db::COL_BODIES, &hash, &compressed_body);
+		batch.put(Some(db::COL_HEADERS), &hash, &compressed_header);
+		batch.put(Some(db::COL_BODIES), &hash, &compressed_body);
 
 		let maybe_parent = self.block_details(&header.parent_hash());
 
@@ -761,10 +761,10 @@ impl BlockChain {
 				let mut best_ancient_block = self.best_ancient_block.write();
 				let ancient_number = best_ancient_block.as_ref().map_or(0, |b| b.number);
 				if self.block_hash(header.number() + 1).is_some() {
-					batch.delete(db::COL_EXTRA, b"ancient");
+					batch.delete(Some(db::COL_EXTRA), b"ancient");
 					*best_ancient_block = None;
 				} else if header.number() > ancient_number {
-					batch.put(db::COL_EXTRA, b"ancient", &hash);
+					batch.put(Some(db::COL_EXTRA), b"ancient", &hash);
 					*best_ancient_block = Some(BestAncientBlock {
 						hash: hash,
 						number: header.number(),
@@ -814,7 +814,7 @@ impl BlockChain {
 	///
 	/// The block the transition occurred at should have already been inserted into the chain.
 	pub fn insert_epoch_transition(&self, batch: &mut DBTransaction, epoch_num: u64, transition: EpochTransition) {
-		let mut transitions = match self.db.read(db::COL_EXTRA, &epoch_num) {
+		let mut transitions = match self.db.read(Some(db::COL_EXTRA), &epoch_num) {
 			Some(existing) => existing,
 			None => EpochTransitions {
 				number: epoch_num,
@@ -825,14 +825,14 @@ impl BlockChain {
 		// ensure we don't write any duplicates.
 		if transitions.candidates.iter().find(|c| c.block_hash == transition.block_hash).is_none() {
 			transitions.candidates.push(transition);
-			batch.write(db::COL_EXTRA, &epoch_num, &transitions);
+			batch.write(Some(db::COL_EXTRA), &epoch_num, &transitions);
 		}
 	}
 
 	/// Iterate over all epoch transitions.
 	/// This will only return transitions within the canonical chain.
 	pub fn epoch_transitions(&self) -> EpochTransitionIter {
-		let iter = self.db.iter_from_prefix(db::COL_EXTRA, &EPOCH_KEY_PREFIX[..]);
+		let iter = self.db.iter_from_prefix(Some(db::COL_EXTRA), &EPOCH_KEY_PREFIX[..]);
 		EpochTransitionIter {
 			chain: self,
 			prefix_iter: iter,
@@ -844,7 +844,7 @@ impl BlockChain {
 		trace!(target: "blockchain", "Loading epoch transition at block {}, {}",
 			block_num, block_hash);
 
-		self.db.read(db::COL_EXTRA, &block_num).and_then(|transitions: EpochTransitions| {
+		self.db.read(Some(db::COL_EXTRA), &block_num).and_then(|transitions: EpochTransitions| {
 			transitions.candidates.into_iter().find(|c| c.block_hash == block_hash)
 		})
 	}
@@ -883,14 +883,14 @@ impl BlockChain {
 
 	/// Write a pending epoch transition by block hash.
 	pub fn insert_pending_transition(&self, batch: &mut DBTransaction, hash: H256, t: PendingEpochTransition) {
-		batch.write(db::COL_EXTRA, &hash, &t);
+		batch.write(Some(db::COL_EXTRA), &hash, &t);
 	}
 
 	/// Get a pending epoch transition by block hash.
 	// TODO: implement removal safely: this can only be done upon finality of a block
 	// that _uses_ the pending transition.
 	pub fn get_pending_transition(&self, hash: H256) -> Option<PendingEpochTransition> {
-		self.db.read(db::COL_EXTRA, &hash)
+		self.db.read(Some(db::COL_EXTRA), &hash)
 	}
 
 	/// Add a child to a given block. Assumes that the block hash is in
@@ -908,7 +908,7 @@ impl BlockChain {
 
 
 		let mut write_details = self.block_details.write();
-		batch.extend_with_cache(db::COL_EXTRA, &mut *write_details, update, CacheUpdatePolicy::Overwrite);
+		batch.extend_with_cache(Some(db::COL_EXTRA), &mut *write_details, update, CacheUpdatePolicy::Overwrite);
 
 		self.cache_man.lock().note_used(CacheId::BlockDetails(block_hash));
 	}
@@ -929,8 +929,8 @@ impl BlockChain {
 		assert!(self.pending_best_block.read().is_none());
 
 		// store block in db
-		batch.put_compressed(db::COL_HEADERS, &hash, block.header_rlp().as_raw().to_vec());
-		batch.put_compressed(db::COL_BODIES, &hash, Self::block_to_body(bytes));
+		batch.put_compressed(Some(db::COL_HEADERS), &hash, block.header_rlp().as_raw().to_vec());
+		batch.put_compressed(Some(db::COL_BODIES), &hash, Self::block_to_body(bytes));
 
 		let info = self.block_info(&header);
 
@@ -1002,12 +1002,12 @@ impl BlockChain {
 
 		{
 			let mut write_receipts = self.block_receipts.write();
-			batch.extend_with_cache(db::COL_EXTRA, &mut *write_receipts, update.block_receipts, CacheUpdatePolicy::Remove);
+			batch.extend_with_cache(Some(db::COL_EXTRA), &mut *write_receipts, update.block_receipts, CacheUpdatePolicy::Remove);
 		}
 
 		{
 			let mut write_blocks_blooms = self.blocks_blooms.write();
-			batch.extend_with_cache(db::COL_EXTRA, &mut *write_blocks_blooms, update.blocks_blooms, CacheUpdatePolicy::Remove);
+			batch.extend_with_cache(Some(db::COL_EXTRA), &mut *write_blocks_blooms, update.blocks_blooms, CacheUpdatePolicy::Remove);
 		}
 
 		// These cached values must be updated last with all four locks taken to avoid
@@ -1018,7 +1018,7 @@ impl BlockChain {
 			match update.info.location {
 				BlockLocation::Branch => (),
 				_ => if is_best {
-					batch.put(db::COL_EXTRA, b"best", &update.info.hash);
+					batch.put(Some(db::COL_EXTRA), b"best", &update.info.hash);
 					*best_block = Some(BestBlock {
 						hash: update.info.hash,
 						number: update.info.number,
@@ -1032,9 +1032,9 @@ impl BlockChain {
 			let mut write_details = self.pending_block_details.write();
 			let mut write_txs = self.pending_transaction_addresses.write();
 
-			batch.extend_with_cache(db::COL_EXTRA, &mut *write_details, update.block_details, CacheUpdatePolicy::Overwrite);
-			batch.extend_with_cache(db::COL_EXTRA, &mut *write_hashes, update.block_hashes, CacheUpdatePolicy::Overwrite);
-			batch.extend_with_option_cache(db::COL_EXTRA, &mut *write_txs, update.transactions_addresses, CacheUpdatePolicy::Overwrite);
+			batch.extend_with_cache(Some(db::COL_EXTRA), &mut *write_details, update.block_details, CacheUpdatePolicy::Overwrite);
+			batch.extend_with_cache(Some(db::COL_EXTRA), &mut *write_hashes, update.block_hashes, CacheUpdatePolicy::Overwrite);
+			batch.extend_with_option_cache(Some(db::COL_EXTRA), &mut *write_txs, update.transactions_addresses, CacheUpdatePolicy::Overwrite);
 		}
 	}
 
@@ -1427,7 +1427,7 @@ mod tests {
 	use ethkey::Secret;
 
 	fn new_db() -> Arc<KeyValueDB> {
-		Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)))
+		Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS))
 	}
 
 	fn new_chain(genesis: &[u8], db: Arc<KeyValueDB>) -> BlockChain {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -191,7 +191,7 @@ impl Client {
 			accountdb: Default::default(),
 		};
 
-		let journal_db = journaldb::new(db.clone(), config.pruning, ::db::COL_STATE);
+		let journal_db = journaldb::new(db.clone(), config.pruning, Some(::db::COL_STATE));
 		let mut state_db = StateDB::new(journal_db, config.state_cache_size);
 		if state_db.journal_db().is_empty() {
 			// Sets the correct state root.
@@ -1191,7 +1191,7 @@ impl snapshot::DatabaseRestore for Client {
 		db.restore(new_db)?;
 
 		let cache_size = state_db.cache_size();
-		*state_db = StateDB::new(journaldb::new(db.clone(), self.pruning, ::db::COL_STATE), cache_size);
+		*state_db = StateDB::new(journaldb::new(db.clone(), self.pruning, Some(::db::COL_STATE)), cache_size);
 		*chain = Arc::new(BlockChain::new(self.config.blockchain.clone(), &[], db.clone()));
 		*tracedb = TraceDB::new(self.config.tracing.clone(), db.clone(), chain.clone());
 		Ok(())

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -191,7 +191,7 @@ impl Client {
 			accountdb: Default::default(),
 		};
 
-		let journal_db = journaldb::new(db.clone(), config.pruning, Some(::db::COL_STATE));
+		let journal_db = journaldb::new(db.clone(), config.pruning, ::db::COL_STATE);
 		let mut state_db = StateDB::new(journal_db, config.state_cache_size);
 		if state_db.journal_db().is_empty() {
 			// Sets the correct state root.
@@ -1191,7 +1191,7 @@ impl snapshot::DatabaseRestore for Client {
 		db.restore(new_db)?;
 
 		let cache_size = state_db.cache_size();
-		*state_db = StateDB::new(journaldb::new(db.clone(), self.pruning, Some(::db::COL_STATE)), cache_size);
+		*state_db = StateDB::new(journaldb::new(db.clone(), self.pruning, ::db::COL_STATE), cache_size);
 		*chain = Arc::new(BlockChain::new(self.config.blockchain.clone(), &[], db.clone()));
 		*tracedb = TraceDB::new(self.config.tracing.clone(), db.clone(), chain.clone());
 		Ok(())

--- a/ethcore/src/client/evm_test_client.rs
+++ b/ethcore/src/client/evm_test_client.rs
@@ -125,8 +125,8 @@ impl<'a> EvmTestClient<'a> {
 	}
 
 	fn state_from_spec(spec: &'a spec::Spec, factories: &Factories) -> Result<state::State<state_db::StateDB>, EvmTestError> {
-		let db = Arc::new(kvdb_memorydb::create(db::NUM_COLUMNS.expect("We use column-based DB; qed")));
-		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, db::COL_STATE);
+		let db = Arc::new(kvdb_memorydb::create(db::NUM_COLUMNS));
+		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, Some(db::COL_STATE));
 		let mut state_db = state_db::StateDB::new(journal_db, 5 * 1024 * 1024);
 		state_db = spec.ensure_db_good(state_db, factories)?;
 
@@ -147,8 +147,8 @@ impl<'a> EvmTestClient<'a> {
 	}
 
 	fn state_from_pod(spec: &'a spec::Spec, factories: &Factories, pod_state: pod_state::PodState) -> Result<state::State<state_db::StateDB>, EvmTestError> {
-		let db = Arc::new(kvdb_memorydb::create(db::NUM_COLUMNS.expect("We use column-based DB; qed")));
-		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, db::COL_STATE);
+		let db = Arc::new(kvdb_memorydb::create(db::NUM_COLUMNS));
+		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, Some(db::COL_STATE));
 		let state_db = state_db::StateDB::new(journal_db, 5 * 1024 * 1024);
 		let mut state = state::State::new(
 			state_db,

--- a/ethcore/src/client/evm_test_client.rs
+++ b/ethcore/src/client/evm_test_client.rs
@@ -126,7 +126,7 @@ impl<'a> EvmTestClient<'a> {
 
 	fn state_from_spec(spec: &'a spec::Spec, factories: &Factories) -> Result<state::State<state_db::StateDB>, EvmTestError> {
 		let db = Arc::new(kvdb_memorydb::create(db::NUM_COLUMNS));
-		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, Some(db::COL_STATE));
+		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, db::COL_STATE);
 		let mut state_db = state_db::StateDB::new(journal_db, 5 * 1024 * 1024);
 		state_db = spec.ensure_db_good(state_db, factories)?;
 
@@ -148,7 +148,7 @@ impl<'a> EvmTestClient<'a> {
 
 	fn state_from_pod(spec: &'a spec::Spec, factories: &Factories, pod_state: pod_state::PodState) -> Result<state::State<state_db::StateDB>, EvmTestError> {
 		let db = Arc::new(kvdb_memorydb::create(db::NUM_COLUMNS));
-		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, Some(db::COL_STATE));
+		let journal_db = journaldb::new(db.clone(), journaldb::Algorithm::EarlyMerge, db::COL_STATE);
 		let state_db = state_db::StateDB::new(journal_db, 5 * 1024 * 1024);
 		let mut state = state::State::new(
 			state_db,

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -355,7 +355,7 @@ impl TestBlockChainClient {
 pub fn get_temp_state_db() -> (StateDB, TempDir) {
 	let tempdir = TempDir::new("").unwrap();
 	let db = Database::open(&DatabaseConfig::with_columns(Some(NUM_COLUMNS)), tempdir.path().to_str().unwrap()).unwrap();
-	let journal_db = journaldb::new(Arc::new(db), journaldb::Algorithm::EarlyMerge, Some(COL_STATE));
+	let journal_db = journaldb::new(Arc::new(db), journaldb::Algorithm::EarlyMerge, COL_STATE);
 	let state_db = StateDB::new(journal_db, 1024 * 1024);
 	(state_db, tempdir)
 }

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -354,8 +354,8 @@ impl TestBlockChainClient {
 
 pub fn get_temp_state_db() -> (StateDB, TempDir) {
 	let tempdir = TempDir::new("").unwrap();
-	let db = Database::open(&DatabaseConfig::with_columns(NUM_COLUMNS), tempdir.path().to_str().unwrap()).unwrap();
-	let journal_db = journaldb::new(Arc::new(db), journaldb::Algorithm::EarlyMerge, COL_STATE);
+	let db = Database::open(&DatabaseConfig::with_columns(Some(NUM_COLUMNS)), tempdir.path().to_str().unwrap()).unwrap();
+	let journal_db = journaldb::new(Arc::new(db), journaldb::Algorithm::EarlyMerge, Some(COL_STATE));
 	let state_db = StateDB::new(journal_db, 1024 * 1024);
 	(state_db, tempdir)
 }

--- a/ethcore/src/db.rs
+++ b/ethcore/src/db.rs
@@ -26,23 +26,23 @@ use rlp;
 
 // database columns
 /// Column for State
-pub const COL_STATE: Option<u32> = Some(0);
+pub const COL_STATE: u32 = 0;
 /// Column for Block headers
-pub const COL_HEADERS: Option<u32> = Some(1);
+pub const COL_HEADERS: u32 = 1;
 /// Column for Block bodies
-pub const COL_BODIES: Option<u32> = Some(2);
+pub const COL_BODIES: u32 = 2;
 /// Column for Extras
-pub const COL_EXTRA: Option<u32> = Some(3);
+pub const COL_EXTRA: u32 = 3;
 /// Column for Traces
-pub const COL_TRACE: Option<u32> = Some(4);
+pub const COL_TRACE: u32 = 4;
 /// Column for the empty accounts bloom filter.
-pub const COL_ACCOUNT_BLOOM: Option<u32> = Some(5);
+pub const COL_ACCOUNT_BLOOM: u32 = 5;
 /// Column for general information from the local node which can persist.
-pub const COL_NODE_INFO: Option<u32> = Some(6);
+pub const COL_NODE_INFO: u32 = 6;
 /// Column for the light client chain.
-pub const COL_LIGHT_CHAIN: Option<u32> = Some(7);
+pub const COL_LIGHT_CHAIN: u32 = 7;
 /// Number of columns in DB
-pub const NUM_COLUMNS: Option<u32> = Some(8);
+pub const NUM_COLUMNS: u32 = 8;
 
 /// Modes for updating caches.
 #[derive(Clone, Copy)]

--- a/ethcore/src/db.rs
+++ b/ethcore/src/db.rs
@@ -91,13 +91,13 @@ pub trait Key<T> {
 /// Should be used to write value into database.
 pub trait Writable {
 	/// Writes the value into the database.
-	fn write<T, R>(&mut self, col: Option<u32>, key: &Key<T, Target = R>, value: &T) where T: rlp::Encodable, R: Deref<Target = [u8]>;
+	fn write<T, R>(&mut self, col: u32, key: &Key<T, Target = R>, value: &T) where T: rlp::Encodable, R: Deref<Target = [u8]>;
 
 	/// Deletes key from the databse.
-	fn delete<T, R>(&mut self, col: Option<u32>, key: &Key<T, Target = R>) where T: rlp::Encodable, R: Deref<Target = [u8]>;
+	fn delete<T, R>(&mut self, col: u32, key: &Key<T, Target = R>) where T: rlp::Encodable, R: Deref<Target = [u8]>;
 
 	/// Writes the value into the database and updates the cache.
-	fn write_with_cache<K, T, R>(&mut self, col: Option<u32>, cache: &mut Cache<K, T>, key: K, value: T, policy: CacheUpdatePolicy) where
+	fn write_with_cache<K, T, R>(&mut self, col: u32, cache: &mut Cache<K, T>, key: K, value: T, policy: CacheUpdatePolicy) where
 	K: Key<T, Target = R> + Hash + Eq,
 	T: rlp::Encodable,
 	R: Deref<Target = [u8]> {
@@ -113,7 +113,7 @@ pub trait Writable {
 	}
 
 	/// Writes the values into the database and updates the cache.
-	fn extend_with_cache<K, T, R>(&mut self, col: Option<u32>, cache: &mut Cache<K, T>, values: HashMap<K, T>, policy: CacheUpdatePolicy) where
+	fn extend_with_cache<K, T, R>(&mut self, col: u32, cache: &mut Cache<K, T>, values: HashMap<K, T>, policy: CacheUpdatePolicy) where
 	K: Key<T, Target = R> + Hash + Eq,
 	T: rlp::Encodable,
 	R: Deref<Target = [u8]> {
@@ -134,7 +134,7 @@ pub trait Writable {
 	}
 
 	/// Writes and removes the values into the database and updates the cache.
-	fn extend_with_option_cache<K, T, R>(&mut self, col: Option<u32>, cache: &mut Cache<K, Option<T>>, values: HashMap<K, Option<T>>, policy: CacheUpdatePolicy) where
+	fn extend_with_option_cache<K, T, R>(&mut self, col: u32, cache: &mut Cache<K, Option<T>>, values: HashMap<K, Option<T>>, policy: CacheUpdatePolicy) where
 	K: Key<T, Target = R> + Hash + Eq,
 	T: rlp::Encodable,
 	R: Deref<Target = [u8]> {
@@ -165,12 +165,12 @@ pub trait Writable {
 /// Should be used to read values from database.
 pub trait Readable {
 	/// Returns value for given key.
-	fn read<T, R>(&self, col: Option<u32>, key: &Key<T, Target = R>) -> Option<T> where
+	fn read<T, R>(&self, col: u32, key: &Key<T, Target = R>) -> Option<T> where
 	T: rlp::Decodable,
 	R: Deref<Target = [u8]>;
 
 	/// Returns value for given key either in cache or in database.
-	fn read_with_cache<K, T, C>(&self, col: Option<u32>, cache: &RwLock<C>, key: &K) -> Option<T> where
+	fn read_with_cache<K, T, C>(&self, col: u32, cache: &RwLock<C>, key: &K) -> Option<T> where
 		K: Key<T> + Eq + Hash + Clone,
 		T: Clone + rlp::Decodable,
 		C: Cache<K, T> {
@@ -189,10 +189,10 @@ pub trait Readable {
 	}
 
 	/// Returns true if given value exists.
-	fn exists<T, R>(&self, col: Option<u32>, key: &Key<T, Target = R>) -> bool where R: Deref<Target= [u8]>;
+	fn exists<T, R>(&self, col: u32, key: &Key<T, Target = R>) -> bool where R: Deref<Target= [u8]>;
 
 	/// Returns true if given value exists either in cache or in database.
-	fn exists_with_cache<K, T, R, C>(&self, col: Option<u32>, cache: &RwLock<C>, key: &K) -> bool where
+	fn exists_with_cache<K, T, R, C>(&self, col: u32, cache: &RwLock<C>, key: &K) -> bool where
 	K: Eq + Hash + Key<T, Target = R>,
 	R: Deref<Target = [u8]>,
 	C: Cache<K, T> {
@@ -208,17 +208,17 @@ pub trait Readable {
 }
 
 impl Writable for DBTransaction {
-	fn write<T, R>(&mut self, col: Option<u32>, key: &Key<T, Target = R>, value: &T) where T: rlp::Encodable, R: Deref<Target = [u8]> {
+	fn write<T, R>(&mut self, col: u32, key: &Key<T, Target = R>, value: &T) where T: rlp::Encodable, R: Deref<Target = [u8]> {
 		self.put(col, &key.key(), &rlp::encode(value));
 	}
 
-	fn delete<T, R>(&mut self, col: Option<u32>, key: &Key<T, Target = R>) where T: rlp::Encodable, R: Deref<Target = [u8]> {
+	fn delete<T, R>(&mut self, col: u32, key: &Key<T, Target = R>) where T: rlp::Encodable, R: Deref<Target = [u8]> {
 		self.delete(col, &key.key());
 	}
 }
 
 impl<KVDB: KeyValueDB + ?Sized> Readable for KVDB {
-	fn read<T, R>(&self, col: Option<u32>, key: &Key<T, Target = R>) -> Option<T> where T: rlp::Decodable, R: Deref<Target = [u8]> {
+	fn read<T, R>(&self, col: u32, key: &Key<T, Target = R>) -> Option<T> where T: rlp::Decodable, R: Deref<Target = [u8]> {
 		let result = self.get(col, &key.key());
 
 		match result {
@@ -229,7 +229,7 @@ impl<KVDB: KeyValueDB + ?Sized> Readable for KVDB {
 		}
 	}
 
-	fn exists<T, R>(&self, col: Option<u32>, key: &Key<T, Target = R>) -> bool where R: Deref<Target = [u8]> {
+	fn exists<T, R>(&self, col: u32, key: &Key<T, Target = R>) -> bool where R: Deref<Target = [u8]> {
 		let result = self.get(col, &key.key());
 
 		match result {

--- a/ethcore/src/json_tests/chain.rs
+++ b/ethcore/src/json_tests/chain.rs
@@ -57,7 +57,7 @@ pub fn json_chain_test(json_data: &[u8]) -> Vec<String> {
 			};
 
 			{
-				let db = Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)));
+				let db = Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS));
 				let mut config = ClientConfig::default();
 				config.history = 8;
 				let client = Client::new(

--- a/ethcore/src/service.rs
+++ b/ethcore/src/service.rs
@@ -78,7 +78,7 @@ impl ClientService {
 
 		info!("Configured for {} using {} engine", Colour::White.bold().paint(spec.name.clone()), Colour::Yellow.bold().paint(spec.engine.name()));
 
-		let mut db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+		let mut db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 
 		db_config.memory_budget = config.db_cache_size;
 		db_config.compaction = config.db_compaction.compaction_profile(client_path);

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -311,7 +311,7 @@ impl StateRebuilder {
 	/// Create a new state rebuilder to write into the given backing DB.
 	pub fn new(db: Arc<KeyValueDB>, pruning: Algorithm) -> Self {
 		StateRebuilder {
-			db: journaldb::new(db.clone(), pruning, ::db::COL_STATE),
+			db: journaldb::new(db.clone(), pruning, Some(::db::COL_STATE)),
 			state_root: KECCAK_NULL_RLP,
 			known_code: HashMap::new(),
 			missing_code: HashMap::new(),

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -311,7 +311,7 @@ impl StateRebuilder {
 	/// Create a new state rebuilder to write into the given backing DB.
 	pub fn new(db: Arc<KeyValueDB>, pruning: Algorithm) -> Self {
 		StateRebuilder {
-			db: journaldb::new(db.clone(), pruning, Some(::db::COL_STATE)),
+			db: journaldb::new(db.clone(), pruning, ::db::COL_STATE),
 			state_root: KECCAK_NULL_RLP,
 			known_code: HashMap::new(),
 			missing_code: HashMap::new(),

--- a/ethcore/src/snapshot/tests/proof_of_authority.rs
+++ b/ethcore/src/snapshot/tests/proof_of_authority.rs
@@ -227,7 +227,7 @@ fn fixed_to_contract_only() {
 	assert_eq!(client.chain_info().best_block_number, 11);
 	let (reader, _tempdir) = snapshot_helpers::snap(&*client);
 
-	let new_db = kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0));
+	let new_db = kvdb_memorydb::create(::db::NUM_COLUMNS);
 	let spec = spec_fixed_to_contract();
 
 	// ensure fresh engine's step matches.
@@ -259,7 +259,7 @@ fn fixed_to_contract_to_contract() {
 
 	assert_eq!(client.chain_info().best_block_number, 16);
 	let (reader, _tempdir) = snapshot_helpers::snap(&*client);
-	let new_db = kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0));
+	let new_db = kvdb_memorydb::create(::db::NUM_COLUMNS);
 	let spec = spec_fixed_to_contract();
 
 	for _ in 0..16 { spec.engine.step() }

--- a/ethcore/src/snapshot/tests/proof_of_work.rs
+++ b/ethcore/src/snapshot/tests/proof_of_work.rs
@@ -43,7 +43,7 @@ fn chunk_and_restore(amount: u64) {
 	let tempdir = TempDir::new("").unwrap();
 	let snapshot_path = tempdir.path().join("SNAP");
 
-	let old_db = Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)));
+	let old_db = Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS));
 	let bc = BlockChain::new(Default::default(), &genesis.encoded(), old_db.clone());
 
 	// build the blockchain.
@@ -79,7 +79,7 @@ fn chunk_and_restore(amount: u64) {
 	writer.into_inner().finish(manifest.clone()).unwrap();
 
 	// restore it.
-	let new_db = Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)));
+	let new_db = Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS));
 	let new_chain = BlockChain::new(Default::default(), &genesis.encoded(), new_db.clone());
 	let mut rebuilder = SNAPSHOT_MODE.rebuilder(new_chain, new_db.clone(), &manifest).unwrap();
 
@@ -125,7 +125,7 @@ fn checks_flag() {
 	let genesis = BlockBuilder::genesis();
 	let chunk = stream.out();
 
-	let db = Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)));
+	let db = Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS));
 	let engine = ::spec::Spec::new_test().engine;
 	let chain = BlockChain::new(Default::default(), &genesis.last().encoded(), db.clone());
 

--- a/ethcore/src/snapshot/tests/service.rs
+++ b/ethcore/src/snapshot/tests/service.rs
@@ -50,7 +50,7 @@ fn restored_is_equivalent() {
 	let client_db = tempdir.path().join("client_db");
 	let path = tempdir.path().join("snapshot");
 
-	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let client_db = Database::open(&db_config, client_db.to_str().unwrap()).unwrap();
 
 	let spec = Spec::new_null();
@@ -107,7 +107,7 @@ fn guards_delete_folders() {
 	let service_params = ServiceParams {
 		engine: spec.engine.clone(),
 		genesis_block: spec.genesis_block(),
-		db_config: DatabaseConfig::with_columns(::db::NUM_COLUMNS),
+		db_config: DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS)),
 		pruning: ::journaldb::Algorithm::Archive,
 		channel: IoChannel::disconnected(),
 		snapshot_root: tempdir.path().to_owned(),

--- a/ethcore/src/snapshot/tests/state.rs
+++ b/ethcore/src/snapshot/tests/state.rs
@@ -41,7 +41,7 @@ fn snap_and_restore() {
 	let mut producer = StateProducer::new();
 	let mut rng = XorShiftRng::from_seed([1, 2, 3, 4]);
 	let mut old_db = MemoryDB::new();
-	let db_cfg = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_cfg = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 
 	for _ in 0..150 {
 		producer.tick(&mut rng, &mut old_db);
@@ -130,7 +130,7 @@ fn get_code_from_prev_chunk() {
 	let chunk2 = make_chunk(acc, h2);
 
 	let tempdir = TempDir::new("").unwrap();
-	let db_cfg = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_cfg = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let new_db = Arc::new(Database::open(&db_cfg, tempdir.path().to_str().unwrap()).unwrap());
 
 	{
@@ -152,7 +152,7 @@ fn checks_flag() {
 	let mut producer = StateProducer::new();
 	let mut rng = XorShiftRng::from_seed([5, 6, 7, 8]);
 	let mut old_db = MemoryDB::new();
-	let db_cfg = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_cfg = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 
 	for _ in 0..10 {
 		producer.tick(&mut rng, &mut old_db);

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -685,7 +685,7 @@ impl Spec {
 		let mut db = journaldb::new(
 			Arc::new(kvdb_memorydb::create(0)),
 			journaldb::Algorithm::Archive,
-			None,
+			0,
 		);
 
 		self.ensure_db_good(BasicBackend(db.as_hashdb_mut()), &factories)

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -150,7 +150,7 @@ impl StateDB {
 	/// Loads accounts bloom from the database
 	/// This bloom is used to handle request for the non-existant account fast
 	pub fn load_bloom(db: &KeyValueDB) -> Bloom {
-		let hash_count_entry = db.get(Some(COL_ACCOUNT_BLOOM), ACCOUNT_BLOOM_HASHCOUNT_KEY)
+		let hash_count_entry = db.get(COL_ACCOUNT_BLOOM, ACCOUNT_BLOOM_HASHCOUNT_KEY)
 			.expect("Low-level database error");
 
 		let hash_count_bytes = match hash_count_entry {
@@ -165,7 +165,7 @@ impl StateDB {
 		let mut key = [0u8; 8];
 		for i in 0..ACCOUNT_BLOOM_SPACE / 8 {
 			LittleEndian::write_u64(&mut key, i as u64);
-			bloom_parts[i] = db.get(Some(COL_ACCOUNT_BLOOM), &key).expect("low-level database error")
+			bloom_parts[i] = db.get(COL_ACCOUNT_BLOOM, &key).expect("low-level database error")
 				.and_then(|val| Some(LittleEndian::read_u64(&val[..])))
 				.unwrap_or(0u64);
 		}
@@ -178,14 +178,14 @@ impl StateDB {
 	/// Commit bloom to a database transaction
 	pub fn commit_bloom(batch: &mut DBTransaction, journal: BloomJournal) -> Result<(), UtilError> {
 		assert!(journal.hash_functions <= 255);
-		batch.put(Some(COL_ACCOUNT_BLOOM), ACCOUNT_BLOOM_HASHCOUNT_KEY, &[journal.hash_functions as u8]);
+		batch.put(COL_ACCOUNT_BLOOM, ACCOUNT_BLOOM_HASHCOUNT_KEY, &[journal.hash_functions as u8]);
 		let mut key = [0u8; 8];
 		let mut val = [0u8; 8];
 
 		for (bloom_part_index, bloom_part_value) in journal.entries {
 			LittleEndian::write_u64(&mut key, bloom_part_index as u64);
 			LittleEndian::write_u64(&mut val, bloom_part_value);
-			batch.put(Some(COL_ACCOUNT_BLOOM), &key, &val);
+			batch.put(COL_ACCOUNT_BLOOM, &key, &val);
 		}
 		Ok(())
 	}

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -39,7 +39,7 @@ use tempdir::TempDir;
 fn imports_from_empty() {
 	let tempdir = TempDir::new("").unwrap();
 	let spec = get_test_spec();
-	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let client_db = Arc::new(Database::open(&db_config, tempdir.path().to_str().unwrap()).unwrap());
 
 	let client = Client::new(
@@ -57,7 +57,7 @@ fn imports_from_empty() {
 fn should_return_registrar() {
 	let tempdir = TempDir::new("").unwrap();
 	let spec = ethereum::new_morden(&tempdir.path().to_owned());
-	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let client_db = Arc::new(Database::open(&db_config, tempdir.path().to_str().unwrap()).unwrap());
 
 	let client = Client::new(
@@ -87,7 +87,7 @@ fn returns_state_root_basic() {
 fn imports_good_block() {
 	let tempdir = TempDir::new("").unwrap();
 	let spec = get_test_spec();
-	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let client_db = Arc::new(Database::open(&db_config, tempdir.path().to_str().unwrap()).unwrap());
 
 	let client = Client::new(
@@ -112,7 +112,7 @@ fn imports_good_block() {
 fn query_none_block() {
 	let tempdir = TempDir::new("").unwrap();
 	let spec = get_test_spec();
-	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let client_db = Arc::new(Database::open(&db_config, tempdir.path().to_str().unwrap()).unwrap());
 
 	let client = Client::new(
@@ -264,7 +264,7 @@ fn change_history_size() {
 	let tempdir = TempDir::new("").unwrap();
 	let test_spec = Spec::new_null();
 	let mut config = ClientConfig::default();
-	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let client_db = Arc::new(Database::open(&db_config, tempdir.path().to_str().unwrap()).unwrap());
 
 	config.history = 2;

--- a/ethcore/src/tests/helpers.rs
+++ b/ethcore/src/tests/helpers.rs
@@ -231,7 +231,7 @@ pub fn get_test_client_with_blocks(blocks: Vec<Bytes>) -> Arc<Client> {
 }
 
 fn new_db() -> Arc<::kvdb::KeyValueDB> {
-	Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)))
+	Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS))
 }
 
 pub fn generate_dummy_blockchain(block_number: u32) -> BlockChain {

--- a/ethcore/src/tests/trace.rs
+++ b/ethcore/src/tests/trace.rs
@@ -42,7 +42,7 @@ fn can_trace_block_and_uncle_reward() {
 	let engine = &*spec.engine;
 
 	// Create client
-	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+	let db_config = DatabaseConfig::with_columns(Some(::db::NUM_COLUMNS));
 	let mut client_config = ClientConfig::default();
 	client_config.tracing.enabled = true;
 	let client_db = Arc::new(Database::open(&db_config, tempdir.path().to_str().unwrap()).unwrap());

--- a/ethcore/src/trace/db.rs
+++ b/ethcore/src/trace/db.rs
@@ -120,7 +120,7 @@ pub struct TraceDB<T> where T: DatabaseExtras {
 impl<T> BloomGroupDatabase for TraceDB<T> where T: DatabaseExtras {
 	fn blooms_at(&self, position: &GroupPosition) -> Option<BloomGroup> {
 		let position = TraceGroupPosition::from(position.clone());
-		let result = self.tracesdb.read_with_cache(db::COL_TRACE, &self.blooms, &position).map(Into::into);
+		let result = self.tracesdb.read_with_cache(Some(db::COL_TRACE), &self.blooms, &position).map(Into::into);
 		self.note_used(CacheId::Bloom(position));
 		result
 	}
@@ -132,8 +132,8 @@ impl<T> TraceDB<T> where T: DatabaseExtras {
 		let mut batch = DBTransaction::new();
 		let genesis = extras.block_hash(0)
 			.expect("Genesis block is always inserted upon extras db creation qed");
-		batch.write(db::COL_TRACE, &genesis, &FlatBlockTraces::default());
-		batch.put(db::COL_TRACE, b"version", TRACE_DB_VER);
+		batch.write(Some(db::COL_TRACE), &genesis, &FlatBlockTraces::default());
+		batch.put(Some(db::COL_TRACE), b"version", TRACE_DB_VER);
 		tracesdb.write(batch).expect("failed to update version");
 
 		TraceDB {
@@ -183,7 +183,7 @@ impl<T> TraceDB<T> where T: DatabaseExtras {
 
 	/// Returns traces for block with hash.
 	fn traces(&self, block_hash: &H256) -> Option<FlatBlockTraces> {
-		let result = self.tracesdb.read_with_cache(db::COL_TRACE, &self.traces, block_hash);
+		let result = self.tracesdb.read_with_cache(Some(db::COL_TRACE), &self.traces, block_hash);
 		self.note_used(CacheId::Trace(block_hash.clone()));
 		result
 	}
@@ -289,7 +289,7 @@ impl<T> TraceDatabase for TraceDB<T> where T: DatabaseExtras {
 
 			let blooms_keys: Vec<_> = blooms_to_insert.keys().cloned().collect();
 			let mut blooms = self.blooms.write();
-			batch.extend_with_cache(db::COL_TRACE, &mut *blooms, blooms_to_insert, CacheUpdatePolicy::Remove);
+			batch.extend_with_cache(Some(db::COL_TRACE), &mut *blooms, blooms_to_insert, CacheUpdatePolicy::Remove);
 			// note_used must be called after locking blooms to avoid cache/traces deadlock on garbage collection
 			for key in blooms_keys {
 				self.note_used(CacheId::Bloom(key));
@@ -301,7 +301,7 @@ impl<T> TraceDatabase for TraceDB<T> where T: DatabaseExtras {
 			let mut traces = self.traces.write();
 			// it's important to use overwrite here,
 			// cause this value might be queried by hash later
-			batch.write_with_cache(db::COL_TRACE, &mut *traces, request.block_hash, request.traces, CacheUpdatePolicy::Overwrite);
+			batch.write_with_cache(Some(db::COL_TRACE), &mut *traces, request.block_hash, request.traces, CacheUpdatePolicy::Overwrite);
 			// note_used must be called after locking traces to avoid cache/traces deadlock on garbage collection
 			self.note_used(CacheId::Trace(request.block_hash.clone()));
 		}
@@ -463,7 +463,7 @@ mod tests {
 	}
 
 	fn new_db() -> Arc<KeyValueDB> {
-		Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)))
+		Arc::new(kvdb_memorydb::create(::db::NUM_COLUMNS))
 	}
 
 	#[test]

--- a/ethcore/src/tx_filter.rs
+++ b/ethcore/src/tx_filter.rs
@@ -169,7 +169,7 @@ mod test {
 		"#;
 
 		let spec = Spec::load(&::std::env::temp_dir(), spec_data.as_bytes()).unwrap();
-		let client_db = Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)));
+		let client_db = Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS));
 
 		let client = Client::new(
 			ClientConfig::default(),

--- a/local-store/src/lib.rs
+++ b/local-store/src/lib.rs
@@ -138,7 +138,7 @@ pub trait NodeInfo: Send + Sync {
 
 /// Create a new local data store, given a database, a column to write to, and a node.
 /// Attempts to read data out of the store, and move it into the node.
-pub fn create<T: NodeInfo>(db: Arc<KeyValueDB>, col: Option<u32>, node: T) -> LocalDataStore<T> {
+pub fn create<T: NodeInfo>(db: Arc<KeyValueDB>, col: u32, node: T) -> LocalDataStore<T> {
 	LocalDataStore {
 		db: db,
 		col: col,
@@ -152,7 +152,7 @@ pub fn create<T: NodeInfo>(db: Arc<KeyValueDB>, col: Option<u32>, node: T) -> Lo
 /// and the node security level.
 pub struct LocalDataStore<T: NodeInfo> {
 	db: Arc<KeyValueDB>,
-	col: Option<u32>,
+	col: u32,
 	node: T,
 }
 

--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -196,7 +196,7 @@ fn execute_import_light(cmd: ImportBlockchain) -> Result<(), String> {
 
 	let mut config = LightClientConfig {
 		queue: Default::default(),
-		chain_column: ::ethcore::db::COL_LIGHT_CHAIN,
+		chain_column: Some(::ethcore::db::COL_LIGHT_CHAIN),
 		db_cache_size: Some(cmd.cache_config.blockchain() as usize * 1024 * 1024),
 		db_compaction: compaction,
 		db_wal: cmd.wal,

--- a/parity/migration.rs
+++ b/parity/migration.rs
@@ -251,11 +251,11 @@ pub fn migrate(path: &Path, pruning: Algorithm, compaction_profile: CompactionPr
 		let db_path = consolidated_database_path(path);
 		// Remove the database dir (it shouldn't exist anyway, but it might when migration was interrupted)
 		let _ = fs::remove_dir_all(db_path.clone());
-		consolidate_database(legacy::blocks_database_path(path), db_path.clone(), db::COL_HEADERS, Extract::Header, &compaction_profile)?;
-		consolidate_database(legacy::blocks_database_path(path), db_path.clone(), db::COL_BODIES, Extract::Body, &compaction_profile)?;
-		consolidate_database(legacy::extras_database_path(path), db_path.clone(), db::COL_EXTRA, Extract::All, &compaction_profile)?;
-		consolidate_database(legacy::state_database_path(path), db_path.clone(), db::COL_STATE, Extract::All, &compaction_profile)?;
-		consolidate_database(legacy::trace_database_path(path), db_path.clone(), db::COL_TRACE, Extract::All, &compaction_profile)?;
+		consolidate_database(legacy::blocks_database_path(path), db_path.clone(), Some(db::COL_HEADERS), Extract::Header, &compaction_profile)?;
+		consolidate_database(legacy::blocks_database_path(path), db_path.clone(), Some(db::COL_BODIES), Extract::Body, &compaction_profile)?;
+		consolidate_database(legacy::extras_database_path(path), db_path.clone(), Some(db::COL_EXTRA), Extract::All, &compaction_profile)?;
+		consolidate_database(legacy::state_database_path(path), db_path.clone(), Some(db::COL_STATE), Extract::All, &compaction_profile)?;
+		consolidate_database(legacy::trace_database_path(path), db_path.clone(), Some(db::COL_TRACE), Extract::All, &compaction_profile)?;
 		let _ = fs::remove_dir_all(legacy::blocks_database_path(path));
 		let _ = fs::remove_dir_all(legacy::extras_database_path(path));
 		let _ = fs::remove_dir_all(legacy::state_database_path(path));

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -221,7 +221,7 @@ fn execute_light_impl(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger
 	// start client and create transaction queue.
 	let mut config = light_client::Config {
 		queue: Default::default(),
-		chain_column: ::ethcore::db::COL_LIGHT_CHAIN,
+		chain_column: Some(::ethcore::db::COL_LIGHT_CHAIN),
 		db_cache_size: Some(cmd.cache_config.blockchain() as usize * 1024 * 1024),
 		db_compaction: compaction,
 		db_wal: cmd.wal,
@@ -604,7 +604,7 @@ pub fn execute_impl(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>)
 			}
 		};
 
-		let store = ::local_store::create(db, ::ethcore::db::COL_NODE_INFO, node_info);
+		let store = ::local_store::create(db, Some(::ethcore::db::COL_NODE_INFO), node_info);
 
 		if cmd.no_persistent_txqueue {
 			info!("Running without a persistent transaction queue.");

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -604,7 +604,7 @@ pub fn execute_impl(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger>)
 			}
 		};
 
-		let store = ::local_store::create(db, Some(::ethcore::db::COL_NODE_INFO), node_info);
+		let store = ::local_store::create(db, ::ethcore::db::COL_NODE_INFO, node_info);
 
 		if cmd.no_persistent_txqueue {
 			info!("Running without a persistent transaction queue.");

--- a/rpc/src/v1/tests/eth.rs
+++ b/rpc/src/v1/tests/eth.rs
@@ -134,7 +134,7 @@ impl EthTester {
 		let client = Client::new(
 			ClientConfig::default(),
 			&spec,
-			Arc::new(kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS.unwrap_or(0))),
+			Arc::new(kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS)),
 			miner_service.clone(),
 			IoChannel::disconnected(),
 		).unwrap();

--- a/sync/src/tests/helpers.rs
+++ b/sync/src/tests/helpers.rs
@@ -291,7 +291,7 @@ impl TestNet<EthPeer<EthcoreClient>> {
 		let client = EthcoreClient::new(
 			ClientConfig::default(),
 			&spec,
-			Arc::new(::kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS.unwrap_or(0))),
+			Arc::new(::kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS)),
 			Arc::new(Miner::with_spec_and_accounts(&spec, accounts)),
 			IoChannel::disconnected(),
 		).unwrap();

--- a/util/journaldb/src/archivedb.rs
+++ b/util/journaldb/src/archivedb.rs
@@ -40,12 +40,12 @@ pub struct ArchiveDB {
 	overlay: MemoryDB,
 	backing: Arc<KeyValueDB>,
 	latest_era: Option<u64>,
-	column: Option<u32>,
+	column: u32,
 }
 
 impl ArchiveDB {
 	/// Create a new instance from a key-value db.
-	pub fn new(backing: Arc<KeyValueDB>, col: Option<u32>) -> ArchiveDB {
+	pub fn new(backing: Arc<KeyValueDB>, col: u32) -> ArchiveDB {
 		let latest_era = backing.get(col, &LATEST_ERA_KEY).expect("Low-level database error.").map(|val| decode::<u64>(&val));
 		ArchiveDB {
 			overlay: MemoryDB::new(),

--- a/util/journaldb/src/lib.rs
+++ b/util/journaldb/src/lib.rs
@@ -139,7 +139,7 @@ impl fmt::Display for Algorithm {
 }
 
 /// Create a new `JournalDB` trait object over a generic key-value database.
-pub fn new(backing: Arc<::kvdb::KeyValueDB>, algorithm: Algorithm, col: Option<u32>) -> Box<JournalDB> {
+pub fn new(backing: Arc<::kvdb::KeyValueDB>, algorithm: Algorithm, col: u32) -> Box<JournalDB> {
 	match algorithm {
 		Algorithm::Archive => Box::new(archivedb::ArchiveDB::new(backing, col)),
 		Algorithm::EarlyMerge => Box::new(earlymergedb::EarlyMergeDB::new(backing, col)),

--- a/util/journaldb/src/overlaydb.rs
+++ b/util/journaldb/src/overlaydb.rs
@@ -38,12 +38,12 @@ use kvdb::{KeyValueDB, DBTransaction};
 pub struct OverlayDB {
 	overlay: MemoryDB,
 	backing: Arc<KeyValueDB>,
-	column: Option<u32>,
+	column: u32,
 }
 
 impl OverlayDB {
 	/// Create a new instance of OverlayDB given a `backing` database.
-	pub fn new(backing: Arc<KeyValueDB>, col: Option<u32>) -> OverlayDB {
+	pub fn new(backing: Arc<KeyValueDB>, col: u32) -> OverlayDB {
 		OverlayDB{ overlay: MemoryDB::new(), backing: backing, column: col }
 	}
 

--- a/util/journaldb/src/overlayrecentdb.rs
+++ b/util/journaldb/src/overlayrecentdb.rs
@@ -67,7 +67,7 @@ pub struct OverlayRecentDB {
 	transaction_overlay: MemoryDB,
 	backing: Arc<KeyValueDB>,
 	journal_overlay: Arc<RwLock<JournalOverlay>>,
-	column: Option<u32>,
+	column: u32,
 }
 
 #[derive(PartialEq)]
@@ -108,7 +108,7 @@ const PADDING : [u8; 10] = [ 0u8; 10 ];
 
 impl OverlayRecentDB {
 	/// Create a new instance.
-	pub fn new(backing: Arc<KeyValueDB>, col: Option<u32>) -> OverlayRecentDB {
+	pub fn new(backing: Arc<KeyValueDB>, col: u32) -> OverlayRecentDB {
 		let journal_overlay = Arc::new(RwLock::new(OverlayRecentDB::read_overlay(&*backing, col)));
 		OverlayRecentDB {
 			transaction_overlay: MemoryDB::new(),
@@ -133,7 +133,7 @@ impl OverlayRecentDB {
 		self.backing.get(self.column, key).expect("Low-level database error. Some issue with your hard disk?")
 	}
 
-	fn read_overlay(db: &KeyValueDB, col: Option<u32>) -> JournalOverlay {
+	fn read_overlay(db: &KeyValueDB, col: u32) -> JournalOverlay {
 		let mut journal = HashMap::new();
 		let mut overlay = MemoryDB::new();
 		let mut count = 0;

--- a/util/journaldb/src/refcounteddb.rs
+++ b/util/journaldb/src/refcounteddb.rs
@@ -56,14 +56,14 @@ pub struct RefCountedDB {
 	latest_era: Option<u64>,
 	inserts: Vec<H256>,
 	removes: Vec<H256>,
-	column: Option<u32>,
+	column: u32,
 }
 
 const PADDING : [u8; 10] = [ 0u8; 10 ];
 
 impl RefCountedDB {
 	/// Create a new instance given a `backing` database.
-	pub fn new(backing: Arc<KeyValueDB>, col: Option<u32>) -> RefCountedDB {
+	pub fn new(backing: Arc<KeyValueDB>, col: u32) -> RefCountedDB {
 		let latest_era = backing.get(col, &LATEST_ERA_KEY).expect("Low-level database error.").map(|val| decode::<u64>(&val));
 
 		RefCountedDB {

--- a/util/kvdb-rocksdb/src/lib.rs
+++ b/util/kvdb-rocksdb/src/lib.rs
@@ -688,12 +688,20 @@ impl Database {
 // duplicate declaration of methods here to avoid trait import in certain existing cases
 // at time of addition.
 impl KeyValueDB for Database {
-	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>> {
-		Database::get(self, col, key)
+	fn get(&self, col: u32, key: &[u8]) -> Result<Option<DBValue>> {
+		Database::get(self, Some(col), key)
 	}
 
-	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>> {
-		Database::get_by_prefix(self, col, prefix)
+	fn get_none_col(&self, key: &[u8]) -> Result<Option<DBValue>> {
+		Database::get(self, None, key)
+	}
+
+	fn get_by_prefix(&self, col: u32, prefix: &[u8]) -> Option<Box<[u8]>> {
+		Database::get_by_prefix(self, Some(col), prefix)
+	}
+
+	fn get_by_prefix_none_col(&self, prefix: &[u8]) -> Option<Box<[u8]>> {
+		Database::get_by_prefix(self, None, prefix)
 	}
 
 	fn write_buffered(&self, transaction: DBTransaction) {
@@ -708,15 +716,27 @@ impl KeyValueDB for Database {
 		Database::flush(self)
 	}
 
-	fn iter<'a>(&'a self, col: Option<u32>) -> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a> {
-		let unboxed = Database::iter(self, col);
+	fn iter<'a>(&'a self, col: u32) -> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a> {
+		let unboxed = Database::iter(self, Some(col));
 		Box::new(unboxed.into_iter().flat_map(|inner| inner))
 	}
 
-	fn iter_from_prefix<'a>(&'a self, col: Option<u32>, prefix: &'a [u8])
+	fn iter_none_col<'a>(&'a self) -> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a> {
+		let unboxed = Database::iter(self, None);
+		Box::new(unboxed.into_iter().flat_map(|inner| inner))
+	}
+
+	fn iter_from_prefix<'a>(&'a self, col: u32, prefix: &'a [u8])
 		-> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a>
 	{
-		let unboxed = Database::iter_from_prefix(self, col, prefix);
+		let unboxed = Database::iter_from_prefix(self, Some(col), prefix);
+		Box::new(unboxed.into_iter().flat_map(|inner| inner))
+	}
+
+	fn iter_from_prefix_none_col<'a>(&'a self, prefix: &'a [u8])
+		-> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a>
+	{
+		let unboxed = Database::iter_from_prefix(self, None, prefix);
 		Box::new(unboxed.into_iter().flat_map(|inner| inner))
 	}
 

--- a/util/migration/src/lib.rs
+++ b/util/migration/src/lib.rs
@@ -107,7 +107,10 @@ impl Batch {
 		let mut transaction = DBTransaction::new();
 
 		for keypair in &self.inner {
-			transaction.put(self.column, &keypair.0, &keypair.1);
+			match self.column {
+				Some(col) => transaction.put(col, &keypair.0, &keypair.1),
+				None => transaction.put_none_col(&keypair.0, &keypair.1),
+			}
 		}
 
 		self.inner.clear();


### PR DESCRIPTION
General cleanup refactoring.

This PR turns the lines like:

```rust
const COL_FOO: Option<u32> = Some(...);
```

Into:

```rust
const COL_FOO: u32 = ...;
```

And adjusts the rest of the code for these changes.
This notably removes some `COL_FOO.unwrap_or(0)` or `COL_FOO.expect(...)` which didn't really make sense.

Note that an ever better change would be to force using columns everywhere in the API and totally remove the `Option`s. However the secret_store uses the `None` column, and turning that into an actual column would require a migration which I'm not sure how to write.
