### PR TITLE
Gitlab test script fixes

### DIFF
--- a/scripts/gitlab-test.sh
+++ b/scripts/gitlab-test.sh
@@ -7,6 +7,7 @@ if [[ "$CI_COMMIT_REF_NAME" = "master" || "$CI_COMMIT_REF_NAME" = "beta" || "$CI
 else
   export GIT_COMPARE=master;
 fi
+git fetch -a
 export RUST_FILES_MODIFIED="$(git --no-pager diff --name-only $GIT_COMPARE...$CI_COMMIT_SHA | grep -v -e ^\\. -e ^LICENSE -e ^README.md -e ^test.sh -e ^windows/ -e ^scripts/ -e ^mac/ -e ^nsis/ -e ^docs/ | wc -l)"
 echo "RUST_FILES_MODIFIED: $RUST_FILES_MODIFIED"
 echo "RUST_FILES_MODIFIED: $RUST_FILES_MODIFIED"

--- a/scripts/gitlab-test.sh
+++ b/scripts/gitlab-test.sh
@@ -7,7 +7,7 @@ if [[ "$CI_COMMIT_REF_NAME" = "master" || "$CI_COMMIT_REF_NAME" = "beta" || "$CI
 else
   export GIT_COMPARE=master;
 fi
-export RUST_FILES_MODIFIED="$(git --no-pager diff --name-only $GIT_COMPARE...$CI_COMMIT_SHA | grep -v -e ^\\. -e ^LICENSE -e ^README.md -e ^test.sh -e ^windows/ -e ^scripts/ -e ^mac/ -e ^nsis/ | wc -l)"
+export RUST_FILES_MODIFIED="$(git --no-pager diff --name-only $GIT_COMPARE...$CI_COMMIT_SHA | grep -v -e ^\\. -e ^LICENSE -e ^README.md -e ^test.sh -e ^windows/ -e ^scripts/ -e ^mac/ -e ^nsis/ -e ^docs/ | wc -l)"
 echo "RUST_FILES_MODIFIED: $RUST_FILES_MODIFIED"
 echo "RUST_FILES_MODIFIED: $RUST_FILES_MODIFIED"
 TEST_SWITCH=$1

--- a/scripts/gitlab-test.sh
+++ b/scripts/gitlab-test.sh
@@ -10,7 +10,6 @@ fi
 git fetch -a
 export RUST_FILES_MODIFIED="$(git --no-pager diff --name-only $GIT_COMPARE...$CI_COMMIT_SHA | grep -v -e ^\\. -e ^LICENSE -e ^README.md -e ^test.sh -e ^windows/ -e ^scripts/ -e ^mac/ -e ^nsis/ -e ^docs/ | wc -l)"
 echo "RUST_FILES_MODIFIED: $RUST_FILES_MODIFIED"
-echo "RUST_FILES_MODIFIED: $RUST_FILES_MODIFIED"
 TEST_SWITCH=$1
 rust_test () {
   git submodule update --init --recursive


### PR DESCRIPTION
After: https://gitlab.parity.io/parity/parity/-/jobs/86612

```
fatal: ambiguous argument 'beta~...62ccdd7ad4c5b45a744ae66f3da5275b91df5236': unknown revision or path not in the working tree.
```

- Removes duplicate echo
- Does a git fetch --all to ensure all references in the working tree are available
- Excludes docs from modified files check.