### PR TITLE
Use tokio::spawn in secret_store listener and fix Uri

### DIFF
--- a/secret_store/src/listener/http_listener.rs
+++ b/secret_store/src/listener/http_listener.rs
@@ -105,7 +105,7 @@ impl KeyServerHttpListener {
 				});
 
 				// TODO: Change this to tokio::spawn once hyper is Send.
-				serve.wait();
+				let _ = serve.wait();
 				future::ok(())
 			});
 

--- a/secret_store/src/listener/http_listener.rs
+++ b/secret_store/src/listener/http_listener.rs
@@ -20,7 +20,6 @@ use hyper::{self, header, Chunk, Uri, Request as HttpRequest, Response as HttpRe
 use hyper::server::Http;
 use serde::Serialize;
 use serde_json;
-use tokio::executor::current_thread;
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tokio_service::Service;
@@ -222,7 +221,7 @@ impl Service for KeyServerHttpHandler {
 
 		Box::new(req.body().concat2().map(move |body| {
 			let path = req_uri.path().to_string();
-			if req_uri.is_absolute() {
+			if path.starts_with("/") {
 				this.process(req_method, req_uri, &path, &body)
 			} else {
 				warn!(target: "secretstore", "Ignoring invalid {}-request {}", req_method, req_uri);

--- a/secret_store/src/listener/http_listener.rs
+++ b/secret_store/src/listener/http_listener.rs
@@ -201,8 +201,6 @@ impl KeyServerHttpHandler {
 	}
 }
 
-unsafe impl Send for KeyServerHttpHandler { }
-
 impl Service for KeyServerHttpHandler {
 	type Request = HttpRequest;
 	type Response = HttpResponse;

--- a/secret_store/src/listener/http_listener.rs
+++ b/secret_store/src/listener/http_listener.rs
@@ -105,7 +105,7 @@ impl KeyServerHttpListener {
 				});
 
 				// TODO: Change this to tokio::spawn once hyper is Send.
-				current_thread::spawn(serve);
+				serve.wait();
 				future::ok(())
 			});
 


### PR DESCRIPTION
Sorry I broke it... XD

* Turned out that we can use `tokio::spawn` here. :smile: The thing I missed is in the below `Service` definition -- you must mark the boxed Future to be Send (and it indeed can be Send already), otherwise the type information is lost.
* We cannot use `current_thread` there because I misunderstood how it works -- `current_thread` will only try to get the `CurrentThread` executor, regardless whether there's already other executors in this thread. That's why it panicked.
* `Uri`'s absolute_path meaning is changed in hyper 0.11.