### PR TITLE
Use full qualified syntax for itertools::Itertools::flatten

### DIFF
--- a/ethstore/src/accounts_dir/memory.rs
+++ b/ethstore/src/accounts_dir/memory.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashMap;
 use parking_lot::RwLock;
-use itertools::Itertools;
+use itertools;
 use ethkey::Address;
 
 use {SafeAccount, Error};
@@ -30,7 +30,7 @@ pub struct MemoryDirectory {
 
 impl KeyDirectory for MemoryDirectory {
 	fn load(&self) -> Result<Vec<SafeAccount>, Error> {
-		Ok(self.accounts.read().values().cloned().flatten().collect())
+		Ok(itertools::Itertools::flatten(self.accounts.read().values().cloned()).collect())
 	}
 
 	fn update(&self, account: SafeAccount) -> Result<SafeAccount, Error> {


### PR DESCRIPTION
Fix compiling Parity with rust v1.26 warning:

```
warning: a method with this name may be added to the standard library in the future
  --> ethstore/src/accounts_dir/memory.rs:33:45
   |
33 |         Ok(self.accounts.read().values().cloned().flatten().collect())
   |                                                   ^^^^^^^
   |
   = note: #[warn(unstable_name_collision)] on by default
   = warning: once this method is added to the standard library, there will be ambiguity here, which will cause a hard error!
   = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
   = help: call with fully qualified syntax `itertools::Itertools::flatten(...)` to keep using the current method
```