### PR TITLE
Revert "ci: disable link-dead-code in coverage build (#8118)"

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -12,7 +12,7 @@
 ### Running coverage
 
 set -x
-cargo test --all --exclude evmjit --no-run || exit $?
+RUSTFLAGS="-C link-dead-code" cargo test --all --exclude evmjit --no-run || exit $?
 KCOV_TARGET="target/cov"
 KCOV_FLAGS="--verify"
 EXCLUDE="/usr/lib,/usr/include,$HOME/.cargo,$HOME/.multirust,rocksdb,secp256k1"


### PR DESCRIPTION
This reverts commit 4d1cb01da0ceff3b025c0f030da7aae86441206a.

https://github.com/paritytech/parity/pull/8118#event-1522171535

This will break the coverage build but at least it won't report an erroneous coverage percentage.