### PR TITLE
Check that the Android build doesn't dep on c++_shared

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,7 +190,7 @@ android-armv7:
     - triggers
   script:
     - cargo build --target=armv7-linux-androideabi
-    # TODO: check that `arm-linux-androideabi-objdump -x ./target/armv7-linux-androideabi/release/parity | grep c++_shared` is empty
+    - if [ $(arm-linux-androideabi-objdump -x ./target/armv7-linux-androideabi/debug/parity | grep -i 'c++_shared' | wc -l) -ne 0]; then echo "FAIL!!" fi
   tags:
     - rust-arm
   artifacts:


### PR DESCRIPTION
The opinion of a shell expert would be appreciate to make sure that what I'm doing is correct.