### PR TITLE
Remove NetworkService::config()

### DIFF
--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -145,7 +145,8 @@ impl InformantData for FullNodeInformantData {
 		let (importing, sync_info) = match (self.sync.as_ref(), self.net.as_ref()) {
 			(Some(sync), Some(net)) => {
 				let status = sync.status();
-				let net_config = net.network_config();
+				let num_peers_range = net.num_peers_range();
+				debug_assert!(num_peers_range.end > num_peers_range.start);
 
 				cache_sizes.insert("sync", status.mem_used);
 
@@ -154,7 +155,7 @@ impl InformantData for FullNodeInformantData {
 					last_imported_block_number: status.last_imported_block_number.unwrap_or(chain_info.best_block_number),
 					last_imported_old_block_number: status.last_imported_old_block_number,
 					num_peers: status.num_peers,
-					max_peers: status.current_max_peers(net_config.min_peers, net_config.max_peers),
+					max_peers: status.current_max_peers(num_peers_range.start, num_peers_range.end - 1),
 					snapshot_sync: status.is_snapshot_syncing(),
 				}))
 			}

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -212,13 +212,14 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 
 	fn net_peers(&self) -> Result<Peers> {
 		let sync_status = self.sync.status();
-		let net_config = self.net.network_config();
+		let num_peers_range = self.net.num_peers_range();
+		debug_assert!(num_peers_range.end > num_peers_range.start);
 		let peers = self.sync.peers().into_iter().map(Into::into).collect();
 
 		Ok(Peers {
 			active: sync_status.num_active_peers,
 			connected: sync_status.num_peers,
-			max: sync_status.current_max_peers(net_config.min_peers, net_config.max_peers),
+			max: sync_status.current_max_peers(num_peers_range.start, num_peers_range.end - 1),
 			peers: peers
 		})
 	}

--- a/rpc/src/v1/tests/mocked/manage_network.rs
+++ b/rpc/src/v1/tests/mocked/manage_network.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use sync::{ManageNetwork, NetworkConfiguration};
+use std::ops::Range;
+use sync::ManageNetwork;
 use self::ethcore_network::{ProtocolId, NetworkContext};
 
 extern crate ethcore_network;
@@ -29,6 +30,6 @@ impl ManageNetwork for TestManageNetwork {
 	fn add_reserved_peer(&self, _peer: String) -> Result<(), String> { Ok(()) }
 	fn start_network(&self) {}
 	fn stop_network(&self) {}
-	fn network_config(&self) -> NetworkConfiguration { NetworkConfiguration::new_local() }
+	fn num_peers_range(&self) -> Range<u32> { 25 .. 51 }
 	fn with_proto_context(&self, _: ProtocolId, _: &mut FnMut(&NetworkContext)) { }
 }

--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -215,7 +215,7 @@ fn execute<S, I>(command: I) -> Result<(), Error> where I: IntoIterator<Item=S>,
 	let network = devp2p::NetworkService::new(net::NetworkConfiguration::new_local(), None)?;
 
 	// Start network service
-	network.start()?;
+	network.start().map_err(|(err, _)| err)?;
 
 	// Attach whisper protocol to the network service
 	network.register_protocol(whisper_network_handler.clone(), whisper::net::PROTOCOL_ID,


### PR DESCRIPTION
More preparation for the libp2p backend.

Once we switch to devp2p and libp2p together, it won't really be possible to query the `NetworkConfiguration` anymore.
This PR therefore removes `config()` in favour of `num_peers_range()`, which is common to both devp2p and libp2p.
