### PR TITLE
Show imported messages for light client

### DIFF
--- a/ethcore/light/src/client/service.rs
+++ b/ethcore/light/src/client/service.rs
@@ -30,7 +30,7 @@ use kvdb::KeyValueDB;
 use cache::Cache;
 use parking_lot::Mutex;
 
-use super::{ChainDataFetcher, Client, Config as ClientConfig};
+use super::{ChainDataFetcher, LightChainNotify, Client, Config as ClientConfig};
 
 /// Errors on service initialization.
 #[derive(Debug)]
@@ -84,6 +84,11 @@ impl<T: ChainDataFetcher> Service<T> {
 			client: client,
 			io_service: io_service,
 		})
+	}
+
+	/// Set the actor to be notified on certain chain events
+	pub fn add_notify(&self, notify: Arc<LightChainNotify>) {
+		self.client.add_listener(Arc::downgrade(&notify));
 	}
 
 	/// Register an I/O handler on the service.

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -412,7 +412,7 @@ fn execute_light_impl(cmd: RunCmd, logger: Arc<RotatingLogger>) -> Result<Runnin
 		Some(rpc_stats),
 		cmd.logger_config.color,
 	));
-
+	service.add_notify(informant.clone());
 	service.register_handler(informant.clone()).map_err(|_| "Unable to register informant handler".to_owned())?;
 
 	Ok(RunningClient::Light {


### PR DESCRIPTION
Fixes #8488.

Show "Imported" messages via `LightChainNotify`.