### PR TITLE
Remove HostInfo::next_nonce

### DIFF
--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -210,6 +210,13 @@ pub struct HostInfo {
 	pub public_endpoint: Option<NodeEndpoint>,
 }
 
+impl HostInfo {
+	fn next_nonce(&mut self) -> H256 {
+		self.nonce = keccak(&self.nonce);
+		self.nonce
+	}
+}
+
 impl HostInfoTrait for HostInfo {
 	fn id(&self) -> &NodeId {
 		self.keys.public()
@@ -217,11 +224,6 @@ impl HostInfoTrait for HostInfo {
 
 	fn secret(&self) -> &Secret {
 		self.keys.secret()
-	}
-
-	fn next_nonce(&mut self) -> H256 {
-		self.nonce = keccak(&self.nonce);
-		self.nonce
 	}
 
 	fn client_version(&self) -> &str {

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -332,8 +332,6 @@ pub trait HostInfo {
 	fn id(&self) -> &NodeId;
 	/// Returns secret key
 	fn secret(&self) -> &Secret;
-	/// Increments and returns connection nonce.
-	fn next_nonce(&mut self) -> H256;
     /// Returns the client version.
 	fn client_version(&self) -> &str;
 }


### PR DESCRIPTION
Another unused method that can be moved out of its trait.