### PR TITLE
Remove inject.js server-side injection for dapps

### DIFF
--- a/dapps/src/page/handler.rs
+++ b/dapps/src/page/handler.rs
@@ -17,9 +17,8 @@
 use std::io;
 use std::time::{Duration, SystemTime};
 use hyper::{self, header, StatusCode};
-use hyper::mime::{self, Mime};
+use hyper::mime::{Mime};
 
-use apps;
 use handlers::{Reader, ContentHandler, add_security_headers};
 use {Embeddable};
 
@@ -98,18 +97,7 @@ impl<T: DappFile> PageHandler<T> {
 			add_security_headers(&mut headers, self.safe_to_embed_on, self.allow_js_eval);
 		}
 
-		let initial_content = if file.content_type().to_owned() == mime::TEXT_HTML {
-			let content = &format!(
-				r#"<script src="/{}/inject.js"></script>"#,
-				apps::UTILS_PATH,
-			);
-
-			content.as_bytes().to_vec()
-		} else {
-			Vec::new()
-		};
-
-		let (reader, body) = Reader::pair(file.into_reader(), initial_content);
+		let (reader, body) = Reader::pair(file.into_reader(), Vec::new());
 		res.set_body(body);
 		(Some(reader), res)
 	}

--- a/dapps/src/tests/home.rs
+++ b/dapps/src/tests/home.rs
@@ -60,32 +60,3 @@ fn should_serve_home() {
 	response.assert_header("Content-Type", "text/html");
 	assert_security_headers(&response.headers);
 }
-
-
-#[test]
-fn should_inject_js() {
-	// given
-	let server = serve_ui();
-
-	// when
-	let response = request(server,
-		"\
-			GET / HTTP/1.1\r\n\
-			Host: 127.0.0.1:8080\r\n\
-			Connection: close\r\n\
-			\r\n\
-			{}
-		"
-	);
-
-	// then
-	response.assert_status("HTTP/1.1 200 OK");
-	response.assert_header("Content-Type", "text/html");
-	assert_eq!(
-		response.body.contains(r#"/inject.js"></script>"#),
-		true,
-		"Expected inject script tag in: {}",
-		response.body
-	);
-	assert_security_headers(&response.headers);
-}


### PR DESCRIPTION
Closes https://github.com/paritytech/parity/issues/8529

The Electron shell (Parity UI) already injects `inject.js` into the dapp webview, so we don't need the server to inject `<script src="/parity-utils/inject.js"></script>` to the response when serving the dapp anymore.

cc @amaurymartiny @tomusdrw 