### PR TITLE
No hardcoded client name

### DIFF
--- a/rpc/src/v1/impls/web3.rs
+++ b/rpc/src/v1/impls/web3.rs
@@ -31,7 +31,7 @@ impl Web3Client {
 
 impl Web3 for Web3Client {
 	fn client_version(&self) -> Result<String> {
-		Ok(version().to_owned().replace("Parity/", "Parity//"))
+		Ok(version().to_owned().replacen("/", "//", 1))
 	}
 
 	fn sha3(&self, data: Bytes) -> Result<H256> {

--- a/rpc/src/v1/tests/mocked/web3.rs
+++ b/rpc/src/v1/tests/mocked/web3.rs
@@ -24,7 +24,7 @@ fn rpc_web3_version() {
 	let mut io = IoHandler::new();
 	io.extend_with(web3);
 
-	let v = version().to_owned().replace("Parity/", "Parity//");
+	let v = version().to_owned().replacen("/", "//", 1);
 
 	let request = r#"{"jsonrpc": "2.0", "method": "web3_clientVersion", "params": [], "id": 1}"#;
 	let response = r#"{"jsonrpc":"2.0","result":"VER","id":1}"#.to_owned().replace("VER", v.as_ref());


### PR DESCRIPTION
* Fixes issues with version string if client name is substituted (required for Energy Web)