### PR TITLE
Remove HostInfo::client_version() and secret()

### DIFF
--- a/util/network-devp2p/src/handshake.rs
+++ b/util/network-devp2p/src/handshake.rs
@@ -26,7 +26,8 @@ use node_table::NodeId;
 use io::{IoContext, StreamToken};
 use ethkey::{KeyPair, Public, Secret, recover, sign, Generator, Random};
 use ethkey::crypto::{ecdh, ecies};
-use network::{Error, ErrorKind, HostInfo};
+use network::{Error, ErrorKind, HostInfo as HostInfoTrait};
+use host::HostInfo;
 
 #[derive(PartialEq, Eq, Debug)]
 enum HandshakeState {

--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -215,19 +215,19 @@ impl HostInfo {
 		self.nonce = keccak(&self.nonce);
 		self.nonce
 	}
+
+	pub(crate) fn client_version(&self) -> &str {
+		&self.config.client_version
+	}
+
+	pub(crate) fn secret(&self) -> &Secret {
+		self.keys.secret()
+	}
 }
 
 impl HostInfoTrait for HostInfo {
 	fn id(&self) -> &NodeId {
 		self.keys.public()
-	}
-
-	fn secret(&self) -> &Secret {
-		self.keys.secret()
-	}
-
-	fn client_version(&self) -> &str {
-		&self.config.client_version
 	}
 }
 

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -330,10 +330,6 @@ impl<'a, T> NetworkContext for &'a T where T: ?Sized + NetworkContext {
 pub trait HostInfo {
 	/// Returns public key
 	fn id(&self) -> &NodeId;
-	/// Returns secret key
-	fn secret(&self) -> &Secret;
-    /// Returns the client version.
-	fn client_version(&self) -> &str;
 }
 
 /// Network IO protocol handler. This needs to be implemented for each new subprotocol.


### PR DESCRIPTION
These methods are only used from within `devp2p` and thus need not be part of the trait.

cc #8193 