### PR TITLE
parity: disable ancient blocks download by default

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -422,9 +422,9 @@ usage! {
 			"--reserved-only",
 			"Connect only to reserved nodes.",
 
-			FLAG flag_no_ancient_blocks: (bool) = false, or |_| None,
-			"--no-ancient-blocks",
-			"Disable downloading old blocks after snapshot restoration or warp sync.",
+			FLAG flag_ancient_blocks: (bool) = false, or |_| None,
+			"--ancient-blocks",
+			"Enable downloading old blocks after snapshot restoration or warp sync. Turns client into a full node.",
 
 			FLAG flag_no_serve_light: (bool) = false, or |c: &Config| c.network.as_ref()?.no_serve_light.clone(),
 			"--no-serve-light",
@@ -487,7 +487,7 @@ usage! {
 			"--jsonrpc-port=[PORT]",
 			"Specify the port portion of the JSONRPC API server.",
 
-			ARG arg_jsonrpc_interface: (String)  = "local", or |c: &Config| c.rpc.as_ref()?.interface.clone(),
+			ARG arg_jsonrpc_interface: (String) = "local", or |c: &Config| c.rpc.as_ref()?.interface.clone(),
 			"--jsonrpc-interface=[IP]",
 			"Specify the hostname portion of the JSONRPC API server, IP should be an interface's IP address, or all (all interfaces) or local.",
 
@@ -520,7 +520,7 @@ usage! {
 			"--ws-port=[PORT]",
 			"Specify the port portion of the WebSockets server.",
 
-			ARG arg_ws_interface: (String)  = "local", or |c: &Config| c.websockets.as_ref()?.interface.clone(),
+			ARG arg_ws_interface: (String) = "local", or |c: &Config| c.websockets.as_ref()?.interface.clone(),
 			"--ws-interface=[IP]",
 			"Specify the hostname portion of the WebSockets server, IP should be an interface's IP address, or all (all interfaces) or local.",
 
@@ -894,7 +894,11 @@ usage! {
 		["Legacy options"]
 			FLAG flag_warp: (bool) = false, or |_| None,
 			"--warp",
-			"Does nothing; warp sync is enabled by default.",
+			"Does nothing; warp sync is enabled by default. Disable warp sync with --no-warp.",
+
+			FLAG flag_no_ancient_blocks: (bool) = false, or |_| None,
+			"--no-ancient-blocks",
+			"Does nothing; ancient block download is disabled by default. Enable download with --ancient-blocks.",
 
 			FLAG flag_dapps_apis_all: (bool) = false, or |_| None,
 			"--dapps-apis-all",
@@ -1579,7 +1583,7 @@ mod tests {
 			arg_node_key: None,
 			arg_reserved_peers: Some("./path_to_file".into()),
 			flag_reserved_only: false,
-			flag_no_ancient_blocks: false,
+			flag_ancient_blocks: false,
 			flag_no_serve_light: false,
 
 			// -- API and Console Options
@@ -1710,6 +1714,7 @@ mod tests {
 
 			// -- Legacy Options
 			flag_warp: false,
+			flag_no_ancient_blocks: false,
 			flag_geth: false,
 			flag_testnet: false,
 			flag_import_geth_keys: false,

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -163,13 +163,13 @@ impl Configuration {
 					port: ws_conf.port,
 					authfile: authfile,
 				}
-			} else if self.args.cmd_signer_reject  {
+			} else if self.args.cmd_signer_reject {
 				Cmd::SignerReject {
 					id: self.args.arg_signer_reject_id,
 					port: ws_conf.port,
 					authfile: authfile,
 				}
-			} else if self.args.cmd_signer_list  {
+			} else if self.args.cmd_signer_list {
 				Cmd::SignerList {
 					port: ws_conf.port,
 					authfile: authfile,
@@ -212,7 +212,7 @@ impl Configuration {
 			};
 			Cmd::Account(account_cmd)
 		} else if self.args.flag_import_geth_keys {
-        	let account_cmd = AccountCmd::ImportFromGeth(
+			let account_cmd = AccountCmd::ImportFromGeth(
 				ImportFromGethAccounts {
 					spec: spec,
 					to: dirs.keys,
@@ -395,7 +395,7 @@ impl Configuration {
 				custom_bootnodes: self.args.arg_bootnodes.is_some(),
 				no_periodic_snapshot: self.args.flag_no_periodic_snapshot,
 				check_seal: !self.args.flag_no_seal_check,
-				download_old_blocks: !self.args.flag_no_ancient_blocks,
+				download_old_blocks: self.args.flag_ancient_blocks,
 				verifier_settings: verifier_settings,
 				serve_light: !self.args.flag_no_serve_light,
 				light: self.args.flag_light,
@@ -1456,10 +1456,10 @@ mod tests {
 			hosts: Some(vec![]),
 			info_page_only: true,
 		}, LogConfig {
-            color: true,
-            mode: None,
-            file: None,
-        } ));
+			color: true,
+			mode: None,
+			file: None,
+		} ));
 	}
 
 	#[test]
@@ -1646,17 +1646,17 @@ mod tests {
 
 		// when
 		let conf1 = parse(&["parity", "-j",
-						 "--jsonrpc-port", "8000",
-						 "--jsonrpc-interface", "all",
-						 "--jsonrpc-cors", "*",
-						 "--jsonrpc-apis", "web3,eth"
-						 ]);
+							"--jsonrpc-port", "8000",
+							"--jsonrpc-interface", "all",
+							"--jsonrpc-cors", "*",
+							"--jsonrpc-apis", "web3,eth"
+						]);
 		let conf2 = parse(&["parity", "--rpc",
-						  "--rpcport", "8000",
-						  "--rpcaddr", "all",
-						  "--rpccorsdomain", "*",
-						  "--rpcapi", "web3,eth"
-						  ]);
+							"--rpcport", "8000",
+							"--rpcaddr", "all",
+							"--rpccorsdomain", "*",
+							"--rpcapi", "web3,eth"
+						]);
 
 		// then
 		assert(conf1);

--- a/parity/deprecated.rs
+++ b/parity/deprecated.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -39,6 +39,10 @@ pub fn find_deprecated(args: &Args) -> Vec<Deprecated> {
 
 	if args.flag_warp {
 		result.push(Deprecated::DoesNothing("--warp"));
+	}
+
+	if args.flag_no_ancient_blocks {
+		result.push(Deprecated::DoesNothing("--no-ancient-blocks"));
 	}
 
 	if args.flag_jsonrpc {
@@ -122,6 +126,7 @@ mod tests {
 		assert_eq!(find_deprecated(&{
 			let mut args = Args::default();
 			args.flag_warp = true;
+			args.flag_no_ancient_blocks = true;
 			args.flag_jsonrpc = true;
 			args.flag_rpc = true;
 			args.flag_jsonrpc_off = true;
@@ -141,6 +146,7 @@ mod tests {
 			args
 		}), vec![
 			Deprecated::DoesNothing("--warp"),
+			Deprecated::DoesNothing("--no-ancient-blocks"),
 			Deprecated::DoesNothing("--jsonrpc"),
 			Deprecated::DoesNothing("--rpc"),
 			Deprecated::Replaced("--jsonrpc-off", "--no-jsonrpc"),


### PR DESCRIPTION
putting this up for discussion as suggested by @folsen

- adds `--ancient-blocks` parameter (disabled by default)
- disables ancient blocks download by default
- move `--no-ancient-blocks` parameter to legacy (`Deprecated::DoesNothing`)
- cleans up some whitespaces (can't we automatically detect issues somehow?)

open questions raised

- shall we really default to a node without full block history
- are there any security implications