### PR TITLE
Disable link-dead-code in code coverage CI build

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -12,7 +12,7 @@
 ### Running coverage
 
 set -x
-RUSTFLAGS="-C link-dead-code" cargo test --all --exclude evmjit --no-run || exit $?
+cargo test --all --exclude evmjit --no-run || exit $?
 KCOV_TARGET="target/cov"
 KCOV_FLAGS="--verify"
 EXCLUDE="/usr/lib,/usr/include,$HOME/.cargo,$HOME/.multirust,rocksdb,secp256k1"


### PR DESCRIPTION
- https://gitlab.parity.io/parity/parity/-/jobs/81532
- https://gitlab.parity.io/parity/parity/-/jobs/81590

The code coverage build has been failing to compile `futures-timer` and it seems to be related to https://github.com/rust-lang/rust/issues/45629 (https://github.com/codecov/example-rust/pull/10). Let's see if this fixes the build.