### PR TITLE
Ethcore now uses rayon 0.9 as a dependency (#8296)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
  "patricia-trie 0.1.0",
  "price-info 1.11.0",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1",
  "rlp_compress 0.1.0",
  "rlp_derive 0.1.0",

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -45,7 +45,7 @@ num_cpus = "1.2"
 parity-machine = { path = "../machine" }
 parking_lot = "0.5"
 price-info = { path = "../price-info" }
-rayon = "0.8"
+rayon = "0.9"
 rand = "0.4"
 rlp = { path = "../util/rlp" }
 rlp_compress = { path = "../util/rlp_compress" }


### PR DESCRIPTION
After this change, runtime dependencies would contain only Rayon `0.9`. Affects https://github.com/paritytech/parity/issues/8296.

P.S.: Maybe we should move right to the `1.0` instead?