### PR TITLE
Don't panic in import_block if invalid rlp

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -1408,7 +1408,7 @@ impl ImportBlock for Client {
 		use verification::queue::kind::blocks::Unverified;
 
 		// create unverified block here so the `keccak` calculation can be cached.
-		let unverified = Unverified::new(bytes);
+		let unverified = Unverified::from_rlp(bytes)?;
 
 		{
 			if self.chain.read().is_known(&unverified.hash()) {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -447,9 +447,7 @@ impl Importer {
 	///
 	/// The block is guaranteed to be the next best blocks in the
 	/// first block sequence. Does no sealing or transaction validation.
-	fn import_old_block(&self, block_bytes: Bytes, receipts_bytes: Bytes, db: &KeyValueDB, chain: &BlockChain) -> Result<H256, ::error::Error> {
-		let block = view!(BlockView, &block_bytes);
-		let header = block.header();
+	fn import_old_block(&self, header: &Header, block_bytes: Bytes, receipts_bytes: Bytes, db: &KeyValueDB, chain: &BlockChain) -> Result<H256, ::error::Error> {
 		let receipts = ::rlp::decode_list(&receipts_bytes);
 		let hash = header.hash();
 		let _import_lock = self.import_lock.lock();
@@ -1423,19 +1421,19 @@ impl ImportBlock for Client {
 	}
 
 	fn import_block_with_receipts(&self, block_bytes: Bytes, receipts_bytes: Bytes) -> Result<H256, BlockImportError> {
+		let header: Header = ::rlp::Rlp::new(&block_bytes).val_at(0)?; 
 		{
 			// check block order
-			let header = view!(BlockView, &block_bytes).header_view();
 			if self.chain.read().is_known(&header.hash()) {
 				bail!(BlockImportErrorKind::Import(ImportErrorKind::AlreadyInChain));
 			}
-			let status = self.block_status(BlockId::Hash(header.parent_hash()));
+			let status = self.block_status(BlockId::Hash(*header.parent_hash()));
 			if status == BlockStatus::Unknown || status == BlockStatus::Pending {
-				bail!(BlockImportErrorKind::Block(BlockError::UnknownParent(header.parent_hash())));
+				bail!(BlockImportErrorKind::Block(BlockError::UnknownParent(*header.parent_hash())));
 			}
 		}
 
-		self.importer.import_old_block(block_bytes, receipts_bytes, &**self.db.read(), &*self.chain.read()).map_err(Into::into)
+		self.importer.import_old_block(&header, block_bytes, receipts_bytes, &**self.db.read(), &*self.chain.read()).map_err(Into::into)
 	}
 }
 

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -190,6 +190,7 @@ error_chain! {
 
 	foreign_links {
 		Block(BlockError) #[doc = "Block error"];
+		Decoder(::rlp::DecoderError) #[doc = "Rlp decoding error"];
 	}
 
 	errors {
@@ -206,6 +207,7 @@ impl From<Error> for BlockImportError {
 		match e {
 			Error(ErrorKind::Block(block_error), _) => BlockImportErrorKind::Block(block_error).into(),
 			Error(ErrorKind::Import(import_error), _) => BlockImportErrorKind::Import(import_error.into()).into(),
+			Error(ErrorKind::Util(util_error::ErrorKind::Decoder(decoder_err)), _) => BlockImportErrorKind::Decoder(decoder_err).into(),
 			_ => BlockImportErrorKind::Other(format!("other block import error: {:?}", e)).into(),
 		}
 	}

--- a/ethcore/src/verification/queue/kind.rs
+++ b/ethcore/src/verification/queue/kind.rs
@@ -119,14 +119,13 @@ pub mod blocks {
 
 	impl Unverified {
 		/// Create an `Unverified` from raw bytes.
-		pub fn new(bytes: Bytes) -> Self {
-			use views::BlockView;
+		pub fn from_rlp(bytes: Bytes) -> Result<Self, ::rlp::DecoderError> {
 
-			let header = view!(BlockView, &bytes).header();
-			Unverified {
+			let header : Header = ::rlp::Rlp::new(&bytes).val_at(0)?; 
+			Ok(Unverified {
 				header: header,
 				bytes: bytes,
-			}
+			})
 		}
 	}
 

--- a/ethcore/src/verification/queue/kind.rs
+++ b/ethcore/src/verification/queue/kind.rs
@@ -121,7 +121,7 @@ pub mod blocks {
 		/// Create an `Unverified` from raw bytes.
 		pub fn from_rlp(bytes: Bytes) -> Result<Self, ::rlp::DecoderError> {
 
-			let header : Header = ::rlp::Rlp::new(&bytes).val_at(0)?; 
+			let header = ::rlp::Rlp::new(&bytes).val_at(0)?; 
 			Ok(Unverified {
 				header: header,
 				bytes: bytes,


### PR DESCRIPTION
Spotted by @tomusdrw: invalid block/header RLP passed to `Unverified::new` would cause a panic. Fortunately where we receive blocks from peers there is already a [guard](https://github.com/paritytech/parity/blob/7fdb87ad38f8ea969a4e733c7bbf621b1668a82d/ethcore/sync/src/block_sync.rs#L486).

Anyway I've changed it so that invalid RLP will result in a `DecoderError` instead of a panicking.

Related to #8033 