### PR TITLE
Return error in case eth_call returns VM errors

### DIFF
--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -376,11 +376,11 @@ pub fn call(error: CallError) -> Error {
 	}
 }
 
-pub fn vm(error: VMError, output: &[u8]) -> Error {
+pub fn vm(error: &VMError, output: &[u8]) -> Error {
 	use rustc_hex::ToHex;
 
 	let data = match error {
-		VMError::Reverted => format!("{} 0x{}", VMError::Reverted, output.to_hex()),
+		&VMError::Reverted => format!("{} 0x{}", VMError::Reverted, output.to_hex()),
 		error => format!("{}", error),
 	};
 

--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -24,6 +24,7 @@ use jsonrpc_core::{futures, Error, ErrorCode, Value};
 use rlp::DecoderError;
 use transaction::Error as TransactionError;
 use ethcore_private_tx::Error as PrivateTransactionError;
+use vm::Error as VMError;
 
 mod codes {
 	// NOTE [ToDr] Codes from [-32099, -32000]
@@ -372,6 +373,21 @@ pub fn call(error: CallError) -> Error {
 		CallError::Exceptional => exceptional(),
 		CallError::Execution(e) => execution(e),
 		CallError::TransactionNotFound => internal("{}, this should not be the case with eth_call, most likely a bug.", CallError::TransactionNotFound),
+	}
+}
+
+pub fn vm(error: VMError, output: &[u8]) -> Error {
+	use rustc_hex::ToHex;
+
+	let data = match error {
+		VMError::Reverted => format!("{} 0x{}", VMError::Reverted, output.to_hex()),
+		error => format!("{}", error),
+	};
+
+	Error {
+		code: ErrorCode::ServerError(codes::EXECUTION_ERROR),
+		message: "VM execution error.".into(),
+		data: Some(Value::String(data)),
 	}
 }
 


### PR DESCRIPTION
Fixes #8442

This changes the behaviors of eth_call to respect VM errors if any. In case of reverted, it will also return the reverted return data in hex format.