### PR TITLE
dapps-fetcher: calculate keccak in-flight while reading the response

### DIFF
--- a/dapps/src/apps/fetcher/installers.rs
+++ b/dapps/src/apps/fetcher/installers.rs
@@ -61,7 +61,9 @@ fn write_response_and_check_hash(
 
 	// Validate hash
 	if id == hash {
-		Ok((file, content_path))
+		// The writing above changed the file Read position, which we need later. So we just create a new file handle
+		// here.
+		Ok((fs::File::open(&content_path)?, content_path))
 	} else {
 		Err(ValidationError::HashMismatch {
 			expected: id,

--- a/dapps/src/apps/fetcher/installers.rs
+++ b/dapps/src/apps/fetcher/installers.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use ethereum_types::H256;
 use fetch;
 use futures_cpupool::CpuPool;
-use hash::keccak_buffer_and_write;
+use hash::keccak_pipe;
 use mime_guess::Mime;
 
 use apps::manifest::{MANIFEST_FILENAME, deserialize_manifest, serialize_manifest, Manifest};
@@ -55,7 +55,7 @@ fn write_response_and_check_hash(
 	// Now write the response
 	let mut file = io::BufWriter::new(fs::File::create(&content_path)?);
 	let mut reader = io::BufReader::new(fetch::BodyReader::new(response));
-	let hash = keccak_buffer_and_write(&mut reader, &mut file)?;
+	let hash = keccak_pipe(&mut reader, &mut file)?;
 	let mut file = file.into_inner()?;
 	file.flush()?;
 

--- a/dapps/src/apps/fetcher/installers.rs
+++ b/dapps/src/apps/fetcher/installers.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use ethereum_types::H256;
 use fetch;
 use futures_cpupool::CpuPool;
-use hash::keccak_buffer;
+use hash::keccak_buffer_and_write;
 use mime_guess::Mime;
 
 use apps::manifest::{MANIFEST_FILENAME, deserialize_manifest, serialize_manifest, Manifest};
@@ -55,15 +55,13 @@ fn write_response_and_check_hash(
 	// Now write the response
 	let mut file = io::BufWriter::new(fs::File::create(&content_path)?);
 	let mut reader = io::BufReader::new(fetch::BodyReader::new(response));
-	io::copy(&mut reader, &mut file)?;
+	let hash = keccak_buffer_and_write(&mut reader, &mut file)?;
+	let mut file = file.into_inner()?;
 	file.flush()?;
 
 	// Validate hash
-	// TODO [ToDr] calculate keccak in-flight while reading the response
-	let mut file = io::BufReader::new(fs::File::open(&content_path)?);
-	let hash = keccak_buffer(&mut file)?;
 	if id == hash {
-		Ok((file.into_inner(), content_path))
+		Ok((file, content_path))
 	} else {
 		Err(ValidationError::HashMismatch {
 			expected: id,
@@ -264,5 +262,11 @@ impl From<io::Error> for ValidationError {
 impl From<zip::result::ZipError> for ValidationError {
 	fn from(err: zip::result::ZipError) -> Self {
 		ValidationError::Zip(err)
+	}
+}
+
+impl From<io::IntoInnerError<io::BufWriter<fs::File>>> for ValidationError {
+	fn from(err: io::IntoInnerError<io::BufWriter<fs::File>>) -> Self {
+		ValidationError::Io(err.into())
 	}
 }

--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -52,7 +52,7 @@ pub fn write_keccak<T: AsRef<[u8]>>(s: T, dest: &mut [u8]) {
 	}
 }
 
-pub fn keccak_buffer_and_write(r: &mut io::BufRead, w: &mut io::Write) -> Result<H256, io::Error> {
+pub fn keccak_pipe(r: &mut io::BufRead, w: &mut io::Write) -> Result<H256, io::Error> {
 	let mut output = [0u8; 32];
 	let mut input = [0u8; 1024];
 	let mut keccak = Keccak::new_keccak256();
@@ -72,7 +72,7 @@ pub fn keccak_buffer_and_write(r: &mut io::BufRead, w: &mut io::Write) -> Result
 }
 
 pub fn keccak_buffer(r: &mut io::BufRead) -> Result<H256, io::Error> {
-	keccak_buffer_and_write(r, &mut io::sink())
+	keccak_pipe(r, &mut io::sink())
 }
 
 #[cfg(test)]

--- a/util/hash/src/lib.rs
+++ b/util/hash/src/lib.rs
@@ -52,7 +52,7 @@ pub fn write_keccak<T: AsRef<[u8]>>(s: T, dest: &mut [u8]) {
 	}
 }
 
-pub fn keccak_buffer(r: &mut io::BufRead) -> Result<H256, io::Error> {
+pub fn keccak_buffer_and_write(r: &mut io::BufRead, w: &mut io::Write) -> Result<H256, io::Error> {
 	let mut output = [0u8; 32];
 	let mut input = [0u8; 1024];
 	let mut keccak = Keccak::new_keccak256();
@@ -64,10 +64,15 @@ pub fn keccak_buffer(r: &mut io::BufRead) -> Result<H256, io::Error> {
 			break;
 		}
 		keccak.update(&input[0..some]);
+		w.write_all(&input[0..some])?;
 	}
 
 	keccak.finalize(&mut output);
 	Ok(output.into())
+}
+
+pub fn keccak_buffer(r: &mut io::BufRead) -> Result<H256, io::Error> {
+	keccak_buffer_and_write(r, &mut io::sink())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fixes a TODO item in dapps-fetcher.

A new function, called `keccak_buffer_and_write` is added. This allows attaching another BufWrite. When reading the input, it writes it to BufWrite as well. The original function `keccak_buffer` is then just setting the parameter to a Sink.