### PR TITLE
A more helpful Error message when we can't handshake because of too many open files

### DIFF
--- a/util/network/src/error.rs
+++ b/util/network/src/error.rs
@@ -141,6 +141,12 @@ error_chain! {
 			description("Packet is too large"),
 			display("Packet is too large"),
 		}
+
+		#[doc = "IO Failed because we ran over resource limits"]
+		TooManyOpenFiles (comment: String) {
+			description("Too many open files."),
+			display("Too many open files; {}. Check your resource limits and restart parity!", comment),
+		}
 	}
 }
 


### PR DESCRIPTION
Attemps to fix #6791 by providing a better error message when the handshake fails because
of limited resources given by the system around.