### PR TITLE
Replace std::env::temp_dir with tempdir in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "primal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -942,6 +943,7 @@ dependencies = [
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -1763,6 +1765,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ethash/Cargo.toml
+++ b/ethash/Cargo.toml
@@ -14,5 +14,8 @@ crunchy = "0.1.0"
 memmap = "0.6"
 either = "1.0.0"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [features]
 benches = []

--- a/ethash/src/compute.rs
+++ b/ethash/src/compute.rs
@@ -315,6 +315,7 @@ fn calculate_dag_item(node_index: u32, cache: &[Node]) -> Node {
 mod test {
 	use super::*;
 	use std::fs;
+	use tempdir::TempDir;
 
 	#[test]
 	fn test_get_cache_size() {
@@ -387,7 +388,7 @@ mod test {
 		];
 		let nonce = 0xd7b3ac70a301a249;
 		// difficulty = 0x085657254bd9u64;
-		let light = NodeCacheBuilder::new(None).light(&::std::env::temp_dir(), 486382);
+		let light = NodeCacheBuilder::new(None).light(TempDir::new("").unwrap().path(), 486382);
 		let result = light_compute(&light, &hash, nonce);
 		assert_eq!(result.mix_hash[..], mix_hash[..]);
 		assert_eq!(result.value[..], boundary[..]);
@@ -395,18 +396,18 @@ mod test {
 
 	#[test]
 	fn test_drop_old_data() {
-		let path = ::std::env::temp_dir();
+		let tempdir = TempDir::new("").unwrap();
 		let builder = NodeCacheBuilder::new(None);
-		let first = builder.light(&path, 0).to_file().unwrap().to_owned();
+		let first = builder.light(tempdir.path(), 0).to_file().unwrap().to_owned();
 
-		let second = builder.light(&path, ETHASH_EPOCH_LENGTH).to_file().unwrap().to_owned();
+		let second = builder.light(tempdir.path(), ETHASH_EPOCH_LENGTH).to_file().unwrap().to_owned();
 		assert!(fs::metadata(&first).is_ok());
 
-		let _ = builder.light(&path, ETHASH_EPOCH_LENGTH * 2).to_file();
+		let _ = builder.light(tempdir.path(), ETHASH_EPOCH_LENGTH * 2).to_file();
 		assert!(fs::metadata(&first).is_err());
 		assert!(fs::metadata(&second).is_ok());
 
-		let _ = builder.light(&path, ETHASH_EPOCH_LENGTH * 3).to_file();
+		let _ = builder.light(tempdir.path(), ETHASH_EPOCH_LENGTH * 3).to_file();
 		assert!(fs::metadata(&second).is_err());
 	}
 }

--- a/ethash/src/compute.rs
+++ b/ethash/src/compute.rs
@@ -387,8 +387,10 @@ mod test {
 			0xe9, 0x7e, 0x53, 0x84,
 		];
 		let nonce = 0xd7b3ac70a301a249;
+
+		let tempdir = TempDir::new("").unwrap();
 		// difficulty = 0x085657254bd9u64;
-		let light = NodeCacheBuilder::new(None).light(TempDir::new("").unwrap().path(), 486382);
+		let light = NodeCacheBuilder::new(None).light(tempdir.path(), 486382);
 		let result = light_compute(&light, &hash, nonce);
 		assert_eq!(result.mix_hash[..], mix_hash[..]);
 		assert_eq!(result.value[..], boundary[..]);

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -26,6 +26,9 @@ extern crate crunchy;
 #[macro_use]
 extern crate log;
 
+#[cfg(test)]
+extern crate tempdir;
+
 mod compute;
 mod seed_compute;
 mod cache;
@@ -135,7 +138,9 @@ impl EthashManager {
 
 #[test]
 fn test_lru() {
-	let ethash = EthashManager::new(&::std::env::temp_dir(), None);
+	use tempdir::TempDir;
+
+	let ethash = EthashManager::new(TempDir::new("").unwrap().path(), None);
 	let hash = [0u8; 32];
 	ethash.compute_light(1, &hash, 1);
 	ethash.compute_light(50000, &hash, 1);

--- a/ethash/src/lib.rs
+++ b/ethash/src/lib.rs
@@ -140,7 +140,8 @@ impl EthashManager {
 fn test_lru() {
 	use tempdir::TempDir;
 
-	let ethash = EthashManager::new(TempDir::new("").unwrap().path(), None);
+	let tempdir = TempDir::new("").unwrap();
+	let ethash = EthashManager::new(tempdir.path(), None);
 	let hash = [0u8; 32];
 	ethash.compute_light(1, &hash, 1);
 	ethash.compute_light(50000, &hash, 1);

--- a/ethcore/node_filter/Cargo.toml
+++ b/ethcore/node_filter/Cargo.toml
@@ -21,3 +21,4 @@ lru-cache = "0.1"
 [dev-dependencies]
 kvdb-memorydb = { path = "../../util/kvdb-memorydb" }
 ethcore-io = { path = "../../util/io" }
+tempdir = "0.3"

--- a/ethcore/node_filter/src/lib.rs
+++ b/ethcore/node_filter/src/lib.rs
@@ -135,7 +135,8 @@ mod test {
 	fn node_filter() {
 		let contract_addr = Address::from_str("0000000000000000000000000000000000000005").unwrap();
 		let data = include_bytes!("../res/node_filter.json");
-		let spec = Spec::load(&TempDir::new("").unwrap().path(), &data[..]).unwrap();
+		let tempdir = TempDir::new("").unwrap();
+		let spec = Spec::load(&tempdir.path(), &data[..]).unwrap();
 		let client_db = Arc::new(::kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS.unwrap_or(0)));
 
 		let client = Client::new(

--- a/ethcore/node_filter/src/lib.rs
+++ b/ethcore/node_filter/src/lib.rs
@@ -32,6 +32,8 @@ extern crate ethabi_contract;
 extern crate ethcore_io as io;
 #[cfg(test)]
 extern crate kvdb_memorydb;
+#[cfg(test)]
+extern crate tempdir;
 #[macro_use]
 extern crate log;
 
@@ -126,13 +128,14 @@ mod test {
 	use network::{ConnectionDirection, ConnectionFilter, NodeId};
 	use io::IoChannel;
 	use super::NodeFilter;
+	use tempdir::TempDir;
 
 	/// Contract code: https://gist.github.com/arkpar/467dbcc73cbb85b0997a7a10ffa0695f
 	#[test]
 	fn node_filter() {
 		let contract_addr = Address::from_str("0000000000000000000000000000000000000005").unwrap();
 		let data = include_bytes!("../res/node_filter.json");
-		let spec = Spec::load(&::std::env::temp_dir(), &data[..]).unwrap();
+		let spec = Spec::load(&TempDir::new("").unwrap().path(), &data[..]).unwrap();
 		let client_db = Arc::new(::kvdb_memorydb::create(::ethcore::db::NUM_COLUMNS.unwrap_or(0)));
 
 		let client = Client::new(

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -204,11 +204,12 @@ mod tests {
 	use header::Header;
 	use spec::Spec;
 	use engines::Seal;
+	use tempdir::TempDir;
 
 	/// Create a new test chain spec with `BasicAuthority` consensus engine.
 	fn new_test_authority() -> Spec {
 		let bytes: &[u8] = include_bytes!("../../res/basic_authority.json");
-		Spec::load(&::std::env::temp_dir(), bytes).expect("invalid chain spec")
+		Spec::load(&TempDir::new("").unwrap().path(), bytes).expect("invalid chain spec")
 	}
 
 	#[test]

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -209,7 +209,8 @@ mod tests {
 	/// Create a new test chain spec with `BasicAuthority` consensus engine.
 	fn new_test_authority() -> Spec {
 		let bytes: &[u8] = include_bytes!("../../res/basic_authority.json");
-		Spec::load(&TempDir::new("").unwrap().path(), bytes).expect("invalid chain spec")
+		let tempdir = TempDir::new("").unwrap();
+		Spec::load(&tempdir.path(), bytes).expect("invalid chain spec")
 	}
 
 	#[test]

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -498,7 +498,8 @@ mod tests {
 	use tempdir::TempDir;
 
 	fn test_spec() -> Spec {
-		new_morden(&TempDir::new("").unwrap().path())
+		let tempdir = TempDir::new("").unwrap();
+		new_morden(&tempdir.path())
 	}
 
 	fn get_default_ethash_params() -> EthashParams {
@@ -777,7 +778,8 @@ mod tests {
 	fn difficulty_frontier() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
+		let tempdir = TempDir::new("").unwrap();
+		let ethash = Ethash::new(tempdir.path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1000000);
@@ -795,7 +797,8 @@ mod tests {
 	fn difficulty_homestead() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
+		let tempdir = TempDir::new("").unwrap();
+		let ethash = Ethash::new(tempdir.path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1500000);
@@ -816,7 +819,8 @@ mod tests {
 			ecip1010_pause_transition: 3000000,
 			..get_default_ethash_params()
 		};
-		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
+		let tempdir = TempDir::new("").unwrap();
+		let ethash = Ethash::new(tempdir.path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(3500000);
@@ -850,7 +854,8 @@ mod tests {
 			ecip1010_continue_transition: 5000000,
 			..get_default_ethash_params()
 		};
-		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
+		let tempdir = TempDir::new("").unwrap();
+		let ethash = Ethash::new(tempdir.path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(5000102);
@@ -896,7 +901,8 @@ mod tests {
 	fn difficulty_max_timestamp() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
+		let tempdir = TempDir::new("").unwrap();
+		let ethash = Ethash::new(tempdir.path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1000000);
@@ -914,7 +920,8 @@ mod tests {
 	fn test_extra_info() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
+		let tempdir = TempDir::new("").unwrap();
+		let ethash = Ethash::new(tempdir.path(), ethparams, machine, None);
 		let mut header = Header::default();
 		header.set_seal(vec![rlp::encode(&H256::from("b251bd2e0283d0658f2cadfdc8ca619b5de94eca5742725e2e757dd13ed7503d")).into_vec(), rlp::encode(&H64::zero()).into_vec()]);
 		let info = ethash.extra_info(&header);

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -495,9 +495,10 @@ mod tests {
 	use super::super::{new_morden, new_mcip3_test, new_homestead_test_machine};
 	use super::{Ethash, EthashParams, ecip1017_eras_block_reward};
 	use rlp;
+	use tempdir::TempDir;
 
 	fn test_spec() -> Spec {
-		new_morden(&::std::env::temp_dir())
+		new_morden(&TempDir::new("").unwrap().path())
 	}
 
 	fn get_default_ethash_params() -> EthashParams {
@@ -776,7 +777,7 @@ mod tests {
 	fn difficulty_frontier() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), ethparams, machine, None);
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1000000);
@@ -794,7 +795,7 @@ mod tests {
 	fn difficulty_homestead() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), ethparams, machine, None);
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1500000);
@@ -815,7 +816,7 @@ mod tests {
 			ecip1010_pause_transition: 3000000,
 			..get_default_ethash_params()
 		};
-		let ethash = Ethash::new(&::std::env::temp_dir(), ethparams, machine, None);
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(3500000);
@@ -849,7 +850,7 @@ mod tests {
 			ecip1010_continue_transition: 5000000,
 			..get_default_ethash_params()
 		};
-		let ethash = Ethash::new(&::std::env::temp_dir(), ethparams, machine, None);
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(5000102);
@@ -895,7 +896,7 @@ mod tests {
 	fn difficulty_max_timestamp() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), ethparams, machine, None);
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
 
 		let mut parent_header = Header::default();
 		parent_header.set_number(1000000);
@@ -913,7 +914,7 @@ mod tests {
 	fn test_extra_info() {
 		let machine = new_homestead_test_machine();
 		let ethparams = get_default_ethash_params();
-		let ethash = Ethash::new(&::std::env::temp_dir(), ethparams, machine, None);
+		let ethash = Ethash::new(&TempDir::new("").unwrap().path(), ethparams, machine, None);
 		let mut header = Header::default();
 		header.set_seal(vec![rlp::encode(&H256::from("b251bd2e0283d0658f2cadfdc8ca619b5de94eca5742725e2e757dd13ed7503d")).into_vec(), rlp::encode(&H64::zero()).into_vec()]);
 		let info = ethash.extra_info(&header);

--- a/ethcore/src/json_tests/difficulty.rs
+++ b/ethcore/src/json_tests/difficulty.rs
@@ -62,7 +62,8 @@ mod difficulty_test_foundation {
 	use tempdir::TempDir;
 
 	fn do_json_test(json_data: &[u8]) -> Vec<String> {
-		json_difficulty_test(json_data, ::ethereum::new_foundation(&TempDir::new("").unwrap().path()))
+		let tempdir = TempDir::new("").unwrap();
+		json_difficulty_test(json_data, ::ethereum::new_foundation(&tempdir.path()))
 	}
 
 	declare_test!{DifficultyTests_difficultyMainNetwork, "BasicTests/difficultyMainNetwork.json"}

--- a/ethcore/src/json_tests/difficulty.rs
+++ b/ethcore/src/json_tests/difficulty.rs
@@ -59,9 +59,10 @@ mod difficulty_test_byzantium {
 
 mod difficulty_test_foundation {
 	use super::json_difficulty_test;
+	use tempdir::TempDir;
 
 	fn do_json_test(json_data: &[u8]) -> Vec<String> {
-		json_difficulty_test(json_data, ::ethereum::new_foundation(&::std::env::temp_dir()))
+		json_difficulty_test(json_data, ::ethereum::new_foundation(&TempDir::new("").unwrap().path()))
 	}
 
 	declare_test!{DifficultyTests_difficultyMainNetwork, "BasicTests/difficultyMainNetwork.json"}

--- a/ethcore/src/snapshot/tests/proof_of_authority.rs
+++ b/ethcore/src/snapshot/tests/proof_of_authority.rs
@@ -60,7 +60,8 @@ lazy_static! {
 /// `test_validator_set::ValidatorSet` provides a native wrapper for the ABi.
 fn spec_fixed_to_contract() -> Spec {
 	let data = include_bytes!("test_validator_contract.json");
-	Spec::load(&TempDir::new("").unwrap().path(), &data[..]).unwrap()
+	let tempdir = TempDir::new("").unwrap();
+	Spec::load(&tempdir.path(), &data[..]).unwrap()
 }
 
 // creates an account provider, filling it with accounts from all the given

--- a/ethcore/src/snapshot/tests/proof_of_authority.rs
+++ b/ethcore/src/snapshot/tests/proof_of_authority.rs
@@ -27,6 +27,7 @@ use snapshot::tests::helpers as snapshot_helpers;
 use spec::Spec;
 use tests::helpers;
 use transaction::{Transaction, Action, SignedTransaction};
+use tempdir::TempDir;
 
 use ethereum_types::Address;
 use kvdb_memorydb;
@@ -59,7 +60,7 @@ lazy_static! {
 /// `test_validator_set::ValidatorSet` provides a native wrapper for the ABi.
 fn spec_fixed_to_contract() -> Spec {
 	let data = include_bytes!("test_validator_contract.json");
-	Spec::load(&::std::env::temp_dir(), &data[..]).unwrap()
+	Spec::load(&TempDir::new("").unwrap().path(), &data[..]).unwrap()
 }
 
 // creates an account provider, filling it with accounts from all the given

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -832,11 +832,12 @@ mod tests {
 	use state::State;
 	use tests::helpers::get_temp_state_db;
 	use views::BlockView;
+	use tempdir::TempDir;
 
 	// https://github.com/paritytech/parity/issues/1840
 	#[test]
 	fn test_load_empty() {
-		assert!(Spec::load(&::std::env::temp_dir(), &[] as &[u8]).is_err());
+		assert!(Spec::load(&TempDir::new("").unwrap().path(), &[] as &[u8]).is_err());
 	}
 
 	#[test]

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -837,7 +837,8 @@ mod tests {
 	// https://github.com/paritytech/parity/issues/1840
 	#[test]
 	fn test_load_empty() {
-		assert!(Spec::load(&TempDir::new("").unwrap().path(), &[] as &[u8]).is_err());
+		let tempdir = TempDir::new("").unwrap();
+		assert!(Spec::load(&tempdir.path(), &[] as &[u8]).is_err());
 	}
 
 	#[test]

--- a/ethcore/src/tx_filter.rs
+++ b/ethcore/src/tx_filter.rs
@@ -118,6 +118,7 @@ mod test {
 	use ethkey::{Secret, KeyPair};
 	use super::TransactionFilter;
 	use transaction::{Transaction, Action};
+	use tempdir::TempDir;
 
 	/// Contract code: https://gist.github.com/arkpar/38a87cb50165b7e683585eec71acb05a
 	#[test]
@@ -168,7 +169,7 @@ mod test {
 		}
 		"#;
 
-		let spec = Spec::load(&::std::env::temp_dir(), spec_data.as_bytes()).unwrap();
+		let spec = Spec::load(&TempDir::new("").unwrap().path(), spec_data.as_bytes()).unwrap();
 		let client_db = Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)));
 
 		let client = Client::new(

--- a/ethcore/src/tx_filter.rs
+++ b/ethcore/src/tx_filter.rs
@@ -169,7 +169,8 @@ mod test {
 		}
 		"#;
 
-		let spec = Spec::load(&TempDir::new("").unwrap().path(), spec_data.as_bytes()).unwrap();
+		let tempdir = TempDir::new("").unwrap();
+		let spec = Spec::load(&tempdir.path(), spec_data.as_bytes()).unwrap();
 		let client_db = Arc::new(::kvdb_memorydb::create(::db::NUM_COLUMNS.unwrap_or(0)));
 
 		let client = Client::new(

--- a/evmbin/Cargo.toml
+++ b/evmbin/Cargo.toml
@@ -24,6 +24,7 @@ vm = { path = "../ethcore/vm" }
 
 [dev-dependencies]
 pretty_assertions = "0.1"
+tempdir = "0.3"
 
 [features]
 evm-debug = ["ethcore/evm-debug-tests"]

--- a/evmbin/src/info.rs
+++ b/evmbin/src/info.rs
@@ -175,6 +175,7 @@ pub mod tests {
 	use std::sync::Arc;
 	use rustc_hex::FromHex;
 	use super::*;
+	use tempdir::TempDir;
 
 	pub fn run_test<T, I, F>(
 		informant: I,
@@ -191,7 +192,7 @@ pub mod tests {
 		params.code = Some(Arc::new(code.from_hex().unwrap()));
 		params.gas = gas.into();
 
-		let spec = ::ethcore::ethereum::new_foundation(&::std::env::temp_dir());
+		let spec = ::ethcore::ethereum::new_foundation(&TempDir::new("").unwrap().path());
 		let result = run_action(&spec, params, informant);
 		match result {
 			Ok(Success { traces, .. }) => {

--- a/evmbin/src/info.rs
+++ b/evmbin/src/info.rs
@@ -192,7 +192,8 @@ pub mod tests {
 		params.code = Some(Arc::new(code.from_hex().unwrap()));
 		params.gas = gas.into();
 
-		let spec = ::ethcore::ethereum::new_foundation(&TempDir::new("").unwrap().path());
+		let tempdir = TempDir::new("").unwrap();
+		let spec = ::ethcore::ethereum::new_foundation(&tempdir.path());
 		let result = run_action(&spec, params, informant);
 		match result {
 			Ok(Success { traces, .. }) => {

--- a/evmbin/src/main.rs
+++ b/evmbin/src/main.rs
@@ -36,6 +36,9 @@ extern crate panic_hook;
 #[macro_use]
 extern crate pretty_assertions;
 
+#[cfg(test)]
+extern crate tempdir;
+
 use std::sync::Arc;
 use std::{fmt, fs};
 use std::path::PathBuf;


### PR DESCRIPTION
Attempt to close [#6147](https://github.com/paritytech/parity/issues/6147)

The remaining occurrences of `std::env::temp_dir()` are the following: 
```bash
$ git grep -n "::std::env::temp_dir"
ethcore/src/ethereum/mod.rs:36:         None => Spec::load(&::std::env::temp_dir(), b)
ethcore/src/ethereum/mod.rs:148:                let spec = new_morden(&::std::env::temp_dir());
ethcore/src/ethereum/mod.rs:163:                let morden = new_morden(&::std::env::temp_dir());
ethcore/src/ethereum/mod.rs:174:                let frontier = new_foundation(&::std::env::temp_dir());
ethcore/src/spec/spec.rs:416:                   &::std::env::temp_dir(),
evmbin/src/main.rs:243:                         spec::Spec::load(&::std::env::temp_dir(), file)?
evmbin/src/main.rs:246:                         ethcore::ethereum::new_foundation(&::std::env::temp_dir())
parity/account.rs:74:   let spec = spec.spec(&::std::env::temp_dir())?;
```