### PR TITLE
Use impl Future in the light client RPC helpers

### DIFF
--- a/rpc/src/v1/impls/eth_pubsub.rs
+++ b/rpc/src/v1/impls/eth_pubsub.rs
@@ -199,7 +199,7 @@ impl LightClient for LightFetch {
 	}
 
 	fn logs(&self, filter: EthFilter) -> BoxFuture<Vec<Log>> {
-		LightFetch::logs(self, filter)
+		Box::new(LightFetch::logs(self, filter)) as BoxFuture<_>
 	}
 }
 

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -538,7 +538,7 @@ impl<T: LightChainClient + 'static> Filterable for EthClient<T> {
 	}
 
 	fn logs(&self, filter: EthcoreFilter) -> BoxFuture<Vec<Log>> {
-		self.fetcher().logs(filter)
+		Box::new(self.fetcher().logs(filter)) as BoxFuture<_>
 	}
 
 	fn pending_logs(&self, _block_number: u64, _filter: &EthcoreFilter) -> Vec<Log> {


### PR DESCRIPTION
cc @rphmeier who suggested the change

Modifies the light client RPC helpers to use `impl Future` instead of `BoxFuture`, which theoretically leads to slightly better performances.

More than the possible improvement, this change is nice in order to experiment with `impl Trait` and see its impact in general.

It turns out that the compilation is almost unchanged.
The binary size changed a bit (with `--release` then stripped)
Before: 54.73MB
After: 55.03MB