### PR TITLE
Fix Cargo.lock not parsable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,7 +2678,7 @@ version = "0.0.1"
 dependencies = [
  "ethabi 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-contract 5.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi-derive 5.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi-derive 5.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.0",
 ]


### PR DESCRIPTION
`master` doesn't build for me because `Cargo.lock` isn't parsable.