### PR TITLE
Fetching logs by hash in blockchain database

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -57,6 +57,12 @@ pub trait BlockProvider {
 	/// (though not necessarily a part of the canon chain).
 	fn is_known(&self, hash: &H256) -> bool;
 
+	/// Returns true if the given block is known and in the canon chain.
+	fn is_canon(&self, hash: &H256) -> bool {
+		let is_canon = || Some(hash == &self.block_hash(self.block_number(hash)?)?);
+		is_canon().unwrap_or(false)
+	}
+
 	/// Get the first block of the best part of the chain.
 	/// Return `None` if there is no gap and the first block is the genesis.
 	/// Any queries of blocks which precede this one are not guaranteed to

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -1976,8 +1976,8 @@ mod tests {
 		]);
 
 		// when
-		let logs1 = bc.logs(vec![1, 2], |_| true, None);
-		let logs2 = bc.logs(vec![1, 2], |_| true, Some(1));
+		let logs1 = bc.logs(vec![b1_hash, b2_hash], |_| true, None);
+		let logs2 = bc.logs(vec![b1_hash, b2_hash], |_| true, Some(1));
 
 		// then
 		assert_eq!(logs1, vec![

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -332,6 +332,8 @@ impl BlockProvider for BlockChain {
 			.collect()
 	}
 
+	/// Returns logs matching given filter. The order of logs returned will be the same as the order of the blocks
+	/// provided. And it's the callers responsibility to sort blocks provided in advance.
 	fn logs<F>(&self, mut blocks: Vec<H256>, matches: F, limit: Option<usize>) -> Vec<LocalizedLogEntry>
 		where F: Fn(&LogEntry) -> bool + Send + Sync, Self: Sized {
 		// sort in reverse order

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1865,7 +1865,7 @@ impl BlockChainClient for Client {
 					&BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) => true,
 					// If it is referred by hash, we see whether a hash -> number -> hash conversion gives us the same
 					// result.
-					&BlockId::Hash(hash) => chain.is_canon(hash),
+					&BlockId::Hash(ref hash) => chain.is_canon(hash),
 				}
 			};
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1906,6 +1906,7 @@ impl BlockChainClient for Client {
 							blocks.push(current_hash);
 						}
 
+						// Stop if `from` block is reached.
 						if header.number() <= from_number {
 							break;
 						}

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1936,7 +1936,7 @@ impl BlockChainClient for Client {
 				current_number = current_number - 1;
 			}
 
-			if current_hash != from_hash || blocks.empty() {
+			if current_hash != from_hash || blocks.is_empty() {
 				return Vec::new();
 			}
 

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1853,98 +1853,94 @@ impl BlockChainClient for Client {
 	}
 
 	fn logs(&self, filter: Filter) -> Vec<LocalizedLogEntry> {
-		macro_rules! return_empty_if_none {
-			( $v: expr ) => (
-				match $v {
-					Some(value) => value,
-					None => return Vec::new(),
-				}
-			)
-		}
+		// Wrap the logic inside a closure so that we can take advantage of question mark syntax.
+		let fetch_logs = || {
+			let chain = self.chain.read();
 
-		let chain = self.chain.read();
-
-		// First, check whether `filter.from_block` and `filter.to_block` is on the canon chain. If so, we can use the
-		// optimized version.
-		let is_canon = |id| {
-			match id {
-				// If it is referred by number, then it is always on the canon chain.
-				&BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) => Some(true),
-				// If it is referred by hash, we see whether a hash -> number -> hash conversion gives us the same
-				// result.
-				&BlockId::Hash(hash) =>
-					Some(hash == chain.block_hash(chain.block_number(&hash)?)?),
-			}
-		};
-
-		let blocks = if return_empty_if_none!(is_canon(&filter.from_block)) && return_empty_if_none!(is_canon(&filter.to_block)) {
-			// If we are on the canon chain, use bloom filter to fetch required hashes.
-			let from = return_empty_if_none!(self.block_number_ref(&filter.from_block));
-			let to = return_empty_if_none!(self.block_number_ref(&filter.to_block));
-
-			let mut numbers = filter.bloom_possibilities().iter()
-				.map(|bloom| {
-					chain.blocks_with_bloom(bloom, from, to)
-				})
-				.flat_map(|m| m)
-				// remove duplicate elements
-				.collect::<HashSet<u64>>()
-				.into_iter()
-				.collect::<Vec<u64>>();
-
-			numbers.sort_by(|a, b| a.cmp(b));
-			numbers.into_iter()
-				.filter_map(|n| chain.block_hash(n))
-				.collect::<Vec<H256>>()
-
-		} else {
-			// Otherwise, we use a slower version that finds a link between from_block and to_block.
-			let get_hash = |id| {
+			// First, check whether `filter.from_block` and `filter.to_block` is on the canon chain. If so, we can use the
+			// optimized version.
+			let is_canon = |id| {
 				match id {
-					&BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) =>
-						chain.block_hash(self.block_number_ref(id)?),
-					&BlockId::Hash(hash) => Some(hash),
+					// If it is referred by number, then it is always on the canon chain.
+					&BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) => Some(true),
+					// If it is referred by hash, we see whether a hash -> number -> hash conversion gives us the same
+					// result.
+					&BlockId::Hash(hash) =>
+						Some(hash == chain.block_hash(chain.block_number(&hash)?)?),
 				}
 			};
 
-			let from_hash = return_empty_if_none!(get_hash(&filter.from_block));
-			let from_number = return_empty_if_none!(chain.block_number(&from_hash));
-			let to_hash = return_empty_if_none!(get_hash(&filter.to_block));
-			let to_number = return_empty_if_none!(chain.block_number(&to_hash));
+			let blocks = if is_canon(&filter.from_block)? && is_canon(&filter.to_block)? {
+				// If we are on the canon chain, use bloom filter to fetch required hashes.
+				let from = self.block_number_ref(&filter.from_block)?;
+				let to = self.block_number_ref(&filter.to_block)?;
 
-			let blooms = filter.bloom_possibilities();
-			let bloom_match = |header: &encoded::Header| {
-				blooms.iter().any(|bloom| header.log_bloom().contains_bloom(bloom))
-			};
+				let mut numbers = filter.bloom_possibilities().iter()
+					.map(|bloom| {
+						chain.blocks_with_bloom(bloom, from, to)
+					})
+					.flat_map(|m| m)
+					// remove duplicate elements
+					.collect::<HashSet<u64>>()
+					.into_iter()
+					.collect::<Vec<u64>>();
 
-			let mut blocks = Vec::new();
-			let mut current_hash = to_hash;
-			let mut current_number = to_number;
+				numbers.sort_by(|a, b| a.cmp(b));
+				numbers.into_iter()
+					.filter_map(|n| chain.block_hash(n))
+					.collect::<Vec<H256>>()
 
-			if bloom_match(&return_empty_if_none!(chain.block_header_data(&current_hash))) {
-				blocks.push(current_hash);
-			}
+			} else {
+				// Otherwise, we use a slower version that finds a link between from_block and to_block.
+				let get_hash = |id| {
+					match id {
+						&BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) =>
+							chain.block_hash(self.block_number_ref(id)?),
+						&BlockId::Hash(hash) => Some(hash),
+					}
+				};
 
-			while current_number > from_number {
-				let header = return_empty_if_none!(chain.block_header_data(&current_hash));
+				let from_hash = get_hash(&filter.from_block)?;
+				let from_number = chain.block_number(&from_hash)?;
+				let to_hash = get_hash(&filter.to_block)?;
+				let to_number = chain.block_number(&to_hash)?;
 
-				if bloom_match(&header) {
+				let blooms = filter.bloom_possibilities();
+				let bloom_match = |header: &encoded::Header| {
+					blooms.iter().any(|bloom| header.log_bloom().contains_bloom(bloom))
+				};
+
+				let mut blocks = Vec::new();
+				let mut current_hash = to_hash;
+				let mut current_number = to_number;
+
+				if bloom_match(&chain.block_header_data(&current_hash)?) {
 					blocks.push(current_hash);
 				}
 
-				current_hash = header.parent_hash();
-				current_number = current_number - 1;
-			}
+				while current_number > from_number {
+					let header = chain.block_header_data(&current_hash)?;
 
-			if current_hash != from_hash || blocks.is_empty() {
-				return Vec::new();
-			}
+					if bloom_match(&header) {
+						blocks.push(current_hash);
+					}
 
-			blocks.reverse();
-			blocks
+					current_hash = header.parent_hash();
+					current_number = current_number - 1;
+				}
+
+				if current_hash != from_hash || blocks.is_empty() {
+					return None;
+				}
+
+				blocks.reverse();
+				blocks
+			};
+
+			Some(self.chain.read().logs(blocks, |entry| filter.matches(entry), filter.limit))
 		};
 
-		self.chain.read().logs(blocks, |entry| filter.matches(entry), filter.limit)
+		fetch_logs().unwrap_or_default()
 	}
 
 	fn filter_traces(&self, filter: TraceFilter) -> Option<Vec<LocalizedTrace>> {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1862,15 +1862,14 @@ impl BlockChainClient for Client {
 			let is_canon = |id| {
 				match id {
 					// If it is referred by number, then it is always on the canon chain.
-					&BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) => Some(true),
+					&BlockId::Earliest | &BlockId::Latest | &BlockId::Number(_) => true,
 					// If it is referred by hash, we see whether a hash -> number -> hash conversion gives us the same
 					// result.
-					&BlockId::Hash(hash) =>
-						Some(hash == chain.block_hash(chain.block_number(&hash)?)?),
+					&BlockId::Hash(hash) => chain.is_canon(hash),
 				}
 			};
 
-			let blocks = if is_canon(&filter.from_block)? && is_canon(&filter.to_block)? {
+			let blocks = if is_canon(&filter.from_block) && is_canon(&filter.to_block) {
 				// If we are on the canon chain, use bloom filter to fetch required hashes.
 				let from = self.block_number_ref(&filter.from_block)?;
 				let to = self.block_number_ref(&filter.to_block)?;

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::{HashSet, HashMap, BTreeMap, VecDeque};
+use std::collections::{HashSet, HashMap, BTreeMap, BTreeSet, VecDeque};
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering as AtomicOrdering};
@@ -1875,18 +1875,14 @@ impl BlockChainClient for Client {
 				let from = self.block_number_ref(&filter.from_block)?;
 				let to = self.block_number_ref(&filter.to_block)?;
 
-				let mut numbers = filter.bloom_possibilities().iter()
+				filter.bloom_possibilities().iter()
 					.map(|bloom| {
 						chain.blocks_with_bloom(bloom, from, to)
 					})
 					.flat_map(|m| m)
 					// remove duplicate elements
-					.collect::<HashSet<u64>>()
+					.collect::<BTreeSet<u64>>()
 					.into_iter()
-					.collect::<Vec<u64>>();
-
-				numbers.sort_by(|a, b| a.cmp(b));
-				numbers.into_iter()
 					.filter_map(|n| chain.block_hash(n))
 					.collect::<Vec<H256>>()
 

--- a/ethcore/src/verification/verification.rs
+++ b/ethcore/src/verification/verification.rs
@@ -476,7 +476,7 @@ mod tests {
 			unimplemented!()
 		}
 
-		fn logs<F>(&self, _blocks: Vec<BlockNumber>, _matches: F, _limit: Option<usize>) -> Vec<LocalizedLogEntry>
+		fn logs<F>(&self, _blocks: Vec<H256>, _matches: F, _limit: Option<usize>) -> Vec<LocalizedLogEntry>
 			where F: Fn(&LogEntry) -> bool, Self: Sized {
 			unimplemented!()
 		}


### PR DESCRIPTION
Fixes #7994. (Unit tests added, but not yet on a PoW reorg blockchain as I'm still downloading mainnet...)

The `Client` struct already passes enacted/retracted blocks information to RPCs. However, the information is lost in logs fetching because `Client` currently insists on converting `filter.from_block` and `filter.to_block` to a canon block's number before querying it in database. As a result, all branch block's log cannot be displayed. This PR fixes it by:

* Change `BlockChain` to query block hashes, instead of block numbers.
* In `Client`, if it is detected that `filter.from_block == filter.to_block` and it is a hash, it passes the hash directly and skips the bloom possibility filter step.