### PR TITLE
Fix an obsolete TODO where `miner` is alias of `author`

### DIFF
--- a/rpc/src/v1/types/block.rs
+++ b/rpc/src/v1/types/block.rs
@@ -55,8 +55,7 @@ pub struct Block {
 	pub uncles_hash: H256,
 	/// Authors address
 	pub author: H160,
-	// TODO: get rid of this one
-	/// ?
+	/// Alias of `author`
 	pub miner: H160,
 	/// State root hash
 	#[serde(rename="stateRoot")]


### PR DESCRIPTION
Fix an obsolete TODO item, and document `author` is alias of `miner`.