### PR TITLE
Fix BlockReward contract "arithmetic operation overflow"

### DIFF
--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -122,7 +122,13 @@ impl EthereumMachine {
 }
 
 impl EthereumMachine {
-	/// Execute a call as the system address.
+	/// Execute a call as the system address. Block environment information passed to the
+	/// VM is modified to have its gas limit bounded at the upper limit of possible used
+	/// gases including this system call, capped at the maximum value able to be
+	/// represented by U256. This system call modifies the block state, but discards other
+	/// informations. If suicides, logs or refunds happened within the system call, they
+	/// will not be executed or recorded. Gas used by this system call will not be counted
+	/// on the block.
 	pub fn execute_as_system(
 		&self,
 		block: &mut ExecutedBlock,

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -132,7 +132,7 @@ impl EthereumMachine {
 	) -> Result<Vec<u8>, Error> {
 		let env_info = {
 			let mut env_info = block.env_info();
-			env_info.gas_limit = env_info.gas_used + gas;
+			env_info.gas_limit = env_info.gas_used.saturating_add(gas);
 			env_info
 		};
 

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -126,7 +126,7 @@ impl EthereumMachine {
 	/// VM is modified to have its gas limit bounded at the upper limit of possible used
 	/// gases including this system call, capped at the maximum value able to be
 	/// represented by U256. This system call modifies the block state, but discards other
-	/// informations. If suicides, logs or refunds happened within the system call, they
+	/// information. If suicides, logs or refunds happen within the system call, they
 	/// will not be executed or recorded. Gas used by this system call will not be counted
 	/// on the block.
 	pub fn execute_as_system(


### PR DESCRIPTION
For calls to `Machine::execute_as_system`, if `gas` is `max_value`, then it is possible to cause this statement to overflow. This sometimes cause the new block reward contract to panic. Changing it to `saturating_add` would fix that.