### PR TITLE
Fix PoW blockchains sealing notifications in chain_new_blocks

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2181,7 +2181,7 @@ impl ImportSealedBlock for Client {
 			route
 		};
 		let route = ChainRoute::from([route].as_ref());
-		self.importer.miner.chain_new_blocks(self, &[h.clone()], &[], route.enacted(), route.retracted(), true);
+		self.importer.miner.chain_new_blocks(self, &[h.clone()], &[], route.enacted(), route.retracted(), self.engine.seals_internally().is_some());
 		self.notify(|notify| {
 			notify.new_blocks(
 				vec![h.clone()],


### PR DESCRIPTION
On master, PoW mining is broken for me. Using any dummy ethash spec and `ethminer`, I would be stuck on mining the same block. `eth` APIs all returns the new best block number except `getWork`, which returns the block to be sealed at the time when I started Parity. This PR fixes this problem.

It looks to be that the issue is when we import a sealed block, for engines that require external sealing, we still need immediate resealing.