### PR TITLE
Check finalized block in blockchain::Blockchain

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -1006,8 +1006,9 @@ impl BlockChain {
 	}
 
 	/// Update metadata detail for an existing block.
-	pub fn update_metadata(&self, batch: &mut DBTransaction, block_hash: H256, metadata: HashMap<Bytes, Bytes>) -> Result<(), MetadataError> {
+	pub fn update_metadata<T: Into<HashMap<Bytes, Bytes>>>(&self, batch: &mut DBTransaction, block_hash: H256, metadata: T) -> Result<(), MetadataError> {
 		let mut block_details = self.block_details(&block_hash).ok_or(MetadataError::UnknownBlock)?;
+		let metadata: HashMap<Bytes, Bytes> = metadata.into();
 		for (key, value) in metadata {
 			block_details.metadata.insert(key, value);
 		}

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -508,6 +508,8 @@ impl BlockChain {
 					total_difficulty: header.difficulty(),
 					parent: header.parent_hash(),
 					children: vec![],
+					finalized: false,
+					metadatas: vec![],
 				};
 
 				let mut batch = DBTransaction::new();
@@ -772,6 +774,8 @@ impl BlockChain {
 				total_difficulty: info.total_difficulty,
 				parent: header.parent_hash(),
 				children: Vec::new(),
+				finalized: false,
+				metadatas: Vec::new(),
 			};
 
 			let mut update = HashMap::new();
@@ -1179,6 +1183,8 @@ impl BlockChain {
 			total_difficulty: info.total_difficulty,
 			parent: parent_hash,
 			children: vec![],
+			finalized: false,
+			metadatas: vec![],
 		};
 
 		// write to batch

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -510,7 +510,7 @@ impl BlockChain {
 					parent: header.parent_hash(),
 					children: vec![],
 					finalized: false,
-					metadatas: HashMap::new(),
+					metadata: HashMap::new(),
 				};
 
 				let mut batch = DBTransaction::new();
@@ -784,7 +784,7 @@ impl BlockChain {
 				parent: header.parent_hash(),
 				children: Vec::new(),
 				finalized: false,
-				metadatas: HashMap::new(),
+				metadata: HashMap::new(),
 			};
 
 			let mut update = HashMap::new();
@@ -1006,10 +1006,10 @@ impl BlockChain {
 	}
 
 	/// Update metadata detail for an existing block.
-	pub fn update_metadatas(&self, batch: &mut DBTransaction, block_hash: H256, metadatas: HashMap<Bytes, Bytes>) -> Result<(), MetadataError> {
+	pub fn update_metadata(&self, batch: &mut DBTransaction, block_hash: H256, metadata: HashMap<Bytes, Bytes>) -> Result<(), MetadataError> {
 		let mut block_details = self.block_details(&block_hash).ok_or(MetadataError::UnknownBlock)?;
-		for (key, value) in metadatas {
-			block_details.metadatas.insert(key, value);
+		for (key, value) in metadata {
+			block_details.metadata.insert(key, value);
 		}
 
 		self.update_block_details(batch, block_hash, block_details);
@@ -1227,7 +1227,7 @@ impl BlockChain {
 			parent: parent_hash,
 			children: vec![],
 			finalized: false,
-			metadatas: HashMap::new(),
+			metadata: HashMap::new(),
 		};
 
 		// write to batch

--- a/ethcore/src/blockchain/extras.rs
+++ b/ethcore/src/blockchain/extras.rs
@@ -183,12 +183,12 @@ pub struct BlockDetails {
 	/// Whether the block is considered finalized
 	pub finalized: bool,
 	/// Metadata information
-	pub metadatas: HashMap<Bytes, Bytes>,
+	pub metadata: HashMap<Bytes, Bytes>,
 }
 
 impl rlp::Encodable for BlockDetails {
 	fn rlp_append(&self, stream: &mut rlp::RlpStream) {
-		let use_short_version = self.metadatas.len() == 0 && !self.finalized;
+		let use_short_version = self.metadata.len() == 0 && !self.finalized;
 
 		match use_short_version {
 			true => { stream.begin_list(4); },
@@ -202,10 +202,10 @@ impl rlp::Encodable for BlockDetails {
 		if !use_short_version {
 			stream.append(&self.finalized);
 
-			let metadatas: Vec<BlockMetadata> = self.metadatas.clone().into_iter().map(|(key, value)| {
+			let metadata: Vec<BlockMetadata> = self.metadata.clone().into_iter().map(|(key, value)| {
 				BlockMetadata { key, value }
 			}).collect();
-			stream.append_list(&metadatas);
+			stream.append_list(&metadata);
 		}
 	}
 }
@@ -228,7 +228,7 @@ impl rlp::Decodable for BlockDetails {
 			} else {
 				rlp.val_at(4)?
 			},
-			metadatas: if use_short_version {
+			metadata: if use_short_version {
 				HashMap::new()
 			} else {
 				let metadatas: Vec<BlockMetadata> = rlp.list_at(5)?;

--- a/ethcore/src/blockchain/extras.rs
+++ b/ethcore/src/blockchain/extras.rs
@@ -23,6 +23,8 @@ use db::Key;
 use engines::epoch::{Transition as EpochTransition};
 use header::BlockNumber;
 use receipt::Receipt;
+use rlp;
+use bytes::Bytes;
 
 use heapsize::HeapSizeOf;
 use ethereum_types::{H256, H264, U256};
@@ -167,7 +169,7 @@ impl Key<EpochTransitions> for u64 {
 }
 
 /// Familial details concerning a block
-#[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
+#[derive(Debug, Clone)]
 pub struct BlockDetails {
 	/// Block number
 	pub number: BlockNumber,
@@ -177,12 +179,72 @@ pub struct BlockDetails {
 	pub parent: H256,
 	/// List of children block hashes
 	pub children: Vec<H256>,
+	/// Whether the block is considered finalized
+	pub finalized: bool,
+	/// Metadata information
+	pub metadatas: Vec<BlockMetadata>,
+}
+
+impl rlp::Encodable for BlockDetails {
+	fn rlp_append(&self, stream: &mut rlp::RlpStream) {
+		let use_short_version = self.metadatas.len() == 0 && !self.finalized;
+
+		match use_short_version {
+			true => { stream.begin_list(4); },
+			false => { stream.begin_list(6); },
+		}
+
+		stream.append(&self.number);
+		stream.append(&self.total_difficulty);
+		stream.append(&self.parent);
+		stream.append_list(&self.children);
+		if !use_short_version {
+			stream.append(&self.finalized);
+			stream.append_list(&self.metadatas);
+		}
+	}
+}
+
+impl rlp::Decodable for BlockDetails {
+	fn decode(rlp: &rlp::UntrustedRlp) -> Result<Self, rlp::DecoderError> {
+		let use_short_version = match rlp.item_count()? {
+			4 => true,
+			6 => false,
+			_ => return Err(rlp::DecoderError::RlpIncorrectListLen),
+		};
+
+		Ok(BlockDetails {
+			number: rlp.val_at(0)?,
+			total_difficulty: rlp.val_at(1)?,
+			parent: rlp.val_at(2)?,
+			children: rlp.list_at(3)?,
+			finalized: if use_short_version {
+				false
+			} else {
+				rlp.val_at(4)?
+			},
+			metadatas: if use_short_version {
+				Vec::new()
+			} else {
+				rlp.list_at(5)?
+			},
+		})
+	}
 }
 
 impl HeapSizeOf for BlockDetails {
 	fn heap_size_of_children(&self) -> usize {
 		self.children.heap_size_of_children()
 	}
+}
+
+/// Metadata key and value
+#[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
+pub struct BlockMetadata {
+	/// Key of the metadata
+	pub key: Bytes,
+	/// Value of the metadata
+	pub value: Bytes,
 }
 
 /// Represents address of certain transaction within block

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -742,7 +742,9 @@ impl BlockChainClient for TestBlockChainClient {
 					}
 				}
 				if adding { Vec::new() } else { blocks }
-			}
+			},
+			is_from_route_finalized: false,
+			is_to_route_finalized: false,
 		})
 	}
 

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -148,6 +148,23 @@ impl fmt::Display for BlockError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+/// Errors related to metadata operations
+pub enum MetadataError {
+	/// The metadata block trying to set is unknown.
+	UnknownBlock,
+}
+
+impl fmt::Display for MetadataError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		let msg = match *self {
+			MetadataError::UnknownBlock => "unknown block",
+		};
+
+		f.write_fmt(format_args!("Block metadata error ({})", msg))
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// Import to the block queue result
 pub enum ImportError {
 	/// Already in the block chain.
@@ -247,6 +264,8 @@ pub enum Error {
 	Ethkey(EthkeyError),
 	/// Account Provider error.
 	AccountProvider(AccountsError),
+	/// Block metadata error.
+	Metadata(MetadataError),
 }
 
 impl fmt::Display for Error {
@@ -271,6 +290,7 @@ impl fmt::Display for Error {
 			Error::Engine(ref err) => err.fmt(f),
 			Error::Ethkey(ref err) => err.fmt(f),
 			Error::AccountProvider(ref err) => err.fmt(f),
+			Error::Metadata(ref err) => err.fmt(f),
 		}
 	}
 }
@@ -284,6 +304,12 @@ impl error::Error for Error {
 
 /// Result of import block operation.
 pub type ImportResult = Result<H256, Error>;
+
+impl From<MetadataError> for Error {
+	fn from(err: MetadataError) -> Error {
+		Error::Metadata(err)
+	}
+}
 
 impl From<ClientError> for Error {
 	fn from(err: ClientError) -> Error {

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -455,7 +455,7 @@ mod tests {
 					parent: header.parent_hash().clone(),
 					children: Vec::new(),
 					finalized: false,
-					metadatas: Default::default(),
+					metadata: Default::default(),
 				}
 			})
 		}

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -454,6 +454,8 @@ mod tests {
 					total_difficulty: header.difficulty().clone(),
 					parent: header.parent_hash().clone(),
 					children: Vec::new(),
+					finalized: false,
+					metadatas: Default::default(),
 				}
 			})
 		}

--- a/ethcore/types/src/tree_route.rs
+++ b/ethcore/types/src/tree_route.rs
@@ -27,4 +27,8 @@ pub struct TreeRoute {
 	pub ancestor: H256,
 	/// An index where best common ancestor would be.
 	pub index: usize,
+	/// Whether it has finalized blocks from `from` (inclusive) to `ancestor` (exclusive).
+	pub is_from_route_finalized: bool,
+	/// Whether it has finalized blocks from `ancestor` (exclusive) to `to` (inclusive).
+	pub is_to_route_finalized: bool,
 }


### PR DESCRIPTION
* Takes BlockDetails to contain `finalized` and `metadatas` in a backward compatible way -- if finalized is false and metadata is empty, it is stored as the old 4 value RLP. Otherwise, it's stored as the extended 6 value RLP.
* Adds `Blockchain::mark_finalized` and `Blockchain::update_metadata` to update finalized value and metadata for any block (but it's not currently used anywhere).
* Changes `Blockchain::block_info` to refuse re-org if it goes pass a finalized block.