### PR TITLE
Use rename_all for RichBlock and RichHeader serialization

### DIFF
--- a/rpc/src/v1/types/block.rs
+++ b/rpc/src/v1/types/block.rs
@@ -44,11 +44,11 @@ impl Serialize for BlockTransactions {
 
 /// Block representation
 #[derive(Debug, Serialize)]
+#[serde(rename_all="camelCase")]
 pub struct Block {
 	/// Hash of the block
 	pub hash: Option<H256>,
 	/// Hash of the parent
-	#[serde(rename="parentHash")]
 	pub parent_hash: H256,
 	/// Hash of the uncles
 	#[serde(rename="sha3Uncles")]
@@ -58,37 +58,28 @@ pub struct Block {
 	/// Alias of `author`
 	pub miner: H160,
 	/// State root hash
-	#[serde(rename="stateRoot")]
 	pub state_root: H256,
 	/// Transactions root hash
-	#[serde(rename="transactionsRoot")]
 	pub transactions_root: H256,
 	/// Transactions receipts root hash
-	#[serde(rename="receiptsRoot")]
 	pub receipts_root: H256,
 	/// Block number
 	pub number: Option<U256>,
 	/// Gas Used
-	#[serde(rename="gasUsed")]
 	pub gas_used: U256,
 	/// Gas Limit
-	#[serde(rename="gasLimit")]
 	pub gas_limit: U256,
 	/// Extra data
-	#[serde(rename="extraData")]
 	pub extra_data: Bytes,
 	/// Logs bloom
-	#[serde(rename="logsBloom")]
 	pub logs_bloom: Option<H2048>,
 	/// Timestamp
 	pub timestamp: U256,
 	/// Difficulty
 	pub difficulty: U256,
 	/// Total difficulty
-	#[serde(rename="totalDifficulty")]
 	pub total_difficulty: Option<U256>,
 	/// Seal fields
-	#[serde(rename="sealFields")]
 	pub seal_fields: Vec<Bytes>,
 	/// Uncles' hashes
 	pub uncles: Vec<H256>,
@@ -100,11 +91,11 @@ pub struct Block {
 
 /// Block header representation.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all="camelCase")]
 pub struct Header {
 	/// Hash of the block
 	pub hash: Option<H256>,
 	/// Hash of the parent
-	#[serde(rename="parentHash")]
 	pub parent_hash: H256,
 	/// Hash of the uncles
 	#[serde(rename="sha3Uncles")]
@@ -114,34 +105,26 @@ pub struct Header {
 	/// Alias of `author`
 	pub miner: H160,
 	/// State root hash
-	#[serde(rename="stateRoot")]
 	pub state_root: H256,
 	/// Transactions root hash
-	#[serde(rename="transactionsRoot")]
 	pub transactions_root: H256,
 	/// Transactions receipts root hash
-	#[serde(rename="receiptsRoot")]
 	pub receipts_root: H256,
 	/// Block number
 	pub number: Option<U256>,
 	/// Gas Used
-	#[serde(rename="gasUsed")]
 	pub gas_used: U256,
 	/// Gas Limit
-	#[serde(rename="gasLimit")]
 	pub gas_limit: U256,
 	/// Extra data
-	#[serde(rename="extraData")]
 	pub extra_data: Bytes,
 	/// Logs bloom
-	#[serde(rename="logsBloom")]
 	pub logs_bloom: H2048,
 	/// Timestamp
 	pub timestamp: U256,
 	/// Difficulty
 	pub difficulty: U256,
 	/// Seal fields
-	#[serde(rename="sealFields")]
 	pub seal_fields: Vec<Bytes>,
 	/// Size in bytes
 	pub size: Option<U256>,

--- a/rpc/src/v1/types/block.rs
+++ b/rpc/src/v1/types/block.rs
@@ -111,8 +111,7 @@ pub struct Header {
 	pub uncles_hash: H256,
 	/// Authors address
 	pub author: H160,
-	// TODO: get rid of this one
-	/// ?
+	/// Alias of `author`
 	pub miner: H160,
 	/// State root hash
 	#[serde(rename="stateRoot")]


### PR DESCRIPTION
* Removed a resolved TODO comment. It is fixed in the same way as #8413.
* Use `rename_all` for RichBlock and RichHeader to save a few LOCs.