### PR TITLE
Shutdown the Snapshot Service early

### DIFF
--- a/ethcore/service/src/service.rs
+++ b/ethcore/service/src/service.rs
@@ -29,7 +29,7 @@ use sync::PrivateTxHandler;
 use ethcore::client::{Client, ClientConfig, ChainNotify, ClientIoMessage};
 use ethcore::miner::Miner;
 use ethcore::snapshot::service::{Service as SnapshotService, ServiceParams as SnapServiceParams};
-use ethcore::snapshot::{RestorationStatus};
+use ethcore::snapshot::{SnapshotService as _SnapshotService, RestorationStatus};
 use ethcore::spec::Spec;
 use ethcore::account_provider::AccountProvider;
 
@@ -168,6 +168,11 @@ impl ClientService {
 
 	/// Get a handle to the database.
 	pub fn db(&self) -> Arc<KeyValueDB> { self.database.clone() }
+
+	/// Shutdown the Client Service
+	pub fn shutdown(&self) {
+		self.snapshot.shutdown();
+	}
 }
 
 /// IO interface for the Client handler

--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -743,6 +743,10 @@ impl SnapshotService for Service {
 			trace!("Error sending snapshot service message: {:?}", e);
 		}
 	}
+
+	fn shutdown(&self) {
+		self.abort_restore();
+	}
 }
 
 impl Drop for Service {

--- a/ethcore/src/snapshot/traits.rs
+++ b/ethcore/src/snapshot/traits.rs
@@ -54,4 +54,7 @@ pub trait SnapshotService : Sync + Send {
 	/// Feed a raw block chunk to the service to be processed asynchronously.
 	/// no-op if currently restoring.
 	fn restore_block_chunk(&self, hash: H256, chunk: Bytes);
+
+	/// Shutdown the Snapshot Service by aborting any ongoing restore
+	fn shutdown(&self);
 }


### PR DESCRIPTION
This PR fixes an issue where the node would not quit if previously downloaded chunks would still be importing by introducing `shutdown` methods to the Client Service and the Snapshot Service.