### PR TITLE
Block::decode() returns Result

### DIFF
--- a/ethcore/src/encoded.rs
+++ b/ethcore/src/encoded.rs
@@ -206,7 +206,7 @@ impl Block {
 	pub fn header_view(&self) -> HeaderView { self.view().header_view() }
 
 	/// Decode to a full block.
-	pub fn decode(&self) -> FullBlock { ::rlp::decode(&self.0).expect("decoding failure") }
+	pub fn decode(&self) -> Result<FullBlock, rlp::DecoderError> { rlp::decode(&self.0) }
 
 	/// Decode the header.
 	pub fn decode_header(&self) -> FullHeader { self.view().rlp().val_at(0) }

--- a/ethcore/src/snapshot/consensus/authority.rs
+++ b/ethcore/src/snapshot/consensus/authority.rs
@@ -100,7 +100,7 @@ impl SnapshotComponents for PoaSnapshot {
 		let (block, receipts) = chain.block(&block_at)
 			.and_then(|b| chain.block_receipts(&block_at).map(|r| (b, r)))
 			.ok_or(Error::BlockNotFound(block_at))?;
-		let block = block.decode();
+		let block = block.decode()?;
 
 		let parent_td = chain.block_details(block.header.parent_hash())
 			.map(|d| d.total_difficulty)


### PR DESCRIPTION
Last part of #8553 where we make `Block::decode` return `Result` as well as `Header::decode`.

(Sorry for the miniscule PR here, I thought this would be much more involved.)