### PR TITLE
Protobus generator script

### DIFF
--- a/scripts/protobus/keys.proto
+++ b/scripts/protobus/keys.proto
@@ -1,0 +1,15 @@
+enum KeyType {
+  RSA = 0;
+  Ed25519 = 1;
+  Secp256k1 = 2;
+}
+
+message PublicKey {
+  required KeyType Type = 1;
+  required bytes Data = 2;
+}
+
+message PrivateKey {
+  required KeyType Type = 1;
+  required bytes Data = 2;
+}

--- a/scripts/protobus/regen_structs_proto.sh
+++ b/scripts/protobus/regen_structs_proto.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# This script regenerates the `src/structs_proto.rs` and `src/keys_proto.rs` files from
+# `structs.proto` and `keys.proto`.
+
+sudo docker run --rm -v `pwd`:/usr/code:z -w /usr/code rust /bin/bash -c " \
+    apt-get update; \
+    apt-get install -y protobuf-compiler; \
+    cargo install protobuf; \
+    mkdir -p src; \
+    protoc --rust_out ./src structs.proto; \
+    protoc --rust_out ./src keys.proto; \
+    chown -R 1000:1000 src"

--- a/scripts/protobus/structs.proto
+++ b/scripts/protobus/structs.proto
@@ -1,0 +1,14 @@
+package spipe.pb;
+
+message Propose {
+	optional bytes rand = 1;
+	optional bytes pubkey = 2;
+	optional string exchanges = 3;
+	optional string ciphers = 4;
+	optional string hashes = 5;
+}
+
+message Exchange {
+	optional bytes epubkey = 1;
+	optional bytes signature = 2;
+}


### PR DESCRIPTION
Attempt to close [#7027](https://github.com/paritytech/parity/issues/7027) it's more or less a copy-paste from [rust-libp2p](https://github.com/libp2p/rust-libp2p)

I couldn't find ```key.proto``` and ```structs.proto``` so I copied them too!

Note, that the rust files are generated in ```scripts/protobus/src``` and should probably be generated at some other place but where I have no idea!