### PR TITLE
Fix compilation error on nightly rust

### DIFF
--- a/util/network-devp2p/src/service.rs
+++ b/util/network-devp2p/src/service.rs
@@ -32,7 +32,7 @@ impl IoHandler<NetworkIoMessage> for HostHandler {
 		if let NetworkIoMessage::NetworkStarted(ref public_url) = *message {
 			let mut url = self.public_url.write();
 			if url.as_ref().map_or(true, |uref| uref != public_url) {
-				info!(target: "network", "Public node URL: {}", Colour::White.bold().paint(public_url.as_ref()));
+				info!(target: "network", "Public node URL: {}", Colour::White.bold().paint(AsRef::<str>::as_ref(public_url)));
 			}
 			*url = Some(public_url.to_owned());
 		}


### PR DESCRIPTION
On nightly rust passing `public_url` works but that breaks on stable. This works for both.