### PR TITLE
Fix account list double 0x display

### DIFF
--- a/ethcore/sync/src/light_sync/response.rs
+++ b/ethcore/sync/src/light_sync/response.rs
@@ -16,7 +16,7 @@
 
 //! Helpers for decoding and verifying responses for headers.
 
-use ethcore::{self, encoded, header::Header};
+use ethcore::{encoded, header::Header};
 use ethereum_types::H256;
 use light::request::{HashOrNumber, CompleteHeadersRequest as HeadersRequest};
 use rlp::DecoderError;

--- a/parity/account.rs
+++ b/parity/account.rs
@@ -94,7 +94,7 @@ fn new(n: NewAccount) -> Result<String, String> {
 	let secret_store = Box::new(secret_store(dir, Some(n.iterations))?);
 	let acc_provider = AccountProvider::new(secret_store, AccountProviderSettings::default());
 	let new_account = acc_provider.new_account(&password).map_err(|e| format!("Could not create new account: {}", e))?;
-	Ok(format!("0x{:?}", new_account))
+	Ok(format!("0x{:x}", new_account))
 }
 
 fn list(list_cmd: ListAccounts) -> Result<String, String> {
@@ -103,7 +103,7 @@ fn list(list_cmd: ListAccounts) -> Result<String, String> {
 	let acc_provider = AccountProvider::new(secret_store, AccountProviderSettings::default());
 	let accounts = acc_provider.accounts().map_err(|e| format!("{}", e))?;
 	let result = accounts.into_iter()
-		.map(|a| format!("0x{:?}", a))
+		.map(|a| format!("0x{:x}", a))
 		.collect::<Vec<String>>()
 		.join("\n");
 


### PR DESCRIPTION
Fix #8547.

Use LowerHex for stable output.