### PR TITLE
Handle rlp decoding Result in patricia trie

### DIFF
--- a/util/patricia_trie/src/lookup.rs
+++ b/util/patricia_trie/src/lookup.rs
@@ -18,7 +18,6 @@
 
 use hashdb::HashDB;
 use nibbleslice::NibbleSlice;
-use rlp::Rlp;
 use ethereum_types::H256;
 
 use super::{TrieError, Query};
@@ -82,9 +81,8 @@ impl<'a, Q: Query> Lookup<'a, Q> {
 				}
 
 				// check if new node data is inline or hash.
-				let r = Rlp::new(node_data);
-				if r.is_data() && r.size() == 32 {
-					hash = r.as_val();
+				if let Some(h) = Node::try_decode_hash(&node_data) {
+					hash = h;
 					break
 				}
 			}

--- a/util/patricia_trie/src/lookup.rs
+++ b/util/patricia_trie/src/lookup.rs
@@ -55,7 +55,7 @@ impl<'a, Q: Query> Lookup<'a, Q> {
 			// without incrementing the depth.
 			let mut node_data = &node_data[..];
 			loop {
-				match Node::decoded(node_data) {
+				match Node::decoded(node_data).expect("rlp read from db; qed") {
 					Node::Leaf(slice, value) => {
 						return Ok(match slice == key {
 							true => Some(self.query.decode(value)),

--- a/util/patricia_trie/src/node.rs
+++ b/util/patricia_trie/src/node.rs
@@ -40,9 +40,31 @@ pub enum Node<'a> {
 
 impl<'a> Node<'a> {
 	/// Decode the `node_rlp` and return the Node.
-	pub fn decoded(node_rlp: &'a [u8]) -> Self {
+	pub fn decoded(node_rlp: &'a [u8]) -> Result<Self, DecoderError> {
 		let r = UntrustedRlp::new(node_rlp);
-		Node::decode_rlp(&r).expect("Self encoded Rlp should be valid; qed")
+		match r.prototype()? {
+			// either leaf or extension - decode first item with NibbleSlice::???
+			// and use is_leaf return to figure out which.
+			// if leaf, second item is a value (is_data())
+			// if extension, second item is a node (either SHA3 to be looked up and
+			// fed back into this function or inline RLP which can be fed back into this function).
+			Prototype::List(2) => match NibbleSlice::from_encoded(r.at(0)?.data()?) {
+				(slice, true) => Ok(Node::Leaf(slice, r.at(1)?.data()?)),
+				(slice, false) => Ok(Node::Extension(slice, r.at(1)?.as_raw())),
+			},
+			// branch - first 16 are nodes, 17th is a value (or empty).
+			Prototype::List(17) => {
+				let mut nodes = [&[] as &[u8]; 16];
+				for i in 0..16 {
+					nodes[i] = r.at(i)?.as_raw();
+				}
+				Ok(Node::Branch(nodes, if r.at(16)?.is_empty() { None } else { Some(r.at(16)?.data()?) }))
+			},
+			// an empty branch index.
+			Prototype::Data(0) => Ok(Node::Empty),
+			// something went wrong.
+			_ => Err(DecoderError::Custom("Rlp is not valid."))
+		}
 	}
 
 	/// Encode the node into RLP.
@@ -88,33 +110,6 @@ impl<'a> Node<'a> {
 			Some(r.as_val().expect("Hash is the correct size of 32 bytes; qed"))
 		} else {
 			None
-		}
-	}
-
-	// TODO: this could implement Decodable? But need to figure out how to unify lifetimes
-	fn decode_rlp<'b>(r: &UntrustedRlp<'b>) -> Result<Node<'b>, DecoderError> {
-		match r.prototype()? {
-			// either leaf or extension - decode first item with NibbleSlice::???
-			// and use is_leaf return to figure out which.
-			// if leaf, second item is a value (is_data())
-			// if extension, second item is a node (either SHA3 to be looked up and
-			// fed back into this function or inline RLP which can be fed back into this function).
-			Prototype::List(2) => match NibbleSlice::from_encoded(r.at(0)?.data()?) {
-				(slice, true) => Ok(Node::Leaf(slice, r.at(1)?.data()?)),
-				(slice, false) => Ok(Node::Extension(slice, r.at(1)?.as_raw())),
-			},
-			// branch - first 16 are nodes, 17th is a value (or empty).
-			Prototype::List(17) => {
-				let mut nodes = [&[] as &[u8]; 16];
-				for i in 0..16 {
-					nodes[i] = r.at(i)?.as_raw();
-				}
-				Ok(Node::Branch(nodes, if r.at(16)?.is_empty() { None } else { Some(r.at(16)?.data()?) }))
-			},
-			// an empty branch index.
-			Prototype::Data(0) => Ok(Node::Empty),
-			// something went wrong.
-			_ => panic!("Rlp is not valid.")
 		}
 	}
 }

--- a/util/patricia_trie/src/node.rs
+++ b/util/patricia_trie/src/node.rs
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use ethereum_types::H256;
 use elastic_array::ElasticArray36;
 use nibbleslice::NibbleSlice;
 use nibblevec::NibbleVec;
 use bytes::*;
-use rlp::*;
+use rlp::{UntrustedRlp, RlpStream, Prototype, DecoderError};
 use hashdb::DBValue;
 
 /// Partial node key type.
@@ -40,30 +41,8 @@ pub enum Node<'a> {
 impl<'a> Node<'a> {
 	/// Decode the `node_rlp` and return the Node.
 	pub fn decoded(node_rlp: &'a [u8]) -> Self {
-		let r = Rlp::new(node_rlp);
-		match r.prototype() {
-			// either leaf or extension - decode first item with NibbleSlice::???
-			// and use is_leaf return to figure out which.
-			// if leaf, second item is a value (is_data())
-			// if extension, second item is a node (either SHA3 to be looked up and
-			// fed back into this function or inline RLP which can be fed back into this function).
-			Prototype::List(2) => match NibbleSlice::from_encoded(r.at(0).data()) {
-				(slice, true) => Node::Leaf(slice, r.at(1).data()),
-				(slice, false) => Node::Extension(slice, r.at(1).as_raw()),
-			},
-			// branch - first 16 are nodes, 17th is a value (or empty).
-			Prototype::List(17) => {
-				let mut nodes = [&[] as &[u8]; 16];
-				for i in 0..16 {
-					nodes[i] = r.at(i).as_raw();
-				}
-				Node::Branch(nodes, if r.at(16).is_empty() { None } else { Some(r.at(16).data()) })
-			},
-			// an empty branch index.
-			Prototype::Data(0) => Node::Empty,
-			// something went wrong.
-			_ => panic!("Rlp is not valid.")
-		}
+		let r = UntrustedRlp::new(node_rlp);
+		Node::decode_rlp(&r).expect("Self encoded Rlp should be valid; qed")
 	}
 
 	/// Encode the node into RLP.
@@ -100,6 +79,42 @@ impl<'a> Node<'a> {
 				stream.append_empty_data();
 				stream.out()
 			}
+		}
+	}
+
+	pub fn try_decode_hash(node_data: &[u8]) -> Option<H256> {
+		let r = UntrustedRlp::new(node_data);
+		if r.is_data() && r.size() == 32 {
+			Some(r.as_val().expect("Hash is the correct size of 32 bytes; qed"))
+		} else {
+			None
+		}
+	}
+
+	// TODO: this could implement Decodable? But need to figure out how to unify lifetimes
+	fn decode_rlp<'b>(r: &UntrustedRlp<'b>) -> Result<Node<'b>, DecoderError> {
+		match r.prototype()? {
+			// either leaf or extension - decode first item with NibbleSlice::???
+			// and use is_leaf return to figure out which.
+			// if leaf, second item is a value (is_data())
+			// if extension, second item is a node (either SHA3 to be looked up and
+			// fed back into this function or inline RLP which can be fed back into this function).
+			Prototype::List(2) => match NibbleSlice::from_encoded(r.at(0)?.data()?) {
+				(slice, true) => Ok(Node::Leaf(slice, r.at(1)?.data()?)),
+				(slice, false) => Ok(Node::Extension(slice, r.at(1)?.as_raw())),
+			},
+			// branch - first 16 are nodes, 17th is a value (or empty).
+			Prototype::List(17) => {
+				let mut nodes = [&[] as &[u8]; 16];
+				for i in 0..16 {
+					nodes[i] = r.at(i)?.as_raw();
+				}
+				Ok(Node::Branch(nodes, if r.at(16)?.is_empty() { None } else { Some(r.at(16)?.data()?) }))
+			},
+			// an empty branch index.
+			Prototype::Data(0) => Ok(Node::Empty),
+			// something went wrong.
+			_ => panic!("Rlp is not valid.")
 		}
 	}
 }

--- a/util/patricia_trie/src/triedbmut.rs
+++ b/util/patricia_trie/src/triedbmut.rs
@@ -88,13 +88,12 @@ enum Node {
 impl Node {
 	// load an inline node into memory or get the hash to do the lookup later.
 	fn inline_or_hash(node: &[u8], db: &HashDB, storage: &mut NodeStorage) -> NodeHandle {
-		let r = Rlp::new(node);
-		if r.is_data() && r.size() == 32 {
-			NodeHandle::Hash(r.as_val::<H256>())
-		} else {
-			let child = Node::from_rlp(node, db, storage);
-			NodeHandle::InMemory(storage.alloc(Stored::New(child)))
-		}
+		RlpNode::try_decode_hash(&node)
+			.map(NodeHandle::Hash)
+			.unwrap_or_else(|| {
+				let child = Node::from_rlp(node, db, storage);
+				NodeHandle::InMemory(storage.alloc(Stored::New(child)))
+			})
 	}
 
 	// decode a node from rlp without getting its children.

--- a/util/patricia_trie/src/triedbmut.rs
+++ b/util/patricia_trie/src/triedbmut.rs
@@ -98,7 +98,7 @@ impl Node {
 
 	// decode a node from rlp without getting its children.
 	fn from_rlp(rlp: &[u8], db: &HashDB, storage: &mut NodeStorage) -> Self {
-		match RlpNode::decoded(rlp) {
+		match RlpNode::decoded(rlp).expect("rlp read from db; qed") {
 			RlpNode::Empty => Node::Empty,
 			RlpNode::Leaf(k, v) => Node::Leaf(k.encoded(true), DBValue::from_slice(&v)),
 			RlpNode::Extension(key, cb) => {

--- a/util/patricia_trie/src/triedbmut.rs
+++ b/util/patricia_trie/src/triedbmut.rs
@@ -24,7 +24,7 @@ use super::node::NodeKey;
 use hashdb::HashDB;
 use bytes::ToPretty;
 use nibbleslice::NibbleSlice;
-use rlp::{Rlp, RlpStream};
+use rlp::{UntrustedRlp, RlpStream};
 use hashdb::DBValue;
 
 use std::collections::{HashSet, VecDeque};
@@ -107,7 +107,7 @@ impl Node {
 			RlpNode::Branch(ref children_rlp, val) => {
 				let mut child = |i| {
 					let raw = children_rlp[i];
-					let child_rlp = Rlp::new(raw);
+					let child_rlp = UntrustedRlp::new(raw);
 					if !child_rlp.is_empty() {
 						Some(Self::inline_or_hash(raw, db, storage))
 					} else {


### PR DESCRIPTION
Part of #8033, replacing existing usage of `Rlp` with `UntrustedRlp`. 

Unwraps the result of decoding a node's rlp, assuming valid rlp since it is a local read from the db.

Next step might be to introduce another case to TrieError for a DecoderError to avoid the unwraps. 

