### PR TITLE
Extract the hard dependency on rocksdb from the light client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,6 @@ dependencies = [
  "keccak-hash 0.1.0",
  "kvdb 0.1.0",
  "kvdb-memorydb 0.1.0",
- "kvdb-rocksdb 0.1.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-cache 0.1.0",
  "memorydb 0.1.1",

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -68,9 +68,9 @@ keccak-hash = { path = "../util/hash" }
 triehash = { path = "../util/triehash" }
 unexpected = { path = "../util/unexpected" }
 journaldb = { path = "../util/journaldb" }
-tempdir = "0.3"
 
 [dev-dependencies]
+tempdir = "0.3"
 trie-standardmap = { path = "../util/trie-standardmap" }
 
 [features]

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -35,11 +35,10 @@ stats = { path = "../../util/stats" }
 keccak-hash = { path = "../../util/hash" }
 triehash = { path = "../../util/triehash" }
 kvdb = { path = "../../util/kvdb" }
-kvdb-rocksdb = { path = "../../util/kvdb-rocksdb" }
-kvdb-memorydb = { path = "../../util/kvdb-memorydb" }
 memory-cache = { path = "../../util/memory_cache" }
 
 [dev-dependencies]
+kvdb-memorydb = { path = "../../util/kvdb-memorydb" }
 tempdir = "0.3"
 
 [features]

--- a/ethcore/light/src/lib.rs
+++ b/ethcore/light/src/lib.rs
@@ -80,9 +80,9 @@ extern crate vm;
 extern crate keccak_hash as hash;
 extern crate triehash;
 extern crate kvdb;
-extern crate kvdb_memorydb;
-extern crate kvdb_rocksdb;
 extern crate memory_cache;
 
+#[cfg(test)]
+extern crate kvdb_memorydb;
 #[cfg(test)]
 extern crate tempdir;

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -352,7 +352,7 @@ impl TestBlockChainClient {
 }
 
 pub fn get_temp_state_db() -> StateDB {
-	let db = kvdb_memorydb::create(NUM_COLUMNS.unwrap());		// TODO: don't unwrap
+	let db = kvdb_memorydb::create(NUM_COLUMNS.unwrap_or(0));
 	let journal_db = journaldb::new(Arc::new(db), journaldb::Algorithm::EarlyMerge, COL_STATE);
 	StateDB::new(journal_db, 1024 * 1024)
 }

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -27,11 +27,10 @@ use ethereum_types::{H256, U256, Address};
 use parking_lot::RwLock;
 use journaldb;
 use kvdb::DBValue;
-use kvdb_rocksdb::{Database, DatabaseConfig};
+use kvdb_memorydb;
 use bytes::Bytes;
 use rlp::*;
 use ethkey::{Generator, Random};
-use tempdir::TempDir;
 use transaction::{self, Transaction, LocalizedTransaction, PendingTransaction, SignedTransaction, Action};
 use blockchain::{TreeRoute, BlockReceipts};
 use client::{
@@ -352,12 +351,10 @@ impl TestBlockChainClient {
 	}
 }
 
-pub fn get_temp_state_db() -> (StateDB, TempDir) {
-	let tempdir = TempDir::new("").unwrap();
-	let db = Database::open(&DatabaseConfig::with_columns(NUM_COLUMNS), tempdir.path().to_str().unwrap()).unwrap();
+pub fn get_temp_state_db() -> StateDB {
+	let db = kvdb_memorydb::create(NUM_COLUMNS.unwrap());		// TODO: don't unwrap
 	let journal_db = journaldb::new(Arc::new(db), journaldb::Algorithm::EarlyMerge, COL_STATE);
-	let state_db = StateDB::new(journal_db, 1024 * 1024);
-	(state_db, tempdir)
+	StateDB::new(journal_db, 1024 * 1024)
 }
 
 impl MiningBlockChainClient for TestBlockChainClient {
@@ -370,8 +367,7 @@ impl MiningBlockChainClient for TestBlockChainClient {
 	fn prepare_open_block(&self, author: Address, gas_range_target: (U256, U256), extra_data: Bytes) -> OpenBlock {
 		let engine = &*self.spec.engine;
 		let genesis_header = self.spec.genesis_header();
-		let (state_db, _tempdir) = get_temp_state_db();
-		let db = self.spec.ensure_db_good(state_db, &Default::default()).unwrap();
+		let db = self.spec.ensure_db_good(get_temp_state_db(), &Default::default()).unwrap();
 
 		let last_hashes = vec![genesis_header.hash()];
 		let mut open_block = OpenBlock::new(

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -115,6 +115,8 @@ extern crate vm;
 extern crate wasm;
 extern crate memory_cache;
 extern crate journaldb;
+#[cfg(test)]
+extern crate tempdir;
 
 #[macro_use]
 extern crate macros;
@@ -127,8 +129,6 @@ extern crate evm;
 
 #[cfg(feature = "jit" )]
 extern crate evmjit;
-
-extern crate tempdir;
 
 pub extern crate ethstore;
 

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -24,6 +24,7 @@ use ansi_term::Colour;
 use ctrlc::CtrlC;
 use ethcore::account_provider::{AccountProvider, AccountProviderSettings};
 use ethcore::client::{Client, Mode, DatabaseCompactionProfile, VMType, BlockChainClient};
+use ethcore::db::NUM_COLUMNS;
 use ethcore::ethstore::ethkey;
 use ethcore::miner::{Miner, MinerService, MinerOptions};
 use ethcore::miner::{StratumOptions, Stratum};
@@ -38,6 +39,7 @@ use hash_fetch::fetch::{Fetch, Client as FetchClient};
 use hash_fetch;
 use informant::{Informant, LightNodeInformantData, FullNodeInformantData};
 use journaldb::Algorithm;
+use kvdb_rocksdb::{Database, DatabaseConfig};
 use light::Cache as LightDataCache;
 use miner::external::ExternalMiner;
 use node_filter::NodeFilter;
@@ -222,9 +224,6 @@ fn execute_light_impl(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger
 	let mut config = light_client::Config {
 		queue: Default::default(),
 		chain_column: ::ethcore::db::COL_LIGHT_CHAIN,
-		db_cache_size: Some(cmd.cache_config.blockchain() as usize * 1024 * 1024),
-		db_compaction: compaction,
-		db_wal: cmd.wal,
 		verify_full: true,
 		check_seal: cmd.check_seal,
 	};
@@ -241,7 +240,22 @@ fn execute_light_impl(cmd: RunCmd, can_restart: bool, logger: Arc<RotatingLogger
 		sync: sync_handle.clone(),
 	};
 
-	let service = light_client::Service::start(config, &spec, fetch, &db_dirs.client_path(algorithm), cache.clone())
+	// initialize database.
+	let db = {
+		let db_config = DatabaseConfig {
+			memory_budget: Some(cmd.cache_config.blockchain() as usize * 1024 * 1024),
+			compaction: compaction,
+			wal: cmd.wal,
+			.. DatabaseConfig::with_columns(NUM_COLUMNS)
+		};
+
+		Arc::new(Database::open(
+			&db_config,
+			&db_dirs.client_path(algorithm).to_str().expect("DB path could not be converted to string.")
+		).map_err(|e| format!("Error opening database: {}", e))?)
+	};
+
+	let service = light_client::Service::start(config, &spec, fetch, db, cache.clone())
 		.map_err(|e| format!("Error starting light client: {}", e))?;
 	let client = service.client();
 	let txq = Arc::new(RwLock::new(::light::transaction_queue::TransactionQueue::default()));

--- a/sync/src/light_sync/tests/test_net.rs
+++ b/sync/src/light_sync/tests/test_net.rs
@@ -25,6 +25,7 @@ use tests::helpers::{TestNet, Peer as PeerLike, TestPacket};
 use ethcore::client::TestBlockChainClient;
 use ethcore::spec::Spec;
 use io::IoChannel;
+use kvdb_memorydb;
 use light::client::fetch::{self, Unavailable};
 use light::net::{LightProtocol, IoContext, Capabilities, Params as LightParams};
 use light::provider::LightProvider;
@@ -218,13 +219,16 @@ impl TestNet<Peer> {
 			// skip full verification because the blocks are bad.
 			config.verify_full = false;
 			let cache = Arc::new(Mutex::new(Cache::new(Default::default(), Duration::hours(6))));
-			let client = LightClient::in_memory(
+			let db = kvdb_memorydb::create(0);
+			let client = LightClient::new(
 				config,
+				Arc::new(db),
+				None,
 				&Spec::new_test(),
 				fetch::unavailable(), // TODO: allow fetch from full nodes.
 				IoChannel::disconnected(),
 				cache
-			);
+			).expect("New DB creation infallible; qed");
 
 			peers.push(Arc::new(Peer::new_light(Arc::new(client))))
 		}


### PR DESCRIPTION
This PR removes the dependency from the light client towards `kvdb_rocksdb`, so that we can use other backends (such as `kvdb_memory`) if we want.
Instead of passing the path to the database to the client, we directly open the database from the `parity` crate and pass it to `LightClient::new`.

Ideally we would like to do the same for the full client. However the snapshot creation and restoration is very difficult to convert as it directly manipulates raw files. If this PR is merged, an issue should be opened to be reminded to do this eventually.

cc #7915 
