### PR TITLE
[ethkey] Unify debug/display for Address/Public/Secret

### DIFF
--- a/ethkey/cli/src/main.rs
+++ b/ethkey/cli/src/main.rs
@@ -31,7 +31,7 @@ use std::{env, fmt, process, io, sync};
 
 use docopt::Docopt;
 use ethkey::{KeyPair, Random, Brain, BrainPrefix, Prefix, Error as EthkeyError, Generator, sign, verify_public, verify_address, brain_recover};
-use rustc_hex::{ToHex, FromHex, FromHexError};
+use rustc_hex::{FromHex, FromHexError};
 
 pub const USAGE: &'static str = r#"
 Ethereum keys generator.
@@ -180,7 +180,7 @@ fn display(result: (KeyPair, Option<String>), mode: DisplayMode) -> String {
 			Some(extra_data) => format!("{}\n{}", extra_data, keypair),
 			None => format!("{}", keypair)
 		},
-		DisplayMode::Secret => format!("{}", keypair.secret().to_hex()),
+		DisplayMode::Secret => format!("{:?}", keypair.secret()),
 		DisplayMode::Public => format!("{:?}", keypair.public()),
 		DisplayMode::Address => format!("{:?}", keypair.address()),
 	}

--- a/ethkey/src/secret.rs
+++ b/ethkey/src/secret.rs
@@ -22,7 +22,7 @@ use secp256k1::key;
 use ethereum_types::H256;
 use {Error, SECP256K1};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Secret {
 	inner: H256,
 }
@@ -30,6 +30,12 @@ pub struct Secret {
 impl ToHex for Secret {
 	fn to_hex(&self) -> String {
 		self.inner.to_hex()
+	}
+}
+
+impl fmt::Debug for Secret {
+	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+		write!(fmt, "{:?}", self.inner)
 	}
 }
 
@@ -168,7 +174,7 @@ impl Secret {
 		if self.is_zero() {
 			return Ok(());
 		}
-		
+
 		match pow {
 			0 => *self = key::ONE_KEY.into(),
 			1 => (),

--- a/ethkey/src/secret.rs
+++ b/ethkey/src/secret.rs
@@ -22,7 +22,7 @@ use secp256k1::key;
 use ethereum_types::H256;
 use {Error, SECP256K1};
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Secret {
 	inner: H256,
 }
@@ -33,7 +33,7 @@ impl ToHex for Secret {
 	}
 }
 
-impl fmt::Debug for Secret {
+impl fmt::Display for Secret {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		write!(fmt, "Secret: 0x{:x}{:x}..{:x}{:x}", self.inner[0], self.inner[1], self.inner[30], self.inner[31])
 	}


### PR DESCRIPTION
This is closes [#6206](https://github.com/paritytech/parity/issues/6206) by using the following formats:
* Debug equal to [derive(Debug)]
* Display in form of c4c5…fcf4

