### PR TITLE
parity: improve cli help and logging

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -424,7 +424,7 @@ usage! {
 
 			FLAG flag_no_ancient_blocks: (bool) = false, or |_| None,
 			"--no-ancient-blocks",
-			"Disable downloading old blocks after snapshot restoration or warp sync.",
+			"Disable downloading old blocks after snapshot restoration or warp sync. Not recommended.",
 
 			FLAG flag_no_serve_light: (bool) = false, or |c: &Config| c.network.as_ref()?.no_serve_light.clone(),
 			"--no-serve-light",
@@ -894,7 +894,7 @@ usage! {
 		["Legacy options"]
 			FLAG flag_warp: (bool) = false, or |_| None,
 			"--warp",
-			"Does nothing; warp sync is enabled by default.",
+			"Does nothing; warp sync is enabled by default. Use --no-warp to disable.",
 
 			FLAG flag_dapps_apis_all: (bool) = false, or |_| None,
 			"--dapps-apis-all",

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// Copyright 2015-2018 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify
@@ -303,13 +303,13 @@ impl<T: InformantData> Informant<T> {
 						paint(White.bold(), format!("{}", chain_info.best_block_hash)),
 						if self.target.executes_transactions() {
 							format!("{} blk/s {} tx/s {} Mgas/s",
-								paint(Yellow.bold(), format!("{:4}", (client_report.blocks_imported * 1000) as u64 / elapsed.as_milliseconds())),
-								paint(Yellow.bold(), format!("{:4}", (client_report.transactions_applied * 1000) as u64 / elapsed.as_milliseconds())),
-								paint(Yellow.bold(), format!("{:3}", (client_report.gas_processed / From::from(elapsed.as_milliseconds() * 1000)).low_u64()))
+								paint(Yellow.bold(), format!("{:5.2}", (client_report.blocks_imported * 1000) as f64 / elapsed.as_milliseconds() as f64)),
+								paint(Yellow.bold(), format!("{:6.1}", (client_report.transactions_applied * 1000) as f64 / elapsed.as_milliseconds() as f64)),
+								paint(Yellow.bold(), format!("{:4}", (client_report.gas_processed / From::from(elapsed.as_milliseconds() * 1000)).low_u64()))
 							)
 						} else {
 							format!("{} hdr/s",
-								paint(Yellow.bold(), format!("{:4}", (client_report.blocks_imported * 1000) as u64 / elapsed.as_milliseconds()))
+								paint(Yellow.bold(), format!("{:6.1}", (client_report.blocks_imported * 1000) as f64 / elapsed.as_milliseconds() as f64))
 							)
 						},
 						paint(Green.bold(), format!("{:5}", queue_info.unverified_queue_size)),
@@ -350,8 +350,8 @@ impl<T: InformantData> Informant<T> {
 				Some(ref rpc_stats) => format!(
 					"RPC: {} conn, {} req/s, {} µs",
 					paint(Blue.bold(), format!("{:2}", rpc_stats.sessions())),
-					paint(Blue.bold(), format!("{:2}", rpc_stats.requests_rate())),
-					paint(Blue.bold(), format!("{:3}", rpc_stats.approximated_roundtrip())),
+					paint(Blue.bold(), format!("{:4}", rpc_stats.requests_rate())),
+					paint(Blue.bold(), format!("{:4}", rpc_stats.approximated_roundtrip())),
 				),
 				_ => String::new(),
 			},


### PR DESCRIPTION
- adds notice that disabling ancient blocks is not recommended
- adds decimals to sync logs to be more verbose on slow progess

.

    2018-05-19 13:46:10  Syncing #5502236 0xd8c1…a4a1   0.00 blk/s    0.0 tx/s    0 Mgas/s      0+    0 Qed  #5502236   20/25 peers   106 KiB chain 99 MiB db 0 bytes queue 6 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:46:20  Syncing #5502244 0xc46d…21e6   0.81 blk/s  149.4 tx/s    5 Mgas/s      0+  306 Qed  #5502555   22/25 peers   479 KiB chain 102 MiB db 36 MiB queue 41 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:46:33  Syncing #5502261 0x93d5…eeb6   1.70 blk/s  343.2 tx/s   11 Mgas/s    677+  437 Qed  #5503995   23/25 peers   1 MiB chain 103 MiB db 68 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:46:40  Syncing #5502273 0x2f1b…7f8e   1.58 blk/s  255.3 tx/s    8 Mgas/s    682+ 1033 Qed  #5503995   23/25 peers   2 MiB chain 104 MiB db 135 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:46:50  Syncing #5502283 0x7e46…a33e   1.00 blk/s  183.2 tx/s    7 Mgas/s    186+ 1517 Qed  #5503995   24/25 peers   2 MiB chain 105 MiB db 179 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:47:00  Syncing #5502291 0xda8d…5b0f   0.70 blk/s  113.5 tx/s    4 Mgas/s      0+ 1704 Qed  #5503995   25/25 peers   3 MiB chain 105 MiB db 195 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:47:10  Syncing #5502309 0xbcf8…7d6a   1.90 blk/s  316.4 tx/s   12 Mgas/s      0+ 1684 Qed  #5503995   25/25 peers   3 MiB chain 105 MiB db 193 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:47:20  Syncing #5502333 0xba92…ec73   2.40 blk/s  328.8 tx/s   16 Mgas/s      0+ 1660 Qed  #5503995   25/25 peers   5 MiB chain 106 MiB db 190 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:47:30  Syncing #5502358 0x4a07…34dd   2.50 blk/s  357.7 tx/s   16 Mgas/s      0+ 1636 Qed  #5503995   25/25 peers   5 MiB chain 107 MiB db 187 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:47:40  Syncing #5502383 0x6f93…ce2c   2.50 blk/s  455.4 tx/s   16 Mgas/s      0+ 1608 Qed  #5503995   25/25 peers   6 MiB chain 108 MiB db 183 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:47:50  Syncing #5502411 0x1536…6154   2.80 blk/s  422.5 tx/s   20 Mgas/s      0+ 1580 Qed  #5503995   24/25 peers   6 MiB chain 108 MiB db 180 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:48:00  Syncing #5502437 0xa72d…494b   2.60 blk/s  418.5 tx/s   17 Mgas/s      0+ 1556 Qed  #5503995   24/25 peers   6 MiB chain 109 MiB db 177 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
    2018-05-19 13:48:10  Syncing #5502461 0x07e0…5d86   2.40 blk/s  266.5 tx/s   15 Mgas/s      0+ 1532 Qed  #5503995   25/25 peers   6 MiB chain 102 MiB db 175 MiB queue 45 MiB sync  RPC:  0 conn,    0 req/s,    0 µs
