### PR TITLE
Include suicided accounts in state diff

### DIFF
--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -869,15 +869,12 @@ impl<B: Backend> State<B> {
 				continue
 			}
 
-			match pod.get(address) {
-				Some(pod_account) => {
-					// needs to be split into two parts for the refcell code here
-					// to work.
-					for key in pod_account.storage.keys() {
-						self.storage_at(address, key)?;
-					}
-				},
-				None => (),
+			if let Some(pod_account) = pod.get(address) {
+				// needs to be split into two parts for the refcell code here
+				// to work.
+				for key in pod_account.storage.keys() {
+					self.storage_at(address, key)?;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #8158 

The bug happens because PodState only records addresses that exist. In state diff, it uses the post PodState to populate the cache of pre-state, but missed killed addresses. So we simply collect all touched address directly from cache, and then use that to call `query_pod`.