### PR TITLE
Fix ancient blocks not downloading

### DIFF
--- a/ethcore/sync/src/blocks.rs
+++ b/ethcore/sync/src/blocks.rs
@@ -266,7 +266,7 @@ impl BlockCollection {
 		}
 	}
 
-	/// Get a valid chain of blocks ordered in descending order and ready for importing into blockchain.
+	/// Get a valid chain of blocks ordered in ascending order and ready for importing into blockchain.
 	pub fn drain(&mut self) -> Vec<BlockAndReceipts> {
 		if self.blocks.is_empty() || self.head.is_none() {
 			return Vec::new();


### PR DESCRIPTION
This fixes ancient blocks not being downloaded.

What happened is that the importing of ancient blocks was asynchronous through a `IoChannel`, and thus checking for the parent being in the chain would fail since the previous wouldn't be imported yet. This is fixed with the `pending_ancient_blocks` `HashSet`.
Then, the importing of blocks would be queued in the `IoChannel` but not unqueued in order, thus leading to the failure of importing blocks, since the parent was needed to compute the total difficulty.
This is fixed by using a proper `VecDequeue` queue in the `IoChannel` that acts as a FIFO.