### PR TITLE
Ease tiny-keccak version requirements (1.4.1 -> 1.4)

### DIFF
--- a/util/hash/Cargo.toml
+++ b/util/hash/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 ethereum-types = "0.3"
-tiny-keccak = "1.4.1"
+tiny-keccak = "1.4"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
this should help with issues like [that one](https://travis-ci.org/paritytech/polkadot/builds/385095222?utm_source=github_status&utm_medium=notification)