### PR TITLE
Pass on storage keys tracing to handle the case when it is not modified

### DIFF
--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -862,7 +862,7 @@ impl<B: Backend> State<B> {
 		}))
 	}
 
-	/// Populate a PodAccount map from this state, with another state as the storage query.
+	/// Populate a PodAccount map from this state, with another state as the account and storage query.
 	pub fn to_pod_diff(&mut self, query: &PodState) -> trie::Result<PodState> {
 		assert!(self.checkpoints.borrow().is_empty());
 

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -2272,9 +2272,6 @@ mod tests {
 		let original = state.clone();
 		state.kill_account(&a);
 
-		assert_eq!(original.touched_addresses(), vec![]);
-		assert_eq!(state.touched_addresses(), vec![a]);
-
 		let diff = state.diff_from(original).unwrap();
 		let diff_map = diff.get();
 		assert_eq!(diff_map.len(), 1);

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -900,7 +900,6 @@ impl<B: Backend> State<B> {
 
 			if let Some((balance, nonce, storage_keys, code)) = account {
 				let storage = storage_keys.into_iter().fold(Ok(BTreeMap::new()), |s: trie::Result<_>, key| {
-
 					let mut s = s?;
 
 					s.insert(key, self.storage_at(&address, &key)?);

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -956,8 +956,8 @@ impl<B: Backend> State<B> {
 	/// Check caches for required data
 	/// First searches for account in the local, then the shared cache.
 	/// Populates local cache if nothing found.
-	fn ensure_cached<F, U>(&self, a: &Address, require: RequireCache, check_null: bool, mut f: F) -> trie::Result<U>
-		where F: FnMut(Option<&Account>) -> U {
+	fn ensure_cached<F, U>(&self, a: &Address, require: RequireCache, check_null: bool, f: F) -> trie::Result<U>
+		where F: Fn(Option<&Account>) -> U {
 		// check local cache first
 		if let Some(ref mut maybe_acc) = self.cache.borrow_mut().get_mut(a) {
 			if let Some(ref mut account) = maybe_acc.account {


### PR DESCRIPTION
Fixes #6520 

The bug happens because in our current implementation, we only build PodAccount from modified storage keys. As a result, storage values before are not available in tracing, thus displayed `0x00..00`. To fix it, we need to merge all old state storage keys with new state storage keys.

`State::ensure_cached` is changed to take a `FnMut` closure. This should really be a `FnOnce` but the compiler thinks we're using it multiple times, so currently I use the supertrait `FnMut`.