### PR TITLE
Custom Error Messages on ENFILE and EMFILE IO Errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "ethereum-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
  "ipnetwork 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1",
  "snappy 0.1.0 (git+https://github.com/paritytech/rust-snappy)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
 name = "ethcore-network"
 version = "1.12.0"
 dependencies = [
+ "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-crypto 0.1.0",
  "ethcore-io 1.12.0",

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -16,3 +16,7 @@ ipnetwork = "0.12.6"
 rlp = { path = "../rlp" }
 libc = "0.2.7"
 snappy = { git = "https://github.com/paritytech/rust-snappy" }
+
+
+[dev-dependencies]
+assert_matches = "1.2"

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -14,7 +14,7 @@ ethereum-types = "0.3"
 ethkey = { path = "../../ethkey" }
 ipnetwork = "0.12.6"
 rlp = { path = "../rlp" }
-libc = "0.2.7"
+libc = "0.2"
 snappy = { git = "https://github.com/paritytech/rust-snappy" }
 
 

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -14,4 +14,5 @@ ethereum-types = "0.3"
 ethkey = { path = "../../ethkey" }
 ipnetwork = "0.12.6"
 rlp = { path = "../rlp" }
+libc = "0.2.7"
 snappy = { git = "https://github.com/paritytech/rust-snappy" }

--- a/util/network/src/error.rs
+++ b/util/network/src/error.rs
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{io, net, fmt};
+use libc::{ENFILE, EMFILE};
 use io::IoError;
 use {rlp, ethkey, crypto, snappy};
 
@@ -83,7 +84,6 @@ impl fmt::Display for DisconnectReason {
 error_chain! {
 	foreign_links {
 		SocketIo(IoError) #[doc = "Socket IO error."];
-		Io(io::Error) #[doc = "Error concerning the Rust standard library's IO subsystem."];
 		Decompression(snappy::InvalidInput) #[doc = "Decompression error."];
 	}
 
@@ -141,6 +141,34 @@ error_chain! {
 			description("Packet is too large"),
 			display("Packet is too large"),
 		}
+
+		#[doc = "We've reached system resource limits for this process"]
+		ProcessTooManyFiles {
+			description("Too many open files in process."),
+			display("Too many open files in this process. Check your resource limits and restart parity"),
+		}
+
+		#[doc = "We've reached system wide resource limits"]
+		SystemTooManyFiles {
+			description("Too many open files on system."),
+			display("Too many open files on system. Consider closing some processes/release some file handlers or increas the system-wide resource limits and restart parity."),
+		}
+
+		#[doc = "An unknown IO error occurred."]
+		Io(err: io::Error) {
+			description("IO Error"),
+			display("We've encoutered an IO Error: {:}", err),
+		}
+	}
+}
+
+impl From<::std::io::Error> for Error {
+	fn from(err: ::std::io::Error) -> Self {
+		match err.raw_os_error() {
+			Some(ENFILE) => ErrorKind::ProcessTooManyFiles.into(),
+			Some(EMFILE) => ErrorKind::SystemTooManyFiles.into(),
+			_ => Error::from_kind(ErrorKind::Io(err))
+		}
 	}
 }
 
@@ -190,4 +218,33 @@ fn test_errors() {
 		ErrorKind::Auth => {},
 		_ => panic!("Unexpected error"),
 	}
+}
+
+#[test]
+fn test_io_errors() {
+	use libc::{EMFILE, ENFILE};
+
+	let en_file_error = io::Error::from_raw_os_error(ENFILE);
+
+	match *<Error as From<io::Error>>::from(en_file_error).kind() {
+		ErrorKind::ProcessTooManyFiles => {},
+		_ => panic!("Unexpected error"),
+	}
+
+
+	let em_file_error = io::Error::from_raw_os_error(EMFILE);
+
+	match *<Error as From<io::Error>>::from(em_file_error).kind() {
+		ErrorKind::SystemTooManyFiles => {},
+		_ => panic!("Unexpected error"),
+	}
+
+
+	let usual_error = io::Error::from_raw_os_error(0);
+
+	match *<Error as From<io::Error>>::from(usual_error).kind() {
+		ErrorKind::Io(_) => {},
+		_ => panic!("Unexpected error"),
+	}
+
 }

--- a/util/network/src/error.rs
+++ b/util/network/src/error.rs
@@ -142,13 +142,13 @@ error_chain! {
 			display("Packet is too large"),
 		}
 
-		#[doc = "We've reached system resource limits for this process"]
+		#[doc = "Reached system resource limits for this process"]
 		ProcessTooManyFiles {
 			description("Too many open files in process."),
 			display("Too many open files in this process. Check your resource limits and restart parity"),
 		}
 
-		#[doc = "We've reached system wide resource limits"]
+		#[doc = "Reached system wide resource limits"]
 		SystemTooManyFiles {
 			description("Too many open files on system."),
 			display("Too many open files on system. Consider closing some processes/release some file handlers or increas the system-wide resource limits and restart parity."),
@@ -157,13 +157,13 @@ error_chain! {
 		#[doc = "An unknown IO error occurred."]
 		Io(err: io::Error) {
 			description("IO Error"),
-			display("We've encoutered an IO Error: {:}", err),
+			display("Unexpected IO error: {}", err),
 		}
 	}
 }
 
-impl From<::std::io::Error> for Error {
-	fn from(err: ::std::io::Error) -> Self {
+impl From<io::Error> for Error {
+	fn from(err: io::Error) -> Self {
 		match err.raw_os_error() {
 			Some(ENFILE) => ErrorKind::ProcessTooManyFiles.into(),
 			Some(EMFILE) => ErrorKind::SystemTooManyFiles.into(),

--- a/util/network/src/error.rs
+++ b/util/network/src/error.rs
@@ -224,27 +224,21 @@ fn test_errors() {
 fn test_io_errors() {
 	use libc::{EMFILE, ENFILE};
 
-	let en_file_error = io::Error::from_raw_os_error(ENFILE);
+	assert_matches!(
+		<Error as From<io::Error>>::from(
+			io::Error::from_raw_os_error(ENFILE)
+			).kind(),
+		ErrorKind::ProcessTooManyFiles);
 
-	match *<Error as From<io::Error>>::from(en_file_error).kind() {
-		ErrorKind::ProcessTooManyFiles => {},
-		_ => panic!("Unexpected error"),
-	}
+	assert_matches!(
+		<Error as From<io::Error>>::from(
+			io::Error::from_raw_os_error(EMFILE)
+			).kind(),
+		ErrorKind::SystemTooManyFiles);
 
-
-	let em_file_error = io::Error::from_raw_os_error(EMFILE);
-
-	match *<Error as From<io::Error>>::from(em_file_error).kind() {
-		ErrorKind::SystemTooManyFiles => {},
-		_ => panic!("Unexpected error"),
-	}
-
-
-	let usual_error = io::Error::from_raw_os_error(0);
-
-	match *<Error as From<io::Error>>::from(usual_error).kind() {
-		ErrorKind::Io(_) => {},
-		_ => panic!("Unexpected error"),
-	}
-
+	assert_matches!(
+		<Error as From<io::Error>>::from(
+			io::Error::from_raw_os_error(0)
+			).kind(),
+		ErrorKind::Io(_));
 }

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -25,6 +25,9 @@ extern crate ipnetwork;
 extern crate snappy;
 extern crate libc;
 
+#[cfg(test)] #[macro_use]
+extern crate assert_matches;
+
 #[macro_use]
 extern crate error_chain;
 

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -23,6 +23,7 @@ extern crate ethkey;
 extern crate rlp;
 extern crate ipnetwork;
 extern crate snappy;
+extern crate libc;
 
 #[macro_use]
 extern crate error_chain;


### PR DESCRIPTION
Add custom mapping of ENFILE and EMFILE IO Errors (Failure because of missing system resource) right when chaining ioError into ::util::Network::Error to improve Error Messages given to user

Notes:
 - Adds libc as a dependency to util/network
 - Adds assert-matches as dev-dependency
 - fixes #6791
 - superseeds #8737