### PR TITLE
Remove unnecessary cloning in overwrite_with

### DIFF
--- a/ethcore/src/state/account.rs
+++ b/ethcore/src/state/account.rs
@@ -459,7 +459,7 @@ impl Account {
 		self.code_size = other.code_size;
 		self.address_hash = other.address_hash;
 		let mut cache = self.storage_cache.borrow_mut();
-		for (k, v) in other.storage_cache.into_inner().into_iter() {
+		for (k, v) in other.storage_cache.into_inner() {
 			cache.insert(k, v);
 		}
 		self.storage_changes = other.storage_changes;


### PR DESCRIPTION
Cloning can be fixed by using into_iter.