### PR TITLE
Decouple timestamp open-block-assignment/verification to Engine

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -267,7 +267,7 @@ impl<'x> OpenBlock<'x> {
 		r.block.header.set_parent_hash(parent.hash());
 		r.block.header.set_number(number);
 		r.block.header.set_author(author);
-		r.block.header.set_timestamp_now(parent.timestamp());
+		r.block.header.set_timestamp(engine.open_block_header_timestamp(parent.timestamp()));
 		r.block.header.set_extra_data(extra_data);
 
 		let gas_floor_target = cmp::max(gas_range_target.0, engine.params().min_gas_limit);

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -397,7 +397,7 @@ impl PrepareOpenBlock for TestBlockChainClient {
 			extra_data,
 			false,
 		).expect("Opening block for tests will not fail.");
-		// TODO [todr] Override timestamp for predictability (set_timestamp_now kind of sucks)
+		// TODO [todr] Override timestamp for predictability
 		open_block.set_timestamp(*self.latest_block_timestamp.read());
 		open_block
 	}

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -50,6 +50,17 @@ impl<M: Machine> Engine<M> for InstantSeal<M>
 	fn verify_local_seal(&self, _header: &M::Header) -> Result<(), M::Error> {
 		Ok(())
 	}
+
+	fn open_block_header_timestamp(&self, parent_timestamp: u64) -> u64 {
+		use std::{time, cmp};
+
+		let now = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap_or_default();
+		cmp::max(now.as_secs(), parent_timestamp)
+	}
+
+	fn is_timestamp_valid(&self, header_timestamp: u64, parent_timestamp: u64) -> bool {
+		header_timestamp >= parent_timestamp
+	}
 }
 
 #[cfg(test)]

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -325,6 +325,19 @@ pub trait Engine<M: Machine>: Sync + Send {
 	fn supports_warp(&self) -> bool {
 		self.snapshot_components().is_some()
 	}
+
+	/// Return a new open block header timestamp based on the parent timestamp.
+	fn open_block_header_timestamp(&self, parent_timestamp: u64) -> u64 {
+		use std::{time, cmp};
+
+		let now = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap_or_default();
+		cmp::max(now.as_secs() as u64, parent_timestamp + 1)
+	}
+
+	/// Check whether the parent timestamp is valid.
+	fn is_timestamp_valid(&self, header_timestamp: u64, parent_timestamp: u64) -> bool {
+		header_timestamp > parent_timestamp
+	}
 }
 
 /// Common type alias for an engine coupled with an Ethereum-like state machine.

--- a/ethcore/src/header.rs
+++ b/ethcore/src/header.rs
@@ -17,7 +17,6 @@
 //! Block header.
 
 use std::cmp;
-use std::time::{SystemTime, UNIX_EPOCH};
 use hash::{KECCAK_NULL_RLP, KECCAK_EMPTY_LIST_RLP, keccak};
 use heapsize::HeapSizeOf;
 use ethereum_types::{H256, U256, Address, Bloom};
@@ -224,12 +223,6 @@ impl Header {
 		change_field(&mut self.hash, &mut self.timestamp, a);
 	}
 
-	/// Set the timestamp field of the header to the current time.
-	pub fn set_timestamp_now(&mut self, but_later_than: u64) {
-		let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
-		self.set_timestamp(cmp::max(now.as_secs() as u64, but_later_than + 1));
-	}
-
 	/// Set the number field of the header.
 	pub fn set_number(&mut self, a: BlockNumber) {
 		change_field(&mut self.hash, &mut self.number, a);
@@ -428,4 +421,3 @@ mod tests {
 		assert_eq!(header_rlp, encoded_header);
 	}
 }
-


### PR DESCRIPTION
Fixes #7694

The bug happens because when Parity constructs a new open block, the timestamp will be set at least one second ahead of parent timestamp. For most of the time, this works fine, and most Engine rules also require this. However, because dev chain seals a block for every transaction, it becomes a problem if one tries to send more than one transaction per second.

This PR adds two new predefined functions in Engine trait, `open_block_header_timestamp` and `is_timestamp_valid`. All other engines are unchanged except `InstantSeal`, where `open_block_header_timestamp` would not do "plus one", and `is_timestamp_valid` would accept it if parent timestamp equals to current one. Those replaces hard coded rules in `verification` mod and `Header::set_timestamp_now`.

This also makes the function `set_timestamp_now` unused. And I read a comment saying this function "kind of sucks"... So I removed it.