### PR TITLE
ethcore-sync: fix connection to peers behind chain fork block

### DIFF
--- a/ethcore/sync/src/chain/mod.rs
+++ b/ethcore/sync/src/chain/mod.rs
@@ -294,6 +294,8 @@ pub enum BlockSet {
 pub enum ForkConfirmation {
 	/// Fork block confirmation pending.
 	Unconfirmed,
+	/// Peer's chain is too short to confirm the fork.
+	TooShort,
 	/// Fork is confirmed.
 	Confirmed,
 }


### PR DESCRIPTION
We're currently not connecting to any peers that are behind the chain's fork block (#1920000 for foundation). This is a regression introduced recently in #8543.

This PR reverts to the previous behavior, where we still accept connections from/to an unconfirmed peer. This behavior is guarded against by `PeerInfo#can_sync()` where we'll make sure that the given peer has confirmed the fork header before we try to sync from him.