### PR TITLE
Allow users to specify interface to listen to via CLI

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -438,6 +438,10 @@ usage! {
 			"--port=[PORT]",
 			"Override the port on which the node should listen.",
 
+			ARG arg_interface: (String)  = "all", or |c: &Config| c.network.as_ref()?.interface.clone(),
+			"--interface=[IP]",
+			"Network interfaces. Valid values are 'all', 'local' or the ip of the interface you want parity to listen to.",
+
 			ARG arg_min_peers: (Option<u16>) = None, or |c: &Config| c.network.as_ref()?.min_peers.clone(),
 			"--min-peers=[NUM]",
 			"Try to maintain at least NUM peers.",
@@ -1119,6 +1123,7 @@ struct Network {
 	warp: Option<bool>,
 	warp_barrier: Option<u64>,
 	port: Option<u16>,
+	interface: Option<String>,
 	min_peers: Option<u16>,
 	max_peers: Option<u16>,
 	snapshot_peers: Option<u16>,
@@ -1567,6 +1572,7 @@ mod tests {
 			// -- Networking Options
 			flag_no_warp: false,
 			arg_port: 30303u16,
+			arg_interface: "all".into(),
 			arg_min_peers: Some(25u16),
 			arg_max_peers: Some(50u16),
 			arg_max_pending_peers: 64u16,
@@ -1823,6 +1829,7 @@ mod tests {
 				warp: Some(false),
 				warp_barrier: None,
 				port: None,
+				interface: None,
 				min_peers: Some(10),
 				max_peers: Some(20),
 				max_pending_peers: Some(30),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -767,7 +767,7 @@ impl Configuration {
 
 	fn net_addresses(&self) -> Result<(SocketAddr, Option<SocketAddr>), String> {
 		let port = self.args.arg_ports_shift + self.args.arg_port;
-		let listen_address = SocketAddr::new("0.0.0.0".parse().unwrap(), port);
+		let listen_address = SocketAddr::new(self.interface(&self.args.arg_interface).parse().unwrap(), port);
 		let public_address = if self.args.arg_nat.starts_with("extip:") {
 			let host = &self.args.arg_nat[6..];
 			let host = host.parse().map_err(|_| format!("Invalid host given with `--nat extip:{}`", host))?;


### PR DESCRIPTION
Adds the `--interface=` command line paramter to enable users to specify the 
network interface for p2p connections.

fixes #7642