### PR TITLE
Remove the error when stopping the network

### DIFF
--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -474,7 +474,7 @@ impl ChainNotify for EthSync {
 
 	fn stop(&self) {
 		self.eth_handler.snapshot_service.abort_restore();
-		self.network.stop().unwrap_or_else(|e| warn!("Error stopping network: {:?}", e));
+		self.network.stop();
 	}
 
 	fn broadcast(&self, message_type: ChainMessageType) {
@@ -832,9 +832,7 @@ impl ManageNetwork for LightSync {
 
 	fn stop_network(&self) {
 		self.proto.abort();
-		if let Err(e) = self.network.stop() {
-			warn!("Error stopping network: {}", e);
-		}
+		self.network.stop();
 	}
 
 	fn network_config(&self) -> NetworkConfiguration {

--- a/util/io/src/service_mio.rs
+++ b/util/io/src/service_mio.rs
@@ -162,11 +162,13 @@ impl<Message> IoContext<Message> where Message: Send + Sync + 'static {
 	}
 
 	/// Unregister current IO handler.
-	pub fn unregister_handler(&self) -> Result<(), IoError> {
-		self.channel.send_io(IoMessage::RemoveHandler {
+	pub fn unregister_handler(&self) {
+		// `send_io` returns an error only if the channel is closed, which means that the
+		// background thread is no longer running. Therefore the handler is no longer active and
+		// can be considered as unregistered.
+		let _ = self.channel.send_io(IoMessage::RemoveHandler {
 			handler_id: self.handler,
-		})?;
-		Ok(())
+		});
 	}
 
 }

--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -396,7 +396,7 @@ impl Host {
 		format!("{}", Node::new(info.id().clone(), info.local_endpoint.clone()))
 	}
 
-	pub fn stop(&self, io: &IoContext<NetworkIoMessage>) -> Result<(), Error> {
+	pub fn stop(&self, io: &IoContext<NetworkIoMessage>) {
 		self.stopping.store(true, AtomicOrdering::Release);
 		let mut to_kill = Vec::new();
 		for e in self.sessions.read().iter() {
@@ -408,8 +408,7 @@ impl Host {
 			trace!(target: "network", "Disconnecting on shutdown: {}", p);
 			self.kill_connection(p, io, true);
 		}
-		io.unregister_handler()?;
-		Ok(())
+		io.unregister_handler();
 	}
 
 	/// Get all connected peers.

--- a/util/network-devp2p/src/service.rs
+++ b/util/network-devp2p/src/service.rs
@@ -125,15 +125,14 @@ impl NetworkService {
 		Ok(())
 	}
 
-	/// Stop network IO
-	pub fn stop(&self) -> Result<(), Error> {
+	/// Stop network IO.
+	pub fn stop(&self) {
 		let mut host = self.host.write();
 		if let Some(ref host) = *host {
 			let io = IoContext::new(self.io_service.channel(), 0); //TODO: take token id from host
-			host.stop(&io)?;
+			host.stop(&io);
 		}
 		*host = None;
-		Ok(())
 	}
 
 	/// Get a list of all connected peers by id.

--- a/util/network-devp2p/tests/tests.rs
+++ b/util/network-devp2p/tests/tests.rs
@@ -112,7 +112,7 @@ fn net_start_stop() {
 	let config = NetworkConfiguration::new_local();
 	let service = NetworkService::new(config, None).unwrap();
 	service.start().unwrap();
-	service.stop().unwrap();
+	service.stop();
 	service.start().unwrap();
 }
 


### PR DESCRIPTION
In preparation for libp2p again.
cc #8193 

Removes the error from `unregister_handler`, and propagates the change so that `stop` can no longer error.
