### PR TITLE
Honor --max-peers if --min-peers is not specified

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -397,11 +397,11 @@ usage! {
 			"--port=[PORT]",
 			"Override the port on which the node should listen.",
 
-			ARG arg_min_peers: (u16) = 25u16, or |c: &Config| c.network.as_ref()?.min_peers.clone(),
+			ARG arg_min_peers: (Option<u16>) = None, or |c: &Config| c.network.as_ref()?.min_peers.clone(),
 			"--min-peers=[NUM]",
 			"Try to maintain at least NUM peers.",
 
-			ARG arg_max_peers: (u16) = 50u16, or |c: &Config| c.network.as_ref()?.max_peers.clone(),
+			ARG arg_max_peers: (Option<u16>) = None, or |c: &Config| c.network.as_ref()?.max_peers.clone(),
 			"--max-peers=[NUM]",
 			"Allow up to NUM peers.",
 
@@ -1482,8 +1482,8 @@ mod tests {
 			// -- Networking Options
 			flag_no_warp: false,
 			arg_port: 30303u16,
-			arg_min_peers: 25u16,
-			arg_max_peers: 50u16,
+			arg_min_peers: Some(25u16),
+			arg_max_peers: Some(50u16),
 			arg_max_pending_peers: 64u16,
 			arg_snapshot_peers: 0u16,
 			arg_allow_ips: "all".into(),

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -1868,4 +1868,18 @@ mod tests {
 			stratum: None,
 		});
 	}
+
+	#[test]
+	fn should_not_accept_min_peers_bigger_than_max_peers() {
+		match Args::parse(&["parity", "--max-peers=39", "--min-peers=40"]) {
+			Err(ArgsError::PeerConfiguration) => (),
+			_ => assert_eq!(false, true),
+		}
+	}
+
+	#[test]
+	fn should_accept_max_peers_equal_or_bigger_than_min_peers() {
+		Args::parse(&["parity", "--max-peers=40", "--min-peers=40"]).unwrap();
+		Args::parse(&["parity", "--max-peers=100", "--min-peers=40"]).unwrap();
+	}
 }

--- a/parity/cli/usage.rs
+++ b/parity/cli/usage.rs
@@ -161,6 +161,7 @@ macro_rules! usage {
 			Clap(ClapError),
 			Decode(toml::de::Error),
 			Config(String, io::Error),
+			PeerConfiguration,
 		}
 
 		impl ArgsError {
@@ -177,6 +178,10 @@ macro_rules! usage {
 						println_stderr!("{}", e);
 						process::exit(2)
 					},
+					ArgsError::PeerConfiguration => {
+						println_stderr!("You have supplied `min_peers` > `max_peers`");
+						process::exit(2)
+					}
 				}
 			}
 		}
@@ -312,9 +317,16 @@ macro_rules! usage {
 			pub fn parse<S: AsRef<str>>(command: &[S]) -> Result<Self, ArgsError> {
 				let raw_args = RawArgs::parse(command)?;
 
+				// Invalid configuration pattern `mix_peers` > `max_peers`
+				if let (Some(max_peers), Some(min_peers)) = (raw_args.arg_max_peers, raw_args.arg_min_peers) {
+					if min_peers > max_peers {
+						return Err(ArgsError::PeerConfiguration)
+					}
+				} 
+
 				// Skip loading config file if no_config flag is specified
-				if raw_args.flag_no_config {
-					return Ok(raw_args.into_args(Config::default()));
+				else if raw_args.flag_no_config {
+					return Ok(raw_args.into_args(Config::default()))
 				}
 
 				let config_file = raw_args.arg_config.clone().unwrap_or_else(|| raw_args.clone().into_args(Config::default()).arg_config);

--- a/parity/cli/usage.rs
+++ b/parity/cli/usage.rs
@@ -317,16 +317,16 @@ macro_rules! usage {
 			pub fn parse<S: AsRef<str>>(command: &[S]) -> Result<Self, ArgsError> {
 				let raw_args = RawArgs::parse(command)?;
 
-				// Invalid configuration pattern `mix_peers` > `max_peers`
 				if let (Some(max_peers), Some(min_peers)) = (raw_args.arg_max_peers, raw_args.arg_min_peers) {
+					// Invalid configuration pattern `mix_peers` > `max_peers`
 					if min_peers > max_peers {
-						return Err(ArgsError::PeerConfiguration)
+						return Err(ArgsError::PeerConfiguration);
 					}
-				} 
+				}
 
 				// Skip loading config file if no_config flag is specified
-				else if raw_args.flag_no_config {
-					return Ok(raw_args.into_args(Config::default()))
+				if raw_args.flag_no_config {
+					return Ok(raw_args.into_args(Config::default()));
 				}
 
 				let config_file = raw_args.arg_config.clone().unwrap_or_else(|| raw_args.clone().into_args(Config::default()).arg_config);

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::cmp::{max, min};
 use std::time::Duration;
 use std::io::Read;
 use std::net::SocketAddr;
@@ -471,7 +472,7 @@ impl Configuration {
 
 	fn max_peers(&self) -> u32 {
 		self.args.arg_max_peers
-			.or(self.args.arg_min_peers)
+			.or(max(self.args.arg_min_peers, Some(DEFAULT_MAX_PEERS)))
 			.unwrap_or(DEFAULT_MAX_PEERS) as u32
 	}
 
@@ -484,7 +485,7 @@ impl Configuration {
 
 	fn min_peers(&self) -> u32 {
 		self.args.arg_min_peers
-			.or(self.args.arg_max_peers)
+			.or(min(self.args.arg_max_peers, Some(DEFAULT_MIN_PEERS)))
 			.unwrap_or(DEFAULT_MIN_PEERS) as u32
 	}
 

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -470,13 +470,9 @@ impl Configuration {
 	}
 
 	fn max_peers(&self) -> u32 {
-		match (self.args.arg_max_peers, self.args.arg_min_peers) {
-			// Only `min_peers` specified by the user then set `max_peers` to that value
-			(None, Some(min)) => min as u32,
-
-			// Both or none specified by the user and max ensured to be bigger than min
-			(_, _) => self.args.arg_max_peers.unwrap_or(DEFAULT_MAX_PEERS) as u32,
-		}
+		self.args.arg_max_peers
+			.or(self.args.arg_min_peers)
+			.unwrap_or(DEFAULT_MAX_PEERS) as u32
 	}
 
 	fn ip_filter(&self) -> Result<IpFilter, String> {
@@ -487,13 +483,9 @@ impl Configuration {
 	}
 
 	fn min_peers(&self) -> u32 {
-		match (self.args.arg_max_peers, self.args.arg_min_peers) {
-			// Only `max_peers` specified by the user then set `min_peers` to that value
-			(Some(max), None) => max as u32,
-
-			// Both or none specified by the user and max ensured to be bigger than min
-			(_, _) => self.args.arg_min_peers.unwrap_or(DEFAULT_MIN_PEERS) as u32,
-		}
+		self.args.arg_min_peers
+			.or(self.args.arg_max_peers)
+			.unwrap_or(DEFAULT_MIN_PEERS) as u32
 	}
 
 	fn max_pending_peers(&self) -> u32 {

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1953,12 +1953,25 @@ mod tests {
 	}
 
 	#[test]
-	fn should_respect_only_max_peers() {
+	fn should_respect_only_max_peers_and_default() {
+		let args = vec!["parity", "--max-peers=50"];
+		let conf = Configuration::parse(&args, None).unwrap();
+		match conf.into_command().unwrap().cmd {
+			Cmd::Run(c) => {
+				assert_eq!(c.net_conf.min_peers, 25);
+				assert_eq!(c.net_conf.max_peers, 50);
+			},
+			_ => panic!("Should be Cmd::Run"),
+		}
+	}
+
+	#[test]
+	fn should_respect_only_max_peers_less_than_default() {
 		let args = vec!["parity", "--max-peers=5"];
 		let conf = Configuration::parse(&args, None).unwrap();
 		match conf.into_command().unwrap().cmd {
 			Cmd::Run(c) => {
-				assert!(c.net_conf.min_peers <= 5);
+				assert_eq!(c.net_conf.min_peers, 5);
 				assert_eq!(c.net_conf.max_peers, 5);
 			},
 			_ => panic!("Should be Cmd::Run"),
@@ -1966,13 +1979,26 @@ mod tests {
 	}
 
 	#[test]
-	fn should_respect_only_min_peers() {
+	fn should_respect_only_min_peers_and_default() {
+		let args = vec!["parity", "--min-peers=5"];
+		let conf = Configuration::parse(&args, None).unwrap();
+		match conf.into_command().unwrap().cmd {
+			Cmd::Run(c) => {
+				assert_eq!(c.net_conf.min_peers, 5);
+				assert_eq!(c.net_conf.max_peers, 50);
+			},
+			_ => panic!("Should be Cmd::Run"),
+		}
+	}
+
+	#[test]
+	fn should_respect_only_min_peers_and_greater_than_default() {
 		let args = vec!["parity", "--min-peers=500"];
 		let conf = Configuration::parse(&args, None).unwrap();
 		match conf.into_command().unwrap().cmd {
 			Cmd::Run(c) => {
 				assert_eq!(c.net_conf.min_peers, 500);
-				assert!(c.net_conf.max_peers >= 500);
+				assert_eq!(c.net_conf.max_peers, 500);
 			},
 			_ => panic!("Should be Cmd::Run"),
 		}


### PR DESCRIPTION
Attempt to solve [#7576](https://github.com/paritytech/parity/issues/7576)

This PR changes the following:
- min and max in `cli/mod.rs` to `Option<u16>`
- none provided              => use defaults
- min-peers only              => max-peers = max(x, DEFAULT_MAX_PEERS)
- max-peers only             => min-peers = min(x, DEFAULT_MIN_PEERS)
- min-peers > max-peers => ERROR
- Added tests for this

I'm not sure if this is the right approach but seemed most straight-forward to me