### PR TITLE
parity: bump stable version to 1.10.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "parity"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1915,7 +1915,7 @@ dependencies = [
  "parity-rpc 1.9.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.9.0",
- "parity-version 1.10.4",
+ "parity-version 1.10.5",
  "parity-whisper 0.1.0",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.0",
@@ -1964,7 +1964,7 @@ dependencies = [
  "parity-reactor 0.1.0",
  "parity-ui 1.9.0",
  "parity-ui-deprecation 1.10.0",
- "parity-version 1.10.4",
+ "parity-version 1.10.5",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2115,7 +2115,7 @@ dependencies = [
  "order-stat 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-reactor 0.1.0",
  "parity-updater 1.9.0",
- "parity-version 1.10.4",
+ "parity-version 1.10.5",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2232,7 +2232,7 @@ dependencies = [
  "ethsync 1.9.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.9.0",
- "parity-version 1.10.4",
+ "parity-version 1.10.5",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.0",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "ethcore-bytes 0.1.0",
  "rlp 0.2.1",
@@ -2855,7 +2855,7 @@ name = "shell32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "1.10.4"
+version = "1.10.5"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/mac/Parity.pkgproj
+++ b/mac/Parity.pkgproj
@@ -462,7 +462,7 @@
 				<key>OVERWRITE_PERMISSIONS</key>
 				<false/>
 				<key>VERSION</key>
-				<string>1.10.4</string>
+				<string>1.10.5</string>
 			</dict>
 			<key>UUID</key>
 			<string>2DCD5B81-7BAF-4DA1-9251-6274B089FD36</string>

--- a/nsis/installer.nsi
+++ b/nsis/installer.nsi
@@ -10,7 +10,7 @@
 !define DESCRIPTION "Fast, light, robust Ethereum implementation"
 !define VERSIONMAJOR 1
 !define VERSIONMINOR 10
-!define VERSIONBUILD 4
+!define VERSIONBUILD 5
 !define ARGS ""
 !define FIRST_START_ARGS "--mode=passive ui"
 

--- a/util/journaldb/src/earlymergedb.rs
+++ b/util/journaldb/src/earlymergedb.rs
@@ -56,7 +56,7 @@ enum RemoveFrom {
 /// the removals actually take effect.
 ///
 /// journal format:
-/// ```
+/// ```text
 /// [era, 0] => [ id, [insert_0, ...], [remove_0, ...] ]
 /// [era, 1] => [ id, [insert_0, ...], [remove_0, ...] ]
 /// [era, n] => [ ... ]
@@ -75,7 +75,7 @@ enum RemoveFrom {
 /// which includes an original key, if any.
 ///
 /// The semantics of the `counter` are:
-/// ```
+/// ```text
 /// insert key k:
 ///   counter already contains k: count += 1
 ///   counter doesn't contain k:
@@ -91,7 +91,7 @@ enum RemoveFrom {
 ///
 /// Practically, this means that for each commit block turning from recent to ancient we do the
 /// following:
-/// ```
+/// ```text
 /// is_canonical:
 ///   inserts: Ignored (left alone in the backing database).
 ///   deletes: Enacted; however, recent history queue is checked for ongoing references. This is

--- a/util/journaldb/src/refcounteddb.rs
+++ b/util/journaldb/src/refcounteddb.rs
@@ -39,7 +39,7 @@ use bytes::Bytes;
 /// the removals actually take effect.
 ///
 /// journal format:
-/// ```
+/// ```text
 /// [era, 0] => [ id, [insert_0, ...], [remove_0, ...] ]
 /// [era, 1] => [ id, [insert_0, ...], [remove_0, ...] ]
 /// [era, n] => [ ... ]

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity version string (via env CARGO_PKG_VERSION)
-version = "1.10.4"
+version = "1.10.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
- bump stable version to 1.10.5
- backports the `text` part of #8581