### PR TITLE
Don't open Browser post-install on Mac, fixes #8194

### DIFF
--- a/mac/post-install.sh
+++ b/mac/post-install.sh
@@ -3,6 +3,4 @@
 test -f /usr/local/libexec/uninstall-parity.sh && /usr/local/libexec/uninstall-parity.sh || true
 killall -9 parity && sleep 5
 su $USER -c "open /Applications/Parity\ Ethereum.app"
-sleep 5
-su $USER -c "open http://127.0.0.1:8180/"
 exit 0


### PR DESCRIPTION
Since we start parity with the UI disabled per default now, opening the browser post installation will show an annoying error message, confusing the user. This patch removes opening the browser to prevent that annoyance.

fixes #8194