### PR TITLE
Remove unused function new_pow_test_spec

### DIFF
--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -923,11 +923,6 @@ impl Spec {
 	pub fn new_validator_multi() -> Self {
 		load_bundled!("validator_multi")
 	}
-
-	/// Create a new spec for a PoW chain
-	pub fn new_pow_test_spec() -> Self {
-		load_bundled!("ethereum/olympic")
-	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The function `new_pow_test_spec` is not used anywhere. And from the naming convention, `olympic` is a chain spec rather than a test spec.