### PR TITLE
Allow making direct RPC queries from the C API

### DIFF
--- a/parity-clib-example/main.cpp
+++ b/parity-clib-example/main.cpp
@@ -1,4 +1,7 @@
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <unistd.h>
 #include <parity.h>
 
@@ -8,8 +11,8 @@ int main() {
     ParityParams cfg = { 0 };
     cfg.on_client_restart_cb = on_restart;
 
-    const char* args[] = {"--light"};
-    size_t str_lens[] = {7};
+    const char* args[] = {"--no-ipc"};
+    size_t str_lens[] = {8};
     if (parity_config_from_cli(args, str_lens, 1, &cfg.configuration) != 0) {
         return 1;
     }
@@ -18,6 +21,16 @@ int main() {
     if (parity_start(&cfg, &parity) != 0) {
         return 1;
     }
+
+    const char* rpc = "{\"method\":\"parity_versionInfo\",\"params\":[],\"id\":1,\"jsonrpc\":\"2.0\"}";
+    size_t out_len = 256;
+    char* out = (char*)malloc(out_len + 1);
+    if (parity_rpc(parity, rpc, strlen(rpc), out, &out_len)) {
+        return 1;
+    }
+    out[out_len] = '\0';
+    printf("RPC output: %s", out);
+    free(out);
 
     sleep(5);
     if (parity != NULL) {

--- a/parity-clib/parity.h
+++ b/parity-clib/parity.h
@@ -86,6 +86,22 @@ int parity_start(const ParityParams* params, void** out);
 ///					must not call this function.
 void parity_destroy(void* parity);
 
+/// Performs an RPC request.
+///
+/// Blocks the current thread until the request is finished. You are therefore encouraged to spawn
+/// a new thread for each RPC request that requires accessing the blockchain.
+///
+/// - `rpc` and `len` must contain the JSON string representing the RPC request.
+/// - `out_str` and `out_len` point to a buffer where the output JSON result will be stored. If the
+///	  buffer is not large enough, the function fails.
+/// - `out_len` will receive the final length of the string.
+/// - On success, the function returns 0. On failure, it returns 1.
+///
+/// **Important**: Keep in mind that this function doesn't write any null terminator on the output
+///                string.
+///
+int parity_rpc(void* parity, const char* rpc, size_t len, char* out_str, size_t* out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -355,7 +355,7 @@ fn with_domain(items: Option<Vec<String>>, domain: &str, ui_address: &Option<rpc
 	})
 }
 
-fn setup_apis<D>(apis: ApiSet, deps: &Dependencies<D>) -> MetaIoHandler<Metadata, Middleware<D::Notifier>>
+pub fn setup_apis<D>(apis: ApiSet, deps: &Dependencies<D>) -> MetaIoHandler<Metadata, Middleware<D::Notifier>>
 	where D: rpc_apis::Dependencies
 {
 	let mut handler = MetaIoHandler::with_middleware(

--- a/rpc/src/v1/types/provenance.rs
+++ b/rpc/src/v1/types/provenance.rs
@@ -49,6 +49,9 @@ pub enum Origin {
 		/// Session id
 		session: H256
 	},
+	/// From the C API
+	#[serde(rename="c-api")]
+	CApi,
 	/// Unknown
 	#[serde(rename="unknown")]
 	Unknown,
@@ -68,6 +71,7 @@ impl fmt::Display for Origin {
 			Origin::Ipc(ref session) => write!(f, "IPC (session: {})", session),
 			Origin::Ws { ref session, ref dapp } => write!(f, "{} via WebSocket (session: {})", dapp, session),
 			Origin::Signer { ref session, ref dapp } => write!(f, "{} via UI (session: {})", dapp, session),
+			Origin::CApi => write!(f, "C API"),
 			Origin::Unknown => write!(f, "unknown origin"),
 		}
 	}


### PR DESCRIPTION
Close #8577 

Allows performing RPC requests through the C API.
This makes the C API more usable in practice.

I initially wanted to propose a more complete interface where you'd create an RPC request object, then poll it from time to time (or some sort of similar mechanism), then retrieve the result, then destroy it.
However I realized that polling the `Future` of the RPC request would panic because we're not inside of a tokio task.

I then wanted to spawn a thread for each RPC request where I'd block waiting for the request to complete, then send the result through a `mpsc::channel()`. But then I realized that the user of the C API could do this themselves for the same overhead.

Therefore I decided to go with synchronous RPC queries only.
