### PR TITLE
Whisper-cli `remove manually added text to the errors`

### DIFF
--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -170,12 +170,12 @@ impl From<String> for Error {
 impl fmt::Display for Error {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
 		match *self {
-			Error::SockAddr(ref e) => write!(f, "SockAddrError: {}", e),
-			Error::Docopt(ref e) => write!(f, "DocoptError: {}", e),
-			Error::Io(ref e) => write!(f, "IoError: {}", e),
-			Error::JsonRpc(ref e) => write!(f, "JsonRpcError: {:?}", e),
-			Error::Network(ref e) => write!(f, "NetworkError: {}", e),
-			Error::Logger(ref e) => write!(f, "LoggerError: {}", e),
+			Error::SockAddr(ref e) => write!(f, "{}", e),
+			Error::Docopt(ref e) => write!(f, "{}", e),
+			Error::Io(ref e) => write!(f, "{}", e),
+			Error::JsonRpc(ref e) => write!(f, "{:?}", e),
+			Error::Network(ref e) => write!(f, "{}", e),
+			Error::Logger(ref e) => write!(f, "{}", e),
 		}
 	}
 }
@@ -251,7 +251,6 @@ fn initialize_logger(log_level: String) -> Result<(), String> {
 	log::setup_log(&l)?;
 	Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Before 
When the user for example entered `whisper --help` the following was presented:

```bash
DocoptError: Whisper CLI.
Whisper CLI.
        Copyright 2018 Parity Technologies (UK) Ltd

Usage:
        whisper [options]
        whisper [-h | --help]

Options:
        --whisper-pool-size SIZE       Specify Whisper pool size [default: 10].
        -p, --port PORT                Specify which RPC port to use [default: 8545].
        -a, --address ADDRESS          Specify which address to use [default: 127.0.0.1].                                                                                       
        -l, --log LEVEL                Specify the logging level. Must conform to the same format as RUST_LOG [default: Error].                                                 
        -h, --help                     Display this message and exit.
```

This happend everytime because the deserialization of the struct failed (which is not present if invalid arguments were entered)

## This PR
Instead, now we only print out the message generated by `Error` itself. It will show this instead if the deserialization fails for example:
```bash
$ whisper --help
Whisper CLI.
        Copyright 2018 Parity Technologies (UK) Ltd

Usage:
        whisper [options]
        whisper [-h | --help]

Options:
        --whisper-pool-size SIZE       Specify Whisper pool size [default: 10].
        -p, --port PORT                Specify which RPC port to use [default: 8545].
        -a, --address ADDRESS          Specify which address to use [default: 127.0.0.1].                                                                                       
        -l, --log LEVEL                Specify the logging level. Must conform to the same format as RUST_LOG [default: Error].                                                 
        -h, --help                     Display this message and exit.
```
That was a rather long explanation for a trivial thing but I wanted to motivate the change! 

/cc @5chdn 