### PR TITLE
rename DatabaseValueView::new to from_rlp

### DIFF
--- a/util/journaldb/src/earlymergedb.rs
+++ b/util/journaldb/src/earlymergedb.rs
@@ -266,13 +266,12 @@ impl EarlyMergeDB {
 			let mut era = decode::<u64>(&val);
 			latest_era = Some(era);
 			loop {
-				//let mut index = 0usize;
 				let mut db_key = DatabaseKey {
 					era,
 					index: 0usize,
 				};
 				while let Some(rlp_data) = db.get(col, &encode(&db_key)).expect("Low-level database error.") {
-					let inserts = DatabaseValueView::new(&rlp_data).inserts().expect("rlp read from db; qed");
+					let inserts = DatabaseValueView::from_rlp(&rlp_data).inserts().expect("rlp read from db; qed");
 					Self::replay_keys(&inserts, db, col, &mut refs);
 					db_key.index += 1;
 				};
@@ -440,7 +439,7 @@ impl JournalDB for EarlyMergeDB {
 			last = encode(&db_key);
 			self.backing.get(self.column, &last)
 		}? {
-			let view = DatabaseValueView::new(&rlp_data);
+			let view = DatabaseValueView::from_rlp(&rlp_data);
 			let inserts = view.inserts().expect("rlp read from db; qed");
 
 			if canon_id == &view.id().expect("rlp read from db; qed") {

--- a/util/journaldb/src/refcounteddb.rs
+++ b/util/journaldb/src/refcounteddb.rs
@@ -169,7 +169,7 @@ impl JournalDB for RefCountedDB {
 				&last
 			})?
 		} {
-			let view = DatabaseValueView::new(&rlp_data);
+			let view = DatabaseValueView::from_rlp(&rlp_data);
 			let our_id = view.id().expect("rlp read from db; qed");
 			let to_remove = if canon_id == &our_id {
 				view.deletes()

--- a/util/journaldb/src/util.rs
+++ b/util/journaldb/src/util.rs
@@ -38,7 +38,7 @@ pub struct DatabaseValueView<'a> {
 }
 
 impl<'a> DatabaseValueView<'a> {
-	pub fn new(data: &'a [u8]) -> Self {
+	pub fn from_rlp(data: &'a [u8]) -> Self {
 		DatabaseValueView {
 			rlp: UntrustedRlp::new(data),
 		}


### PR DESCRIPTION
Addresses feedback from @andresilva in #8047 after I merged in too soon before his review.

Just renaming new to from_rlp and removing a commented out line.