### PR TITLE
Set the request index to that of the current request

### DIFF
--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -129,9 +129,8 @@ impl LightFetch {
 				}
 			}
 			BlockId::Hash(h) => {
-				reqs.push(request::HeaderByHash(h.into()).into());
-
 				let idx = reqs.len();
+				reqs.push(request::HeaderByHash(h.into()).into());
 				Ok(HeaderRef::Unresolved(idx, h.into()))
 			}
 			_ => Err(errors::unknown_block()) // latest, earliest, and pending will have all already returned.

--- a/rpc/src/v1/tests/eth.rs
+++ b/rpc/src/v1/tests/eth.rs
@@ -204,6 +204,18 @@ fn eth_get_block() {
 	assert_eq!(tester.handler.handle_request_sync(req_block).unwrap(), res_block);
 }
 
+#[test]
+fn eth_get_block_by_hash() {
+	let chain = extract_chain!("BlockchainTests/bcGasPricerTest/RPC_API_Test");
+	let tester = EthTester::from_chain(&chain);
+
+	// We're looking for block number 4 from "RPC_API_Test_Frontier"
+	let req_block = r#"{"method":"eth_getBlockByHash","params":["0x9c9bdab4cb53fd834e790b13545597f026494d42112e84c0aca9dd6bcc545295",false],"id":1,"jsonrpc":"2.0"}"#;
+
+	let res_block = r#"{"jsonrpc":"2.0","result":{"author":"0x8888f1f195afa192cfee860698584c030f4c9db1","difficulty":"0x200c0","extraData":"0x","gasLimit":"0x1dd8112","gasUsed":"0x5458","hash":"0x9c9bdab4cb53fd834e790b13545597f026494d42112e84c0aca9dd6bcc545295","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x8888f1f195afa192cfee860698584c030f4c9db1","mixHash":"0xaddea8d25bb0f955fa6c1d58d74ab8a3fec99d37943e2a261e3b12f97d6bff7c","nonce":"0x8e18bed16d5a88da","number":"0x4","parentHash":"0x2cbf4fc930c5b4c87598f43fc8eb26dccdab2f58a7d0d3ca92ec60a5444a330e","receiptsRoot":"0x7ed8026cf72ed0e98e6fd53ab406e51ffd34397d9da0052494ff41376fda7b5f","sealFields":["0xa0addea8d25bb0f955fa6c1d58d74ab8a3fec99d37943e2a261e3b12f97d6bff7c","0x888e18bed16d5a88da"],"sha3Uncles":"0x75cc08a7cb2cf8081446659fecb2633fb6b922d26edd59bd2272b1f5cae1c78b","size":"0x661","stateRoot":"0x68805721294e365020aca15ed56c360d9dc2cf03cbeff84c9b84b8aed023bfb5","timestamp":"0x59d662ff","totalDifficulty":"0xa0180","transactions":["0xb094b9dc356dbb8b256402c6d5709288066ad6a372c90c9c516f14277545fd58"],"transactionsRoot":"0x97a593d8d7e15b57f5c6bb25bc6c325463ef99f874bc08a78656c3ab5cb23262","uncles":["0xa1e9c9ecd2af999e0723aae1dc55dd9789ca618e0b34badcc8ac7d9a3dad3af2","0x81d429b6b6635214a2b0f976cc4b2ed49808140d6bede50129bc10d22ac9249e"]},"id":1}"#;
+	assert_eq!(tester.handler.handle_request_sync(req_block).unwrap(), res_block);
+}
+
 // a frontier-like test with an expanded gas limit and balance on known account.
 const TRANSACTION_COUNT_SPEC: &'static [u8] = br#"{
 	"name": "Frontier (Test)",


### PR DESCRIPTION
When setting up the chain of (two) requests to look up a block by hash, the second need to refer to the first. This fixes an issue where the back ref was set to the subsequent request, not the current one. When the [requests are executed](https://github.com/paritytech/parity/blob/master/ethcore/light/src/on_demand/mod.rs#L313) we loop through them in order and ensure the requests that should produce headers all match up. We do this by index so they better be right or we [panic](https://github.com/paritytech/parity/issues/8678).

In other words: off by one.

closes #8678