### PR TITLE
 Stabilize 1.10.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,7 +188,7 @@ docker-build:
   before_script:
     - docker info
   script:
-    - if [ "$CI_BUILD_REF_NAME" == "beta" ]; then DOCKER_TAG="latest"; else DOCKER_TAG=$CI_BUILD_REF_NAME; fi
+    - if [ "$CI_BUILD_REF_NAME" == "master" ]; then DOCKER_TAG="latest"; else DOCKER_TAG=$CI_BUILD_REF_NAME; fi
     - echo "Tag:" $DOCKER_TAG
     - docker login -u $Docker_Hub_User_Parity -p $Docker_Hub_Pass_Parity
     - scripts/docker-build.sh $DOCKER_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,7 +188,7 @@ docker-build:
   before_script:
     - docker info
   script:
-    - if [ "$CI_BUILD_REF_NAME" == "beta-release" ]; then DOCKER_TAG="latest"; else DOCKER_TAG=$CI_BUILD_REF_NAME; fi
+    - if [ "$CI_BUILD_REF_NAME" == "beta" ]; then DOCKER_TAG="latest"; else DOCKER_TAG=$CI_BUILD_REF_NAME; fi
     - echo "Tag:" $DOCKER_TAG
     - docker login -u $Docker_Hub_User_Parity -p $Docker_Hub_Pass_Parity
     - scripts/docker-build.sh $DOCKER_TAG

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "parity"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1910,7 +1910,7 @@ dependencies = [
  "parity-rpc 1.9.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.9.0",
- "parity-version 1.10.2",
+ "parity-version 1.10.3",
  "parity-whisper 0.1.0",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.0",
@@ -1959,7 +1959,7 @@ dependencies = [
  "parity-reactor 0.1.0",
  "parity-ui 1.9.0",
  "parity-ui-deprecation 1.10.0",
- "parity-version 1.10.2",
+ "parity-version 1.10.3",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2110,7 +2110,7 @@ dependencies = [
  "order-stat 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-reactor 0.1.0",
  "parity-updater 1.9.0",
- "parity-version 1.10.2",
+ "parity-version 1.10.3",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2227,7 +2227,7 @@ dependencies = [
  "ethsync 1.9.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.9.0",
- "parity-version 1.10.2",
+ "parity-version 1.10.3",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.0",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "ethcore-bytes 0.1.0",
  "rlp 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "1.10.2"
+version = "1.10.3"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
         # evmjit dependencies
         zlib1g-dev \
         libedit-dev \
-	libudev-dev &&\
+        libudev-dev &&\
 # cmake and llvm ppa's. then update ppa's
  add-apt-repository -y "ppa:george-edison55/cmake-3.x" && \
         add-apt-repository "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main" && \

--- a/mac/Parity.pkgproj
+++ b/mac/Parity.pkgproj
@@ -462,7 +462,7 @@
 				<key>OVERWRITE_PERMISSIONS</key>
 				<false/>
 				<key>VERSION</key>
-				<string>1.10.2</string>
+				<string>1.10.3</string>
 			</dict>
 			<key>UUID</key>
 			<string>2DCD5B81-7BAF-4DA1-9251-6274B089FD36</string>

--- a/nsis/installer.nsi
+++ b/nsis/installer.nsi
@@ -10,7 +10,7 @@
 !define DESCRIPTION "Fast, light, robust Ethereum implementation"
 !define VERSIONMAJOR 1
 !define VERSIONMINOR 10
-!define VERSIONBUILD 2
+!define VERSIONBUILD 3
 !define ARGS ""
 !define FIRST_START_ARGS "--mode=passive ui"
 

--- a/scripts/gitlab-build.sh
+++ b/scripts/gitlab-build.sh
@@ -309,6 +309,7 @@ case $BUILD_PLATFORM in
   x86_64-unknown-snap-gnu)
     ARC="amd64"
     EXT="snap"
+    apt update
     apt install -y expect zip rhash
     snapcraft clean
     echo "Prepare snapcraft.yaml for build on Gitlab CI in Docker image"

--- a/scripts/gitlab-build.sh
+++ b/scripts/gitlab-build.sh
@@ -313,7 +313,7 @@ case $BUILD_PLATFORM in
     snapcraft clean
     echo "Prepare snapcraft.yaml for build on Gitlab CI in Docker image"
     sed -i 's/git/'"$VER"'/g' snap/snapcraft.yaml
-    if [[ "$CI_BUILD_REF_NAME" = "beta" || "$VER" == *1.10* ]];
+    if [[ "$CI_BUILD_REF_NAME" = "beta" || "$VER" == *1.11* ]];
       then
         sed -i -e 's/grade: devel/grade: stable/' snap/snapcraft.yaml;
     fi

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,14 +3,14 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity version string (via env CARGO_PKG_VERSION)
-version = "1.10.2"
+version = "1.10.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 
 [package.metadata]
 # This versions track. Should be changed to `stable` or `beta` when on respective branches.
 # Used by auto-updater and for Parity version string.
-track = "beta"
+track = "stable"
 
 # Indicates a critical release in this track (i.e. consensus issue)
 critical = false


### PR DESCRIPTION
- Make 1.10 "stable"
- Bump Stable to 1.10.3
- Backports  #8462 and #8483 
- Use `master` as Docker's `latest` (`beta-release` is not used anymore)