### PR TITLE
Tweaks and add a Dockerfile to compile for Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ name = "multihash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.12.1 (git+https://github.com/paritytech/ring)",
  "tiny-keccak 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2302,7 +2302,7 @@ dependencies = [
  "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.12.1 (git+https://github.com/paritytech/ring)",
  "rlp 0.2.1",
  "serde 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2602,6 +2602,15 @@ dependencies = [
 
 [[package]]
 name = "rayon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2665,12 +2674,13 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/paritytech/ring#13eec16273e5e8fbbb21def81eaeb11972f4f903"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2804,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.12.1 (git+https://github.com/paritytech/ring)",
  "sct 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2830,7 +2840,7 @@ name = "sct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.12.1 (git+https://github.com/paritytech/ring)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3073,6 +3083,18 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3483,12 +3505,12 @@ dependencies = [
  "parity-wasm 0.27.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
- "wasmi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmi"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3501,7 +3523,7 @@ name = "webpki"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.12.1 (git+https://github.com/paritytech/ring)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3773,13 +3795,14 @@ dependencies = [
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
+"checksum rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
 "checksum rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e811e76f1dbf68abf87a759083d34600017fc4e10b6bd5ad84a700f9dba4b1"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
-"checksum ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6f7d28b30a72c01b458428e0ae988d4149c20d902346902be881e3edc4bb325c"
+"checksum ring 0.12.1 (git+https://github.com/paritytech/ring)" = "<none>"
 "checksum rocksdb 0.4.5 (git+https://github.com/paritytech/rust-rocksdb)" = "<none>"
 "checksum rocksdb-sys 0.3.0 (git+https://github.com/paritytech/rust-rocksdb)" = "<none>"
 "checksum rotor 0.6.3 (git+https://github.com/tailhook/rotor)" = "<none>"
@@ -3826,6 +3849,7 @@ dependencies = [
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
+"checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
@@ -3865,7 +3889,7 @@ dependencies = [
 "checksum vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wasmi 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dedfb4cbfba1e1921b12ed05762d9d5ae99ce40e72b98bbf271561ef487e8c7"
+"checksum wasmi 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "26b20dbeb7caee04597a5d2c93e2b3e64872c6ea2af732d7ad49dbec44067c35"
 "checksum webpki 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e1622384bcb5458c6a3e3fa572f53ea8fef1cc85e535a2983dea87e9154fac2"
 "checksum webpki-roots 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155d4060e5befdf3a6076bd28c22513473d9900b763c9e4521acc6f78a75415c"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,3 +133,6 @@ members = [
 	"transaction-pool",
 	"whisper"
 ]
+
+[patch.crates-io]
+ring = { git = "https://github.com/paritytech/ring" }

--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -1,0 +1,77 @@
+FROM ubuntu:xenial
+LABEL maintainer="Parity Technologies <devops@parity.io>"
+
+RUN apt-get update && \
+    apt-get install -yq sudo curl file build-essential wget git g++ cmake pkg-config bison flex \
+                        unzip lib32stdc++6 lib32z1 python autotools-dev automake autoconf libtool \
+                        gperf xsltproc docbook-xsl
+
+# Rust & Cargo
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH /root/.cargo/bin:$PATH
+RUN rustup toolchain install stable
+RUN rustup target add --toolchain stable arm-linux-androideabi
+RUN rustup target add --toolchain stable armv7-linux-androideabi
+
+# Android NDK and toolchain
+RUN cd /usr/local && \
+    wget -q https://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip && \
+    unzip -q android-ndk-r16b-linux-x86_64.zip && \
+    rm android-ndk-r16b-linux-x86_64.zip
+ENV NDK_HOME /usr/local/android-ndk-r16b
+RUN /usr/local/android-ndk-r16b/build/tools/make-standalone-toolchain.sh \
+    --arch=arm --install-dir=/opt/ndk-standalone --stl=libc++ --platform=android-26
+ENV PATH $PATH:/opt/ndk-standalone/bin
+
+# Compiling OpenSSL for Android
+RUN cd /root && \
+    git clone git://git.openssl.org/openssl.git && \
+    cd openssl && \
+    git checkout OpenSSL_1_1_0-stable
+ENV CROSS_SYSROOT /opt/ndk-standalone/sysroot
+RUN cd /root/openssl && \
+    ./Configure android-armeabi --cross-compile-prefix=arm-linux-androideabi- \
+    -static no-stdio no-ui \
+    -I/usr/local/android-ndk-r16b/sysroot/usr/include \
+    -I/usr/local/android-ndk-r16b/sysroot/usr/include/arm-linux-androideabi \
+    -L/usr/local/android-ndk-r16b/sysroot/usr/lib \
+    --prefix=/opt/ndk-standalone/sysroot/usr
+RUN cd /root/openssl && \
+    make build_libs && \
+    make install_dev
+RUN rm -rf /root/openssl
+
+# Compiling libudev for Android
+# This is the most hacky part of the process, as we need to apply a patch and pass specific
+# options that the compiler environment doesn't define.
+RUN cd /root && \
+    git clone https://github.com/gentoo/eudev.git
+ADD libudev.patch /root
+RUN cd /root/eudev && \
+    git checkout 83d918449f22720d84a341a05e24b6d109e6d3ae && \
+    ./autogen.sh && \
+    ./configure --disable-introspection --disable-programs --disable-hwdb \
+                --host=arm-linux-androideabi --prefix=/opt/ndk-standalone/sysroot/usr/ \
+                --enable-shared=false CC=arm-linux-androideabi-clang \
+                CFLAGS="-D LINE_MAX=2048 -D RLIMIT_NLIMITS=15 -D IPTOS_LOWCOST=2 -std=gnu99" \
+                CXX=arm-linux-androideabi-clang++ && \
+    git apply - < /root/libudev.patch && \
+    make && \
+    make install
+RUN rm -rf /root/eudev
+RUN rm /root/libudev.patch
+
+# Rust-related configuration
+ADD cargo-config.toml /root/.cargo/config
+ENV ARM_LINUX_ANDROIDEABI_OPENSSL_DIR /opt/ndk-standalone/sysroot/usr
+ENV ARMV7_LINUX_ANDROIDEABI_OPENSSL_DIR /opt/ndk-standalone/sysroot/usr
+ENV CC_arm_linux_androideabi arm-linux-androideabi-clang
+ENV CC_armv7_linux_androideabi arm-linux-androideabi-clang
+ENV CXX_arm_linux_androideabi arm-linux-androideabi-clang++
+ENV CXX_armv7_linux_androideabi arm-linux-androideabi-clang++
+ENV AR_arm_linux_androideabi arm-linux-androideabi-ar
+ENV AR_armv7_linux_androideabi arm-linux-androideabi-ar
+ENV CFLAGS_arm_linux_androideabi -std=gnu11 -fPIC -D OS_ANDROID
+ENV CFLAGS_armv7_linux_androideabi -std=gnu11 -fPIC -D OS_ANDROID
+ENV CXXFLAGS_arm_linux_androideabi -std=gnu++11 -fPIC -fexceptions -frtti -static-libstdc++ -D OS_ANDROID
+ENV CXXFLAGS_armv7_linux_androideabi -std=gnu++11 -fPIC -fexceptions -frtti -static-libstdc++ -D OS_ANDROID

--- a/docker/android/cargo-config.toml
+++ b/docker/android/cargo-config.toml
@@ -1,0 +1,9 @@
+[target.armv7-linux-androideabi]
+linker = "arm-linux-androideabi-clang"
+ar = "arm-linux-androideabi-ar"
+rustflags = ["-C", "link-arg=-lc++_static", "-C", "link-arg=-lc++abi", "-C", "link-arg=-landroid_support"]
+
+[target.arm-linux-androideabi]
+linker = "arm-linux-androideabi-clang"
+ar = "arm-linux-androideabi-ar"
+rustflags = ["-C", "link-arg=-lc++_static", "-C", "link-arg=-lc++abi", "-C", "link-arg=-landroid_support"]

--- a/docker/android/libudev.patch
+++ b/docker/android/libudev.patch
@@ -1,0 +1,216 @@
+diff --git a/src/collect/collect.c b/src/collect/collect.c
+index 2cf1f00..b24f26b 100644
+--- a/src/collect/collect.c
++++ b/src/collect/collect.c
+@@ -84,7 +84,7 @@ static void usage(void)
+                "  invoked for each ID in <idlist>) collect returns 0, the\n"
+                "  number of missing IDs otherwise.\n"
+                "  On error a negative number is returned.\n\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ /*
+diff --git a/src/scsi_id/scsi_id.c b/src/scsi_id/scsi_id.c
+index 8b76d87..7bf3948 100644
+--- a/src/scsi_id/scsi_id.c
++++ b/src/scsi_id/scsi_id.c
+@@ -321,7 +321,7 @@ static void help(void) {
+                "  -u --replace-whitespace          Replace all whitespace by underscores\n"
+                "  -v --verbose                     Verbose logging\n"
+                "  -x --export                      Print values as environment keys\n"
+-               , program_invocation_short_name);
++               , "parity");
+ 
+ }
+ 
+diff --git a/src/shared/hashmap.h b/src/shared/hashmap.h
+index a03ee58..a7c2005 100644
+--- a/src/shared/hashmap.h
++++ b/src/shared/hashmap.h
+@@ -98,10 +98,7 @@ extern const struct hash_ops uint64_hash_ops;
+ #if SIZEOF_DEV_T != 8
+ unsigned long devt_hash_func(const void *p, const uint8_t hash_key[HASH_KEY_SIZE]) _pure_;
+ int devt_compare_func(const void *a, const void *b) _pure_;
+-extern const struct hash_ops devt_hash_ops = {
+-        .hash = devt_hash_func,
+-        .compare = devt_compare_func
+-};
++extern const struct hash_ops devt_hash_ops;
+ #else
+ #define devt_hash_func uint64_hash_func
+ #define devt_compare_func uint64_compare_func
+diff --git a/src/shared/log.c b/src/shared/log.c
+index 4a40996..1496984 100644
+--- a/src/shared/log.c
++++ b/src/shared/log.c
+@@ -335,7 +335,7 @@ static int write_to_syslog(
+ 
+         IOVEC_SET_STRING(iovec[0], header_priority);
+         IOVEC_SET_STRING(iovec[1], header_time);
+-        IOVEC_SET_STRING(iovec[2], program_invocation_short_name);
++        IOVEC_SET_STRING(iovec[2], "parity");
+         IOVEC_SET_STRING(iovec[3], header_pid);
+         IOVEC_SET_STRING(iovec[4], buffer);
+ 
+@@ -383,7 +383,7 @@ static int write_to_kmsg(
+         char_array_0(header_pid);
+ 
+         IOVEC_SET_STRING(iovec[0], header_priority);
+-        IOVEC_SET_STRING(iovec[1], program_invocation_short_name);
++        IOVEC_SET_STRING(iovec[1], "parity");
+         IOVEC_SET_STRING(iovec[2], header_pid);
+         IOVEC_SET_STRING(iovec[3], buffer);
+         IOVEC_SET_STRING(iovec[4], "\n");
+diff --git a/src/udev/udevadm-control.c b/src/udev/udevadm-control.c
+index 6af7163..3271e56 100644
+--- a/src/udev/udevadm-control.c
++++ b/src/udev/udevadm-control.c
+@@ -41,7 +41,7 @@ static void print_help(void) {
+                "  -p --property=KEY=VALUE  Set a global property for all events\n"
+                "  -m --children-max=N      Maximum number of children\n"
+                "     --timeout=SECONDS     Maximum time to block for a reply\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ static int adm_control(struct udev *udev, int argc, char *argv[]) {
+diff --git a/src/udev/udevadm-info.c b/src/udev/udevadm-info.c
+index 0aec976..a31ac02 100644
+--- a/src/udev/udevadm-info.c
++++ b/src/udev/udevadm-info.c
+@@ -279,7 +279,7 @@ static void help(void) {
+                "  -P --export-prefix          Export the key name with a prefix\n"
+                "  -e --export-db              Export the content of the udev database\n"
+                "  -c --cleanup-db             Clean up the udev database\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ static int uinfo(struct udev *udev, int argc, char *argv[]) {
+diff --git a/src/udev/udevadm-monitor.c b/src/udev/udevadm-monitor.c
+index 15ded09..b58dd08 100644
+--- a/src/udev/udevadm-monitor.c
++++ b/src/udev/udevadm-monitor.c
+@@ -73,7 +73,7 @@ static void help(void) {
+                "  -u --udev                                Print udev events\n"
+                "  -s --subsystem-match=SUBSYSTEM[/DEVTYPE] Filter events by subsystem\n"
+                "  -t --tag-match=TAG                       Filter events by tag\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ static int adm_monitor(struct udev *udev, int argc, char *argv[]) {
+diff --git a/src/udev/udevadm-settle.c b/src/udev/udevadm-settle.c
+index 33597bc..b36a504 100644
+--- a/src/udev/udevadm-settle.c
++++ b/src/udev/udevadm-settle.c
+@@ -43,7 +43,7 @@ static void help(void) {
+                "     --version              Show package version\n"
+                "  -t --timeout=SECONDS      Maximum time to wait for events\n"
+                "  -E --exit-if-exists=FILE  Stop waiting if file exists\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ static int adm_settle(struct udev *udev, int argc, char *argv[]) {
+diff --git a/src/udev/udevadm-test-builtin.c b/src/udev/udevadm-test-builtin.c
+index baaeca9..50ed812 100644
+--- a/src/udev/udevadm-test-builtin.c
++++ b/src/udev/udevadm-test-builtin.c
+@@ -39,7 +39,7 @@ static void help(struct udev *udev) {
+                "  -h --help     Print this message\n"
+                "     --version  Print version of the program\n\n"
+                "Commands:\n"
+-               , program_invocation_short_name);
++               , "parity");
+ 
+         udev_builtin_list(udev);
+ }
+diff --git a/src/udev/udevadm-test.c b/src/udev/udevadm-test.c
+index 47fd924..a855412 100644
+--- a/src/udev/udevadm-test.c
++++ b/src/udev/udevadm-test.c
+@@ -39,7 +39,7 @@ static void help(void) {
+                "     --version                         Show package version\n"
+                "  -a --action=ACTION                   Set action string\n"
+                "  -N --resolve-names=early|late|never  When to resolve names\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ static int adm_test(struct udev *udev, int argc, char *argv[]) {
+diff --git a/src/udev/udevadm-trigger.c b/src/udev/udevadm-trigger.c
+index 4dc756a..67787d3 100644
+--- a/src/udev/udevadm-trigger.c
++++ b/src/udev/udevadm-trigger.c
+@@ -92,7 +92,7 @@ static void help(void) {
+                "  -y --sysname-match=NAME           Trigger devices with this /sys path\n"
+                "     --name-match=NAME              Trigger devices with this /dev name\n"
+                "  -b --parent-match=NAME            Trigger devices with that parent device\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ static int adm_trigger(struct udev *udev, int argc, char *argv[]) {
+diff --git a/src/udev/udevadm.c b/src/udev/udevadm.c
+index 3e57cf6..b03dfaa 100644
+--- a/src/udev/udevadm.c
++++ b/src/udev/udevadm.c
+@@ -62,7 +62,7 @@ static int adm_help(struct udev *udev, int argc, char *argv[]) {
+         printf("%s [--help] [--version] [--debug] COMMAND [COMMAND OPTIONS]\n\n"
+                "Send control commands or test the device manager.\n\n"
+                "Commands:\n"
+-               , program_invocation_short_name);
++               , "parity");
+ 
+         for (i = 0; i < ELEMENTSOF(udevadm_cmds); i++)
+                 if (udevadm_cmds[i]->help != NULL)
+@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
+                                 goto out;
+                         }
+ 
+-        fprintf(stderr, "%s: missing or unknown command\n", program_invocation_short_name);
++        fprintf(stderr, "%s: missing or unknown command\n", "parity");
+         rc = 2;
+ out:
+         mac_selinux_finish();
+diff --git a/src/udev/udevd.c b/src/udev/udevd.c
+index cf826c6..4eec0af 100644
+--- a/src/udev/udevd.c
++++ b/src/udev/udevd.c
+@@ -1041,7 +1041,7 @@ static void help(void) {
+                "  -t --event-timeout=SECONDS  Seconds to wait before terminating an event\n"
+                "  -N --resolve-names=early|late|never\n"
+                "                              When to resolve users and groups\n"
+-               , program_invocation_short_name);
++               , "parity");
+ }
+ 
+ static int parse_argv(int argc, char *argv[]) {
+diff --git a/src/v4l_id/v4l_id.c b/src/v4l_id/v4l_id.c
+index 1dce0d5..f65badf 100644
+--- a/src/v4l_id/v4l_id.c
++++ b/src/v4l_id/v4l_id.c
+@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
+                         printf("%s [-h,--help] <device file>\n\n"
+                                "Video4Linux device identification.\n\n"
+                                "  -h  Print this message\n"
+-                               , program_invocation_short_name);
++                               , "parity");
+                         return 0;
+                 case '?':
+                         return -EINVAL;
+diff --git a/src/shared/path-util.c b/src/shared/path-util.c
+index 0744563..7151356 100644
+--- a/src/shared/path-util.c
++++ b/src/shared/path-util.c
+@@ -109,7 +109,7 @@ char *path_make_absolute_cwd(const char *p) {
+         if (path_is_absolute(p))
+                 return strdup(p);
+ 
+-        cwd = get_current_dir_name();
++        cwd = getcwd(malloc(128), 128);
+         if (!cwd)
+                 return NULL;
+ 

--- a/ethcore/wasm/Cargo.toml
+++ b/ethcore/wasm/Cargo.toml
@@ -12,4 +12,4 @@ libc = "0.2"
 pwasm-utils = "0.1"
 vm = { path = "../vm" }
 ethcore-logger = { path = "../../logger" }
-wasmi = { version = "0.1", features = ["opt-in-32bit"] }
+wasmi = { version = "0.1.2", features = ["opt-in-32bit"] }

--- a/parity/url.rs
+++ b/parity/url.rs
@@ -57,3 +57,10 @@ pub fn open(url: &str) {
 	use std;
 	let _ = std::process::Command::new("xdg-open").arg(url).spawn();
 }
+
+#[cfg(target_os="android")]
+pub fn open(_url: &str) {
+	// TODO: While it is generally always bad to leave a function implemented, there is not much
+	//		 more we can do here. This function will eventually be removed when we compile Parity
+	//		 as a library and not as a full binary.
+}

--- a/util/network-devp2p/src/ip_utils.rs
+++ b/util/network-devp2p/src/ip_utils.rs
@@ -210,7 +210,7 @@ impl SocketAddrExt for IpAddr {
 	}
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "android")))]
 mod getinterfaces {
 	use std::{mem, io, ptr};
 	use libc::{AF_INET, AF_INET6};
@@ -280,12 +280,12 @@ mod getinterfaces {
 	}
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "android")))]
 fn get_if_addrs() -> io::Result<Vec<IpAddr>> {
 	getinterfaces::get_all()
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "android"))]
 fn get_if_addrs() -> io::Result<Vec<IpAddr>> {
 	Ok(Vec::new())
 }


### PR DESCRIPTION
Close #7954 

## About the PR

This PR does some tweaks to the code for it to compile for Android, and adds a Dockerfile that sets up the environment for building the Parity client for Android.

This PR is not totally final, because it replaces `ring` with my local fork while waiting for [this PR](https://github.com/briansmith/ring/pull/633) to be merged. Unfortunately the PR is probably controversial, so I'm not sure what is going to happen there.

Also I don't think I'm putting the `Dockerfile` (and the files that come with it) in the right repository. Let me know where I should put it instead.

## About the changes

The minimum Android version required to run Parity compiled with this PR is version 8.0, which is very recent. It should be possible to go down to version 7.0 or even 5.1 by applying manual patches to the C code, but applying patches is obviously not a great thing to do.

If you want to run the compiled client on an actual hardware device, you have to pass `--base-path=/data/local/tmp --no-ipc`. Android doesn't support IPC, and has very few writable directories.
The plan in the future is that Parity should be used as a library by various Android apps, and therefore the path where the data needs to be written will have to be provided by the app.
