### PR TITLE
Improve VM executor stack size estimation rules

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -34,10 +34,21 @@ use transaction::{Action, SignedTransaction};
 use crossbeam;
 pub use executed::{Executed, ExecutionResult};
 
-/// Roughly estimate what stack size each level of evm depth will use
-/// TODO [todr] We probably need some more sophisticated calculations here (limit on my machine 132)
-/// Maybe something like here: `https://github.com/ethereum/libethereum/blob/4db169b8504f2b87f7d5a481819cfb959fc65f6c/libethereum/ExtVM.cpp`
-const STACK_SIZE_PER_DEPTH: usize = 24*1024;
+#[cfg(debug_assertions)]
+/// Roughly estimate what stack size each level of evm depth will use. (Debug build)
+const STACK_SIZE_PER_DEPTH: usize = 128 * 1024;
+
+#[cfg(not(debug_assertions))]
+/// Roughly estimate what stack size each level of evm depth will use.
+const STACK_SIZE_PER_DEPTH: usize = 24 * 1024;
+
+#[cfg(debug_assertions)]
+/// Entry stack overhead prior to execution.
+const STACK_SIZE_ENTRY_OVERHEAD: usize = 100 * 1024;
+
+#[cfg(not(debug_assertions))]
+/// Entry stack overhead prior to execution.
+const STACK_SIZE_ENTRY_OVERHEAD: usize = 20 * 1024;
 
 /// Returns new address created from address, nonce, and code hash
 pub fn contract_address(address_scheme: CreateContractAddress, sender: &Address, nonce: &U256, code: &[u8]) -> (Address, Option<H256>) {
@@ -333,11 +344,11 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 		vm_tracer: &mut V
 	) -> vm::Result<FinalizationResult> where T: Tracer, V: VMTracer {
 
-		let depth_threshold = ::io::LOCAL_STACK_SIZE.with(|sz| sz.get() / STACK_SIZE_PER_DEPTH);
+		let depth_threshold = ::io::LOCAL_STACK_SIZE.with(|sz| (sz.get() - STACK_SIZE_ENTRY_OVERHEAD) / STACK_SIZE_PER_DEPTH);
 		let static_call = params.call_type == CallType::StaticCall;
 
 		// Ordinary execution - keep VM in same thread
-		if (self.depth + 1) % depth_threshold != 0 {
+		if (self.depth + 1) != depth_threshold {
 			let vm_factory = self.state.vm_factory();
 			let mut ext = self.as_externalities(OriginInfo::from(&params), unconfirmed_substate, output_policy, tracer, vm_tracer, static_call);
 			trace!(target: "executive", "ext.schedule.have_delegate_call: {}", ext.schedule().have_delegate_call);
@@ -345,17 +356,15 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 			return vm.exec(params, &mut ext).finalize(ext);
 		}
 
-		// Start in new thread to reset stack
-		// TODO [todr] No thread builder yet, so we need to reset once for a while
-		// https://github.com/aturon/crossbeam/issues/16
+		// Start in new thread with stack size needed up to max depth
 		crossbeam::scope(|scope| {
 			let vm_factory = self.state.vm_factory();
 			let mut ext = self.as_externalities(OriginInfo::from(&params), unconfirmed_substate, output_policy, tracer, vm_tracer, static_call);
 
-			scope.spawn(move || {
+			scope.builder().stack_size((schedule.max_depth - depth_threshold) * STACK_SIZE_PER_DEPTH).spawn(move || {
 				let mut vm = vm_factory.create(&params, &schedule);
 				vm.exec(params, &mut ext).finalize(ext)
-			})
+			}).expect("Sub-thread creation cannot fail; the host might run out of resources; qed")
 		}).join()
 	}
 

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -43,7 +43,7 @@ const STACK_SIZE_PER_DEPTH: usize = 128 * 1024;
 const STACK_SIZE_PER_DEPTH: usize = 24 * 1024;
 
 #[cfg(debug_assertions)]
-/// Entry stack overhead prior to execution.
+/// Entry stack overhead prior to execution. (Debug build)
 const STACK_SIZE_ENTRY_OVERHEAD: usize = 100 * 1024;
 
 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
This improves the stack size estimation, taking advantage of `scope.builder().stack_size(...)`, so instead of resetting stack once a while by creating new threads, we only need at most one additional thread for a VM execution.

The stack size per depth is now changed to take account whether we are in debug build or release build, so it also accidentally fixes #8376.

Regarding the additional `expect()` in `builder()...spawn()` -- this is because the original bare `spawn` function (https://docs.rs/crossbeam/0.3.2/src/crossbeam/scoped.rs.html#230-234) simply uses an `unwrap()`.