### PR TITLE
Allow stable snaps to be stable.

### DIFF
--- a/scripts/gitlab-build.sh
+++ b/scripts/gitlab-build.sh
@@ -314,7 +314,7 @@ case $BUILD_PLATFORM in
     snapcraft clean
     echo "Prepare snapcraft.yaml for build on Gitlab CI in Docker image"
     sed -i 's/git/'"$VER"'/g' snap/snapcraft.yaml
-    if [[ "$CI_BUILD_REF_NAME" = "beta" || "$VER" == *1.11* ]];
+    if [[ "$CI_BUILD_REF_NAME" = "stable" || "$VER" == *1.10* ]];
       then
         sed -i -e 's/grade: devel/grade: stable/' snap/snapcraft.yaml;
     fi


### PR DESCRIPTION
I can not release stable on snapcraft. 

https://dashboard.snapcraft.io/snaps/parity/revisions/11644/