### PR TITLE
Fix the mio test again

### DIFF
--- a/util/io/src/lib.rs
+++ b/util/io/src/lib.rs
@@ -186,7 +186,12 @@ mod tests {
 	use std::time::Duration;
 	use super::*;
 
+	// Mio's behaviour is too unstable for this test. Sometimes we have to wait a few milliseconds,
+	// sometimes more than 5 seconds for the message to arrive.
+	// Therefore we ignore this test in order to not have spurious failure when running continuous
+	// integration.
 	#[test]
+	#[cfg_attr(feature = "mio", ignore)]
 	fn send_message_to_handler() {
 		struct MyHandler(atomic::AtomicBool);
 
@@ -209,7 +214,7 @@ mod tests {
 
 		service.send_message(MyMessage { data: 5 }).unwrap();
 
-		thread::sleep(Duration::from_secs(5));
+		thread::sleep(Duration::from_secs(1));
 		assert!(handler.0.load(atomic::Ordering::SeqCst));
 	}
 


### PR DESCRIPTION
#8537 introduced this failing test, but didn't change the behaviour.

What happens is that we send a message to a background thread, which is then processed by the mio events loop, and then dispatched to a handler. However for some reason if other unit tests are running simultaneously, it looks like the background thread takes forever to process the message.

cc #8601 
cc @niklasad1 
