### PR TITLE
removed redundant Box from patricia-trie Result

### DIFF
--- a/util/patricia_trie/src/lib.rs
+++ b/util/patricia_trie/src/lib.rs
@@ -89,7 +89,7 @@ impl error::Error for TrieError {
 }
 
 /// Trie result type. Boxed to avoid copying around extra space for `H256`s on successful queries.
-pub type Result<T> = ::std::result::Result<T, Box<TrieError>>;
+pub type Result<T> = ::std::result::Result<T, TrieError>;
 
 /// Trie-Item type.
 pub type TrieItem<'a> = Result<(Vec<u8>, DBValue)>;

--- a/util/patricia_trie/src/lookup.rs
+++ b/util/patricia_trie/src/lookup.rs
@@ -44,10 +44,10 @@ impl<'a, Q: Query> Lookup<'a, Q> {
 		for depth in 0.. {
 			let node_data = match self.db.get(&hash) {
 				Some(value) => value,
-				None => return Err(Box::new(match depth {
+				None => return Err(match depth {
 					0 => TrieError::InvalidStateRoot(hash),
 					_ => TrieError::IncompleteDatabase(hash),
-				})),
+				}),
 			};
 
 			self.query.record(&hash, &node_data, depth);

--- a/util/patricia_trie/src/triedb.rs
+++ b/util/patricia_trie/src/triedb.rs
@@ -62,7 +62,7 @@ impl<'db> TrieDB<'db> {
 	/// Returns an error if `root` does not exist
 	pub fn new(db: &'db HashDB, root: &'db H256) -> super::Result<Self> {
 		if !db.contains(root) {
-			Err(Box::new(TrieError::InvalidStateRoot(*root)))
+			Err(TrieError::InvalidStateRoot(*root))
 		} else {
 			Ok(TrieDB {
 				db: db,
@@ -79,7 +79,7 @@ impl<'db> TrieDB<'db> {
 
 	/// Get the data of the root node.
 	fn root_data(&self) -> super::Result<DBValue> {
-		self.db.get(self.root).ok_or_else(|| Box::new(TrieError::InvalidStateRoot(*self.root)))
+		self.db.get(self.root).ok_or_else(|| TrieError::InvalidStateRoot(*self.root))
 	}
 
 	/// Indentation helper for `format_all`.
@@ -138,7 +138,7 @@ impl<'db> TrieDB<'db> {
 		match r.is_data() && r.size() == 32 {
 			true => {
 				let key = r.as_val::<H256>();
-				self.db.get(&key).ok_or_else(|| Box::new(TrieError::IncompleteDatabase(key)))
+				self.db.get(&key).ok_or_else(|| TrieError::IncompleteDatabase(key))
 			}
 			false => Ok(DBValue::from_slice(node))
 		}

--- a/util/patricia_trie/src/triedbmut.rs
+++ b/util/patricia_trie/src/triedbmut.rs
@@ -317,7 +317,7 @@ impl<'a> TrieDBMut<'a> {
 	/// Returns an error if `root` does not exist.
 	pub fn from_existing(db: &'a mut HashDB, root: &'a mut H256) -> super::Result<Self> {
 		if !db.contains(root) {
-			return Err(Box::new(TrieError::InvalidStateRoot(*root)));
+			return Err(TrieError::InvalidStateRoot(*root));
 		}
 
 		let root_handle = NodeHandle::Hash(*root);
@@ -342,7 +342,7 @@ impl<'a> TrieDBMut<'a> {
 
 	// cache a node by hash
 	fn cache(&mut self, hash: H256) -> super::Result<StorageHandle> {
-		let node_rlp = self.db.get(&hash).ok_or_else(|| Box::new(TrieError::IncompleteDatabase(hash)))?;
+		let node_rlp = self.db.get(&hash).ok_or_else(|| TrieError::IncompleteDatabase(hash))?;
 		let node = Node::from_rlp(&node_rlp, &*self.db, &mut self.storage);
 		Ok(self.storage.alloc(Stored::Cached(node, hash)))
 	}


### PR DESCRIPTION
`patricia_trie::Error` has always 32 bytes. There is no point in boxing it, cause `patricia_trie::Result`  value is almost always bigger