### PR TITLE
ParityDB integration with Parity CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "paritydb 0.1.0",
+ "paritydb 0.1.0 (git+https://github.com/sorpaas/paritydb?branch=temp)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2413,6 +2413,7 @@ dependencies = [
 [[package]]
 name = "paritydb"
 version = "0.1.0"
+source = "git+https://github.com/sorpaas/paritydb?branch=temp#ed0ef4314dbac60fdb00980fbc60bc7fdb9ada9a"
 dependencies = [
  "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3961,6 +3962,7 @@ dependencies = [
 "checksum parity-ui-precompiled 1.9.0 (git+https://github.com/js-dist-paritytech/parity-master-1-10-shell.git?rev=bd25b41cd642c6b822d820dded3aa601a29aa079)" = "<none>"
 "checksum parity-wasm 0.27.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a93ad771f67ce8a6af64c6444a99c07b15f4674203657496fc31244ffb1de2c3"
 "checksum parity-wordlist 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0dec124478845b142f68b446cbee953d14d4b41f1bc0425024417720dce693"
+"checksum paritydb 0.1.0 (git+https://github.com/sorpaas/paritydb?branch=temp)" = "<none>"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd9d732f2de194336fb02fe11f9eed13d9e76f13f4315b4d88a14ca411750cd"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,15 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1204,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hex-slice"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hidapi"
 version = "0.3.1"
 source = "git+https://github.com/paritytech/hidapi-rs#e77ea09c98f29ea8855dd9cd9461125a28ca9125"
@@ -1302,6 +1316,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "itertools"
 version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1465,6 +1487,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kvdb-paritydb"
+version = "0.1.0"
+dependencies = [
+ "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.1.0",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paritydb 0.1.0",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kvdb-rocksdb"
 version = "0.1.0"
 dependencies = [
@@ -1587,6 +1620,17 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1954,6 +1998,7 @@ dependencies = [
  "jsonrpc-core 8.0.1 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-1.11)",
  "keccak-hash 0.1.0",
  "kvdb 0.1.0",
+ "kvdb-paritydb 0.1.0",
  "kvdb-rocksdb 0.1.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mem 0.1.0",
@@ -2363,6 +2408,30 @@ dependencies = [
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "paritydb"
+version = "0.1.0"
+dependencies = [
+ "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-slice 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3803,6 +3872,7 @@ dependencies = [
 "checksum fixed-hash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18d6fd718fb4396e7a9c93ac59ba7143501467ca7a143c145b5555a571d5576"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
+"checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
@@ -3816,6 +3886,7 @@ dependencies = [
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
+"checksum hex-slice 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "839068f4e2a7e9dc421aac6b8a4bfe022c56124b8ab57e43aad019143fa0a7e2"
 "checksum hidapi 0.3.1 (git+https://github.com/paritytech/hidapi-rs)" = "<none>"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.11.24 (registry+https://github.com/rust-lang/crates.io-index)" = "df4dd5dae401458087396b6db7fabc4d6760aa456a5fa8e92bda549f39cae661"
@@ -3827,6 +3898,7 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipnetwork 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2134e210e2a024b5684f90e1556d5f71a1ce7f8b12e9ac9924c67fb36f63b336"
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
+"checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum jsonrpc-core 8.0.1 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-1.11)" = "<none>"
 "checksum jsonrpc-http-server 8.0.0 (git+https://github.com/paritytech/jsonrpc.git?branch=parity-1.11)" = "<none>"
@@ -3852,6 +3924,7 @@ dependencies = [
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46f3c7359028b31999287dae4e5047ddfe90a23b7dca2282ce759b491080c99b"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
@@ -3888,6 +3961,7 @@ dependencies = [
 "checksum parity-ui-precompiled 1.9.0 (git+https://github.com/js-dist-paritytech/parity-master-1-10-shell.git?rev=bd25b41cd642c6b822d820dded3aa601a29aa079)" = "<none>"
 "checksum parity-wasm 0.27.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a93ad771f67ce8a6af64c6444a99c07b15f4674203657496fc31244ffb1de2c3"
 "checksum parity-wordlist 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0dec124478845b142f68b446cbee953d14d4b41f1bc0425024417720dce693"
+"checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd9d732f2de194336fb02fe11f9eed13d9e76f13f4315b4d88a14ca411750cd"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ mem = { path = "util/mem" }
 
 parity-dapps = { path = "dapps", optional = true }
 ethcore-secretstore = { path = "secret_store", optional = true }
+kvdb-paritydb = { path = "util/kvdb-paritydb", optional = true }
 
 registrar = { path = "registrar" }
 

--- a/util/kvdb-paritydb/Cargo.toml
+++ b/util/kvdb-paritydb/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 kvdb = { path = "../kvdb" }
-paritydb = { path = "../../../paritydb/paritydb" }
+paritydb = { git = "https://github.com/sorpaas/paritydb", branch = "temp" }
 log = "0.3"
 elastic-array = "0.10"
 tempdir = "0.3"

--- a/util/kvdb-paritydb/Cargo.toml
+++ b/util/kvdb-paritydb/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kvdb-paritydb"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+
+[dependencies]
+kvdb = { path = "../kvdb" }
+paritydb = { path = "../../../paritydb/paritydb" }
+log = "0.3"
+elastic-array = "0.10"
+tempdir = "0.3"

--- a/util/kvdb-paritydb/src/lib.rs
+++ b/util/kvdb-paritydb/src/lib.rs
@@ -1,0 +1,282 @@
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate log;
+
+extern crate kvdb;
+extern crate paritydb;
+extern crate elastic_array;
+
+use std::path::PathBuf;
+use std::sync::{RwLock, RwLockReadGuard};
+use std::{fs, io};
+use kvdb::{KeyValueDB, DBTransaction, DBValue, DBOp, Result};
+use paritydb::{Options, Database as DB, Value, DatabaseIterator as DBIterator};
+
+#[derive(Debug, Clone)]
+pub struct DatabaseConfig {
+	/// Set number of columns
+	pub columns: Option<u32>,
+}
+
+pub struct Database {
+	dbs: Vec<RwLock<Option<DB>>>,
+	config: DatabaseConfig,
+	path: String,
+}
+
+impl Database {
+	fn open_column(mut path: PathBuf, subpath: &str) -> Result<DB> {
+		path.push(subpath);
+
+		let db_file = {
+			let mut path = path.clone();
+			path.push("data.db");
+			path
+		};
+
+		let meta_file = {
+			let mut path = path.clone();
+			path.push("meta.db");
+			path
+		};
+
+		if db_file.exists() && meta_file.exists() {
+			Ok(DB::open(path, Options::default()).map_err(|e| format!("ParityDB error: {}", e))?)
+		} else {
+			Ok(DB::create(path, Options::default()).map_err(|e| format!("ParityDB error: {}", e))?)
+		}
+	}
+
+	pub fn open(config: &DatabaseConfig, path: &str) -> Result<Database> {
+		let mut dbs = Vec::new();
+
+		dbs.push(RwLock::new(Some(Self::open_column(PathBuf::from(path), "default")?)));
+		if let Some(columns) = config.columns {
+			for i in 0..columns {
+				dbs.push(RwLock::new(Some(Self::open_column(PathBuf::from(path), &i.to_string())?)));
+			}
+		}
+
+		Ok(Database {
+			dbs,
+			config: config.clone(),
+			path: path.to_string(),
+		})
+	}
+}
+
+impl KeyValueDB for Database {
+	fn get(&self, col: Option<u32>, key: &[u8]) -> Result<Option<DBValue>> {
+		let db_guard = match col {
+			None => self.dbs[0].read(),
+			Some(col) => {
+				let col = col as usize;
+				if col > self.dbs.len() {
+					return Err(format!("ParityDB error: column does not exist.").into());
+				}
+				self.dbs[col].read()
+			},
+		}.map_err(|e| format!("ParityDB error: {}", e))?;
+		let db = db_guard.as_ref().expect("DB should always exist");
+
+		// Postfix the key to 32 bytes.
+		let mut postfixed_key = [0u8; 32];
+		if key.len() > 32 {
+			return Err("ParityDB error: longest key length is 32 bytes.".into());
+		}
+		postfixed_key[0..key.len()].copy_from_slice(key);
+
+		let raw_value = db.get(postfixed_key).map_err(|e| format!("ParityDB error: {}", e))?;
+		let value = raw_value.map(|raw_value| {
+			match raw_value {
+				Value::Raw(data) => DBValue::from_slice(data),
+				Value::Record(record) => {
+					let mut array = Vec::new();
+					array.resize(record.value_len(), 0u8);
+					record.read_value(&mut array);
+					DBValue::from_vec(array)
+				}
+			}
+		});
+
+		Ok(value)
+	}
+
+	fn get_by_prefix(&self, col: Option<u32>, prefix: &[u8]) -> Option<Box<[u8]>> {
+		match self.iter_from_prefix(col, prefix).next() {
+			Some((k, v)) => if k.starts_with(prefix) { Some(v) } else { None },
+			_ => None
+		}
+	}
+
+	fn write_buffered(&self, transaction: DBTransaction) {
+		let DBTransaction { ops } = transaction;
+		let mut transactions = Vec::new();
+		for _ in 0..self.dbs.len() {
+			transactions.push(None);
+		}
+
+		for op in ops {
+			let col = op.col().unwrap_or(0) as usize;
+			if col > self.dbs.len() {
+				warn!("ParityDB error: column does not exist.");
+				continue;
+			}
+			if transactions[col].is_none() {
+				transactions[col] = Some(self.dbs[col].read().expect("DB read cannot fail; qed").as_ref().expect("DB should always exist").create_transaction());
+			}
+			let transaction = transactions[col].as_mut().expect("None case checked above; qed");
+
+			let postfixed_key = {
+				let key = op.key();
+				let mut postfixed_key = [0u8; 32];
+				if key.len() > 32 {
+					warn!("ParityDB error: longest key length is 32 bytes.");
+					continue;
+				}
+				postfixed_key[0..key.len()].copy_from_slice(key);
+				postfixed_key
+			};
+
+			match op {
+				DBOp::Insert { value, .. } => {
+					transaction.insert(postfixed_key, value).expect("Key length is checked above; qed");
+				},
+				DBOp::Delete { .. } => {
+					transaction.delete(postfixed_key).expect("Key length is checked above; qed");
+				},
+			}
+		}
+
+		for (i, transaction) in transactions.into_iter().enumerate() {
+			if let Some(transaction) = transaction {
+				self.dbs[i].write().expect("DB write cannot fail; qed").as_mut().expect("DB should always exist").commit(&transaction).expect("Transaction commitment error indicate problem with underlying database folder.");
+			}
+		}
+	}
+
+	fn flush(&self) -> Result<()> {
+		for db in self.dbs.iter() {
+			db.write().map_err(|e| format!("ParityDB error: {}", e))?.as_mut()
+				.expect("DB should always exist")
+				.flush_journal(None).map_err(|e| format!("ParityDB error: {}", e))?;
+		}
+
+		Ok(())
+	}
+
+	fn iter<'a>(&'a self, col: Option<u32>) -> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a> {
+		let col = col.unwrap_or(0) as usize;
+		if col > self.dbs.len() {
+			panic!("ParityDB error: column does not exist");
+		}
+
+		let guard = self.dbs[col].read().expect("DB read cannot fail; qed");
+		// We need some unsafe black magic here because we need an "owning reference", but Rust's type system cannot
+		// figure this out. The reference is safe as long as we make sure the following properties are true:
+		//
+		// 1. `iter` is in a "stable address". This is guaranteed by Box.
+		// 2. `iter` is dropped before `guard` is dropped. So that all references within 'a are still valid.
+		let iter = unsafe {
+			Box::from_raw(Box::into_raw(Box::new(guard.as_ref().expect("DB should always exist").iter().expect("Iterator building failure indicate problem with underlying database folder."))) as *mut () as *mut DBIterator<'a>)
+		};
+
+		Box::new(DatabaseIterator { _guard: guard, iter })
+	}
+
+	fn iter_from_prefix<'a>(&'a self, col: Option<u32>, prefix: &'a [u8])
+							-> Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a> {
+		Box::new(self.iter(col).filter(move |v| v.0.starts_with(prefix)))
+	}
+
+	fn restore(&self, new_db: &str) -> Result<()> {
+		use std::mem;
+
+		for i in 0..self.dbs.len() {
+			let mut db = self.dbs[i].write().map_err(|e| format!("DB write error: {}", e))?;
+			*db = None;
+		}
+
+		let mut backup_db = PathBuf::from(&self.path);
+		backup_db.pop();
+		backup_db.push("backup_db");
+
+		let existed = match fs::rename(&self.path, &backup_db) {
+			Ok(_) => true,
+			Err(e) => if let io::ErrorKind::NotFound = e.kind() {
+				false
+			} else {
+				return Err(e.into());
+			}
+		};
+
+		match fs::rename(&new_db, &self.path) {
+			Ok(_) => {
+				// clean up the backup.
+				if existed {
+					fs::remove_dir_all(&backup_db)?;
+				}
+			}
+			Err(e) => {
+				// restore the backup.
+				if existed {
+					fs::rename(&backup_db, &self.path)?;
+				}
+				return Err(e.into())
+			}
+		}
+
+		let new_db = Self::open(&self.config, &self.path)?;
+		for i in 0..self.dbs.len() {
+			let mut db = self.dbs[i].write().map_err(|e| format!("DB acquire error: {}", e))?;
+			*db = mem::replace(&mut *new_db.dbs[i].write().map_err(|e| format!("DB acquire error: {}", e))?, None);
+		}
+
+		Ok(())
+	}
+}
+
+struct DatabaseIterator<'a> {
+	_guard: RwLockReadGuard<'a, Option<DB>>,
+	iter: Box<DBIterator<'a>>,
+}
+
+impl<'a> Iterator for DatabaseIterator<'a> {
+	type Item = (Box<[u8]>, Box<[u8]>);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		match self.iter.next() {
+			None => None,
+			Some(Err(_)) => None,
+			Some(Ok((key, value))) => {
+				let key: Vec<u8> = key.into();
+				let value = match value {
+					Value::Raw(data) => data.into(),
+					Value::Record(record) => {
+						let mut array = Vec::new();
+						array.resize(record.value_len(), 0u8);
+						record.read_value(&mut array);
+						array
+					},
+				};
+
+				Some((key.into_boxed_slice(), value.into_boxed_slice()))
+			}
+		}
+	}
+}


### PR DESCRIPTION
cc #7865 

This adds an experimental ParityDB integration with the CLI. If you want to test this, please use the kvdb-paritydb-cli branch (https://github.com/sorpaas/parity/tree/kvdb-paritydb-cli), which contains the merged change of #8371. Use feature flag `paritydb`, for example `cargo run --features paritydb -- --base-path ~/.paritydb-test --config dev`. **Please remember to use a different base path as it will mess up with existing databases**. With that branch, I'm at least able to use the dev chain with ParityDB, send transactions and mine blocks. Haven't done more testing yet.

Some current limitations of ParityDB:

* Key length needs to be a fixed value (unlike rocksdb which can be a variable). So in this implementation I hard-set it to 64 bytes, postfix keys if they're less than this length.
* No prefix-iteration functionality in ParityDB. So the current implementation uses a filter under the full iterator. Fortunately we're not using that functionality a lot.
* No column functionality in ParityDB. So the current implementation just opens a separate DB for each column.

And several TODO tasks before we can consider this to be merge-able:

* [ ] Fix grumbles in https://github.com/paritytech/paritydb/pull/73 and change paritydb dependency back to https://github.com/paritytech/paritydb
* [ ] After #8371, merge `kvdb-paritydb-cli` branch.
