### PR TITLE
rpc, eth_filter: return error if the filter id does not exist

### DIFF
--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -399,6 +399,14 @@ pub fn deprecated<T: Into<Option<String>>>(message: T) -> Error {
 	}
 }
 
+pub fn filter_not_found() -> Error {
+	Error {
+		code: ErrorCode::ServerError(codes::UNSUPPORTED_REQUEST),
+		message: "Filter not found".into(),
+		data: None,
+	}
+}
+
 // on-demand sender cancelled.
 pub fn on_demand_cancel(_cancel: futures::sync::oneshot::Canceled) -> Error {
 	internal("on-demand sender cancelled", "")


### PR DESCRIPTION
Fixes #6706

When the requested filter id does not exist, return an error instead of silently fail.