### PR TITLE
Remove Result wrapper from AccountProvider in RPC impls

### DIFF
--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -170,12 +170,6 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> EthClient<C, SN, S
 		}
 	}
 
-	/// Attempt to get the `Arc<AccountProvider>`, errors if provider was not
-	/// set.
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
-
 	fn rich_block(&self, id: BlockNumberOrId, include_txs: bool) -> Result<Option<RichBlock>> {
 		let client = &self.client;
 
@@ -404,7 +398,7 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> EthClient<C, SN, S
 	}
 
 	fn dapp_accounts(&self, dapp: DappId) -> Result<Vec<H160>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		store
 			.note_dapp_used(dapp.clone())
 			.and_then(|_| store.dapp_addresses(dapp))

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -398,10 +398,9 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> EthClient<C, SN, S
 	}
 
 	fn dapp_accounts(&self, dapp: DappId) -> Result<Vec<H160>> {
-		let store = self.accounts.clone();
-		store
+		self.accounts
 			.note_dapp_used(dapp.clone())
-			.and_then(|_| store.dapp_addresses(dapp))
+			.and_then(|_| self.accounts.dapp_addresses(dapp))
 			.map_err(|e| errors::account("Could not fetch accounts.", e))
 	}
 

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -105,12 +105,6 @@ impl<C, M, U> ParityClient<C, M, U> where
 			eip86_transition,
 		}
 	}
-
-	/// Attempt to get the `Arc<AccountProvider>`, errors if provider was not
-	/// set.
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
 }
 
 impl<C, M, U, S> Parity for ParityClient<C, M, U> where
@@ -124,7 +118,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 	fn accounts_info(&self, dapp: Trailing<DappId>) -> Result<BTreeMap<H160, AccountInfo>> {
 		let dapp = dapp.unwrap_or_default();
 
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let dapp_accounts = store
 			.note_dapp_used(dapp.clone().into())
 			.and_then(|_| store.dapp_addresses(dapp.into()))
@@ -144,7 +138,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 	}
 
 	fn hardware_accounts_info(&self) -> Result<BTreeMap<H160, HwAccountInfo>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let info = store.hardware_accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
 		Ok(info
 			.into_iter()
@@ -154,14 +148,14 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 	}
 
 	fn locked_hardware_accounts_info(&self) -> Result<Vec<String>> {
-		let store = self.account_provider()?;
-		Ok(store.locked_hardware_accounts().map_err(|e| errors::account("Error communicating with hardware wallet.", e))?)
+		let store = self.accounts.clone();
+		store.locked_hardware_accounts().map_err(|e| errors::account("Error communicating with hardware wallet.", e))
 	}
 
 	fn default_account(&self, meta: Self::Metadata) -> Result<H160> {
 		let dapp_id = meta.dapp_id();
 
-		Ok(self.account_provider()?
+		Ok(self.accounts.clone()
 			.dapp_default_address(dapp_id.into())
 			.map(Into::into)
 			.ok()

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -118,15 +118,14 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 	fn accounts_info(&self, dapp: Trailing<DappId>) -> Result<BTreeMap<H160, AccountInfo>> {
 		let dapp = dapp.unwrap_or_default();
 
-		let store = self.accounts.clone();
-		let dapp_accounts = store
+		let dapp_accounts = self.accounts
 			.note_dapp_used(dapp.clone().into())
-			.and_then(|_| store.dapp_addresses(dapp.into()))
+			.and_then(|_| self.accounts.dapp_addresses(dapp.into()))
 			.map_err(|e| errors::account("Could not fetch accounts.", e))?
 			.into_iter().collect::<HashSet<_>>();
 
-		let info = store.accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
-		let other = store.addresses_info();
+		let info = self.accounts.accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
+		let other = self.accounts.addresses_info();
 
 		Ok(info
 			.into_iter()
@@ -138,8 +137,7 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 	}
 
 	fn hardware_accounts_info(&self) -> Result<BTreeMap<H160, HwAccountInfo>> {
-		let store = self.accounts.clone();
-		let info = store.hardware_accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
+		let info = self.accounts.hardware_accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
 		Ok(info
 			.into_iter()
 			.map(|(a, v)| (H160::from(a), HwAccountInfo { name: v.name, manufacturer: v.meta }))
@@ -148,14 +146,13 @@ impl<C, M, U, S> Parity for ParityClient<C, M, U> where
 	}
 
 	fn locked_hardware_accounts_info(&self) -> Result<Vec<String>> {
-		let store = self.accounts.clone();
-		store.locked_hardware_accounts().map_err(|e| errors::account("Error communicating with hardware wallet.", e))
+		self.accounts.locked_hardware_accounts().map_err(|e| errors::account("Error communicating with hardware wallet.", e))
 	}
 
 	fn default_account(&self, meta: Self::Metadata) -> Result<H160> {
 		let dapp_id = meta.dapp_id();
 
-		Ok(self.accounts.clone()
+		Ok(self.accounts
 			.dapp_default_address(dapp_id.into())
 			.map(Into::into)
 			.ok()

--- a/rpc/src/v1/impls/parity_accounts.rs
+++ b/rpc/src/v1/impls/parity_accounts.rs
@@ -318,7 +318,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn hardware_pin_matrix_ack(&self, path: String, pin: String) -> Result<bool> {
-		Ok(self.accounts.hardware_pin_matrix_ack(&path, &pin).map_err(|e| errors::account("Error communicating with hardware wallet.", e))?)
+		self.accounts.hardware_pin_matrix_ack(&path, &pin).map_err(|e| errors::account("Error communicating with hardware wallet.", e))
 	}
 }
 

--- a/rpc/src/v1/impls/parity_accounts.rs
+++ b/rpc/src/v1/impls/parity_accounts.rs
@@ -40,17 +40,11 @@ impl ParityAccountsClient {
 			accounts: store.clone(),
 		}
 	}
-
-	/// Attempt to get the `Arc<AccountProvider>`, errors if provider was not
-	/// set.
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
 }
 
 impl ParityAccounts for ParityAccountsClient {
 	fn all_accounts_info(&self) -> Result<BTreeMap<RpcH160, ExtAccountInfo>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let info = store.accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
 		let other = store.addresses_info();
 
@@ -82,7 +76,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn new_account_from_phrase(&self, phrase: String, pass: String) -> Result<RpcH160> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		let brain = Brain::new(phrase).generate().unwrap();
 		store.insert_account(brain.secret().clone(), &pass)
@@ -91,7 +85,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn new_account_from_wallet(&self, json: String, pass: String) -> Result<RpcH160> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.import_presale(json.as_bytes(), &pass)
 			.or_else(|_| store.import_wallet(json.as_bytes(), &pass, true))
@@ -100,7 +94,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn new_account_from_secret(&self, secret: RpcH256, pass: String) -> Result<RpcH160> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		let secret = Secret::from_unsafe_slice(&secret.0)
 			.map_err(|e| errors::account("Could not create account.", e))?;
@@ -112,14 +106,14 @@ impl ParityAccounts for ParityAccountsClient {
 	fn test_password(&self, account: RpcH160, password: String) -> Result<bool> {
 		let account: Address = account.into();
 
-		self.account_provider()?
+		self.accounts.clone()
 			.test_password(&account, &password)
 			.map_err(|e| errors::account("Could not fetch account info.", e))
 	}
 
 	fn change_password(&self, account: RpcH160, password: String, new_password: String) -> Result<bool> {
 		let account: Address = account.into();
-		self.account_provider()?
+		self.accounts.clone()
 			.change_password(&account, password, new_password)
 			.map(|_| true)
 			.map_err(|e| errors::account("Could not fetch account info.", e))
@@ -127,14 +121,14 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn kill_account(&self, account: RpcH160, password: String) -> Result<bool> {
 		let account: Address = account.into();
-		self.account_provider()?
+		self.accounts.clone()
 			.kill_account(&account, &password)
 			.map(|_| true)
 			.map_err(|e| errors::account("Could not delete account.", e))
 	}
 
 	fn remove_address(&self, addr: RpcH160) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let addr: Address = addr.into();
 
 		store.remove_address(addr);
@@ -142,7 +136,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn set_account_name(&self, addr: RpcH160, name: String) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let addr: Address = addr.into();
 
 		store.set_account_name(addr.clone(), name.clone())
@@ -151,7 +145,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn set_account_meta(&self, addr: RpcH160, meta: String) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let addr: Address = addr.into();
 
 		store.set_account_meta(addr.clone(), meta.clone())
@@ -160,7 +154,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn set_dapp_addresses(&self, dapp: DappId, addresses: Option<Vec<RpcH160>>) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.set_dapp_addresses(dapp.into(), addresses.map(into_vec))
 			.map_err(|e| errors::account("Couldn't set dapp addresses.", e))
@@ -168,7 +162,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn dapp_addresses(&self, dapp: DappId) -> Result<Vec<RpcH160>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.dapp_addresses(dapp.into())
 			.map_err(|e| errors::account("Couldn't get dapp addresses.", e))
@@ -176,7 +170,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn set_dapp_default_address(&self, dapp: DappId, address: RpcH160) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.set_dapp_default_address(dapp.into(), address.into())
 			.map_err(|e| errors::account("Couldn't set dapp default address.", e))
@@ -184,7 +178,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn dapp_default_address(&self, dapp: DappId) -> Result<RpcH160> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.dapp_default_address(dapp.into())
 			.map_err(|e| errors::account("Couldn't get dapp default address.", e))
@@ -192,7 +186,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn set_new_dapps_addresses(&self, addresses: Option<Vec<RpcH160>>) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store
 			.set_new_dapps_addresses(addresses.map(into_vec))
@@ -201,7 +195,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn new_dapps_addresses(&self) -> Result<Option<Vec<RpcH160>>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.new_dapps_addresses()
 			.map_err(|e| errors::account("Couldn't get dapps addresses.", e))
@@ -209,7 +203,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn set_new_dapps_default_address(&self, address: RpcH160) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.set_new_dapps_default_address(address.into())
 			.map_err(|e| errors::account("Couldn't set new dapps default address.", e))
@@ -217,7 +211,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn new_dapps_default_address(&self) -> Result<RpcH160> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.new_dapps_default_address()
 			.map_err(|e| errors::account("Couldn't get new dapps default address.", e))
@@ -225,7 +219,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn recent_dapps(&self) -> Result<BTreeMap<DappId, u64>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store.recent_dapps()
 			.map_err(|e| errors::account("Couldn't get recent dapps.", e))
@@ -233,7 +227,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn import_geth_accounts(&self, addresses: Vec<RpcH160>) -> Result<Vec<RpcH160>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		store
 			.import_geth_accounts(into_vec(addresses), false)
@@ -242,66 +236,66 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn geth_accounts(&self) -> Result<Vec<RpcH160>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 
 		Ok(into_vec(store.list_geth_accounts(false)))
 	}
 
 	fn create_vault(&self, name: String, password: String) -> Result<bool> {
-		self.account_provider()?
+		self.accounts.clone()
 			.create_vault(&name, &password)
 			.map_err(|e| errors::account("Could not create vault.", e))
 			.map(|_| true)
 	}
 
 	fn open_vault(&self, name: String, password: String) -> Result<bool> {
-		self.account_provider()?
+		self.accounts.clone()
 			.open_vault(&name, &password)
 			.map_err(|e| errors::account("Could not open vault.", e))
 			.map(|_| true)
 	}
 
 	fn close_vault(&self, name: String) -> Result<bool> {
-		self.account_provider()?
+		self.accounts.clone()
 			.close_vault(&name)
 			.map_err(|e| errors::account("Could not close vault.", e))
 			.map(|_| true)
 	}
 
 	fn list_vaults(&self) -> Result<Vec<String>> {
-		self.account_provider()?
+		self.accounts.clone()
 			.list_vaults()
 			.map_err(|e| errors::account("Could not list vaults.", e))
 	}
 
 	fn list_opened_vaults(&self) -> Result<Vec<String>> {
-		self.account_provider()?
+		self.accounts.clone()
 			.list_opened_vaults()
 			.map_err(|e| errors::account("Could not list vaults.", e))
 	}
 
 	fn change_vault_password(&self, name: String, new_password: String) -> Result<bool> {
-		self.account_provider()?
+		self.accounts.clone()
 			.change_vault_password(&name, &new_password)
 			.map_err(|e| errors::account("Could not change vault password.", e))
 			.map(|_| true)
 	}
 
 	fn change_vault(&self, address: RpcH160, new_vault: String) -> Result<bool> {
-		self.account_provider()?
+		self.accounts.clone()
 			.change_vault(address.into(), &new_vault)
 			.map_err(|e| errors::account("Could not change vault.", e))
 			.map(|_| true)
 	}
 
 	fn get_vault_meta(&self, name: String) -> Result<String> {
-		self.account_provider()?
+		self.accounts.clone()
 			.get_vault_meta(&name)
 			.map_err(|e| errors::account("Could not get vault metadata.", e))
 	}
 
 	fn set_vault_meta(&self, name: String, meta: String) -> Result<bool> {
-		self.account_provider()?
+		self.accounts.clone()
 			.set_vault_meta(&name, &meta)
 			.map_err(|e| errors::account("Could not update vault metadata.", e))
 			.map(|_| true)
@@ -309,7 +303,7 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn derive_key_index(&self, addr: RpcH160, password: String, derivation: DeriveHierarchical, save_as_account: bool) -> Result<RpcH160> {
 		let addr: Address = addr.into();
-		self.account_provider()?
+		self.accounts.clone()
 			.derive_account(
 				&addr,
 				Some(password),
@@ -322,7 +316,7 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn derive_key_hash(&self, addr: RpcH160, password: String, derivation: DeriveHash, save_as_account: bool) -> Result<RpcH160> {
 		let addr: Address = addr.into();
-		self.account_provider()?
+		self.accounts.clone()
 			.derive_account(
 				&addr,
 				Some(password),
@@ -335,7 +329,7 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn export_account(&self, addr: RpcH160, password: String) -> Result<KeyFile> {
 		let addr = addr.into();
-		self.account_provider()?
+		self.accounts.clone()
 			.export_account(
 				&addr,
 				password,
@@ -345,7 +339,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn sign_message(&self, addr: RpcH160, password: String, message: RpcH256) -> Result<RpcH520> {
-		self.account_provider()?
+		self.accounts.clone()
 			.sign(
 				addr.into(),
 				Some(password),
@@ -356,7 +350,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn hardware_pin_matrix_ack(&self, path: String, pin: String) -> Result<bool> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		Ok(store.hardware_pin_matrix_ack(&path, &pin).map_err(|e| errors::account("Error communicating with hardware wallet.", e))?)
 	}
 }

--- a/rpc/src/v1/impls/parity_accounts.rs
+++ b/rpc/src/v1/impls/parity_accounts.rs
@@ -44,9 +44,8 @@ impl ParityAccountsClient {
 
 impl ParityAccounts for ParityAccountsClient {
 	fn all_accounts_info(&self) -> Result<BTreeMap<RpcH160, ExtAccountInfo>> {
-		let store = self.accounts.clone();
-		let info = store.accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
-		let other = store.addresses_info();
+		let info = self.accounts.accounts_info().map_err(|e| errors::account("Could not fetch account info.", e))?;
+		let other = self.accounts.addresses_info();
 
 		let account_iter = info
 			.into_iter()
@@ -76,29 +75,23 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn new_account_from_phrase(&self, phrase: String, pass: String) -> Result<RpcH160> {
-		let store = self.accounts.clone();
-
 		let brain = Brain::new(phrase).generate().unwrap();
-		store.insert_account(brain.secret().clone(), &pass)
+		self.accounts.insert_account(brain.secret().clone(), &pass)
 			.map(Into::into)
 			.map_err(|e| errors::account("Could not create account.", e))
 	}
 
 	fn new_account_from_wallet(&self, json: String, pass: String) -> Result<RpcH160> {
-		let store = self.accounts.clone();
-
-		store.import_presale(json.as_bytes(), &pass)
-			.or_else(|_| store.import_wallet(json.as_bytes(), &pass, true))
+		self.accounts.import_presale(json.as_bytes(), &pass)
+			.or_else(|_| self.accounts.import_wallet(json.as_bytes(), &pass, true))
 			.map(Into::into)
 			.map_err(|e| errors::account("Could not create account.", e))
 	}
 
 	fn new_account_from_secret(&self, secret: RpcH256, pass: String) -> Result<RpcH160> {
-		let store = self.accounts.clone();
-
 		let secret = Secret::from_unsafe_slice(&secret.0)
 			.map_err(|e| errors::account("Could not create account.", e))?;
-		store.insert_account(secret, &pass)
+		self.accounts.insert_account(secret, &pass)
 			.map(Into::into)
 			.map_err(|e| errors::account("Could not create account.", e))
 	}
@@ -106,14 +99,14 @@ impl ParityAccounts for ParityAccountsClient {
 	fn test_password(&self, account: RpcH160, password: String) -> Result<bool> {
 		let account: Address = account.into();
 
-		self.accounts.clone()
+		self.accounts
 			.test_password(&account, &password)
 			.map_err(|e| errors::account("Could not fetch account info.", e))
 	}
 
 	fn change_password(&self, account: RpcH160, password: String, new_password: String) -> Result<bool> {
 		let account: Address = account.into();
-		self.accounts.clone()
+		self.accounts
 			.change_password(&account, password, new_password)
 			.map(|_| true)
 			.map_err(|e| errors::account("Could not fetch account info.", e))
@@ -121,181 +114,156 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn kill_account(&self, account: RpcH160, password: String) -> Result<bool> {
 		let account: Address = account.into();
-		self.accounts.clone()
+		self.accounts
 			.kill_account(&account, &password)
 			.map(|_| true)
 			.map_err(|e| errors::account("Could not delete account.", e))
 	}
 
 	fn remove_address(&self, addr: RpcH160) -> Result<bool> {
-		let store = self.accounts.clone();
 		let addr: Address = addr.into();
 
-		store.remove_address(addr);
+		self.accounts.remove_address(addr);
 		Ok(true)
 	}
 
 	fn set_account_name(&self, addr: RpcH160, name: String) -> Result<bool> {
-		let store = self.accounts.clone();
 		let addr: Address = addr.into();
 
-		store.set_account_name(addr.clone(), name.clone())
-			.unwrap_or_else(|_| store.set_address_name(addr, name));
+		self.accounts.set_account_name(addr.clone(), name.clone())
+			.unwrap_or_else(|_| self.accounts.set_address_name(addr, name));
 		Ok(true)
 	}
 
 	fn set_account_meta(&self, addr: RpcH160, meta: String) -> Result<bool> {
-		let store = self.accounts.clone();
 		let addr: Address = addr.into();
 
-		store.set_account_meta(addr.clone(), meta.clone())
-			.unwrap_or_else(|_| store.set_address_meta(addr, meta));
+		self.accounts.set_account_meta(addr.clone(), meta.clone())
+			.unwrap_or_else(|_| self.accounts.set_address_meta(addr, meta));
 		Ok(true)
 	}
 
 	fn set_dapp_addresses(&self, dapp: DappId, addresses: Option<Vec<RpcH160>>) -> Result<bool> {
-		let store = self.accounts.clone();
-
-		store.set_dapp_addresses(dapp.into(), addresses.map(into_vec))
+		self.accounts.set_dapp_addresses(dapp.into(), addresses.map(into_vec))
 			.map_err(|e| errors::account("Couldn't set dapp addresses.", e))
 			.map(|_| true)
 	}
 
 	fn dapp_addresses(&self, dapp: DappId) -> Result<Vec<RpcH160>> {
-		let store = self.accounts.clone();
-
-		store.dapp_addresses(dapp.into())
+		self.accounts.dapp_addresses(dapp.into())
 			.map_err(|e| errors::account("Couldn't get dapp addresses.", e))
 			.map(into_vec)
 	}
 
 	fn set_dapp_default_address(&self, dapp: DappId, address: RpcH160) -> Result<bool> {
-		let store = self.accounts.clone();
-
-		store.set_dapp_default_address(dapp.into(), address.into())
+		self.accounts.set_dapp_default_address(dapp.into(), address.into())
 			.map_err(|e| errors::account("Couldn't set dapp default address.", e))
 			.map(|_| true)
 	}
 
 	fn dapp_default_address(&self, dapp: DappId) -> Result<RpcH160> {
-		let store = self.accounts.clone();
-
-		store.dapp_default_address(dapp.into())
+		self.accounts.dapp_default_address(dapp.into())
 			.map_err(|e| errors::account("Couldn't get dapp default address.", e))
 			.map(Into::into)
 	}
 
 	fn set_new_dapps_addresses(&self, addresses: Option<Vec<RpcH160>>) -> Result<bool> {
-		let store = self.accounts.clone();
-
-		store
+		self.accounts
 			.set_new_dapps_addresses(addresses.map(into_vec))
 			.map_err(|e| errors::account("Couldn't set dapps addresses.", e))
 			.map(|_| true)
 	}
 
 	fn new_dapps_addresses(&self) -> Result<Option<Vec<RpcH160>>> {
-		let store = self.accounts.clone();
-
-		store.new_dapps_addresses()
+		self.accounts.new_dapps_addresses()
 			.map_err(|e| errors::account("Couldn't get dapps addresses.", e))
 			.map(|accounts| accounts.map(into_vec))
 	}
 
 	fn set_new_dapps_default_address(&self, address: RpcH160) -> Result<bool> {
-		let store = self.accounts.clone();
-
-		store.set_new_dapps_default_address(address.into())
+		self.accounts.set_new_dapps_default_address(address.into())
 			.map_err(|e| errors::account("Couldn't set new dapps default address.", e))
 			.map(|_| true)
 	}
 
 	fn new_dapps_default_address(&self) -> Result<RpcH160> {
-		let store = self.accounts.clone();
-
-		store.new_dapps_default_address()
+		self.accounts.new_dapps_default_address()
 			.map_err(|e| errors::account("Couldn't get new dapps default address.", e))
 			.map(Into::into)
 	}
 
 	fn recent_dapps(&self) -> Result<BTreeMap<DappId, u64>> {
-		let store = self.accounts.clone();
-
-		store.recent_dapps()
+		self.accounts.recent_dapps()
 			.map_err(|e| errors::account("Couldn't get recent dapps.", e))
 			.map(|map| map.into_iter().map(|(k, v)| (k.into(), v)).collect())
 	}
 
 	fn import_geth_accounts(&self, addresses: Vec<RpcH160>) -> Result<Vec<RpcH160>> {
-		let store = self.accounts.clone();
-
-		store
+		self.accounts
 			.import_geth_accounts(into_vec(addresses), false)
 			.map(into_vec)
 			.map_err(|e| errors::account("Couldn't import Geth accounts", e))
 	}
 
 	fn geth_accounts(&self) -> Result<Vec<RpcH160>> {
-		let store = self.accounts.clone();
-
-		Ok(into_vec(store.list_geth_accounts(false)))
+		Ok(into_vec(self.accounts.list_geth_accounts(false)))
 	}
 
 	fn create_vault(&self, name: String, password: String) -> Result<bool> {
-		self.accounts.clone()
+		self.accounts
 			.create_vault(&name, &password)
 			.map_err(|e| errors::account("Could not create vault.", e))
 			.map(|_| true)
 	}
 
 	fn open_vault(&self, name: String, password: String) -> Result<bool> {
-		self.accounts.clone()
+		self.accounts
 			.open_vault(&name, &password)
 			.map_err(|e| errors::account("Could not open vault.", e))
 			.map(|_| true)
 	}
 
 	fn close_vault(&self, name: String) -> Result<bool> {
-		self.accounts.clone()
+		self.accounts
 			.close_vault(&name)
 			.map_err(|e| errors::account("Could not close vault.", e))
 			.map(|_| true)
 	}
 
 	fn list_vaults(&self) -> Result<Vec<String>> {
-		self.accounts.clone()
+		self.accounts
 			.list_vaults()
 			.map_err(|e| errors::account("Could not list vaults.", e))
 	}
 
 	fn list_opened_vaults(&self) -> Result<Vec<String>> {
-		self.accounts.clone()
+		self.accounts
 			.list_opened_vaults()
 			.map_err(|e| errors::account("Could not list vaults.", e))
 	}
 
 	fn change_vault_password(&self, name: String, new_password: String) -> Result<bool> {
-		self.accounts.clone()
+		self.accounts
 			.change_vault_password(&name, &new_password)
 			.map_err(|e| errors::account("Could not change vault password.", e))
 			.map(|_| true)
 	}
 
 	fn change_vault(&self, address: RpcH160, new_vault: String) -> Result<bool> {
-		self.accounts.clone()
+		self.accounts
 			.change_vault(address.into(), &new_vault)
 			.map_err(|e| errors::account("Could not change vault.", e))
 			.map(|_| true)
 	}
 
 	fn get_vault_meta(&self, name: String) -> Result<String> {
-		self.accounts.clone()
+		self.accounts
 			.get_vault_meta(&name)
 			.map_err(|e| errors::account("Could not get vault metadata.", e))
 	}
 
 	fn set_vault_meta(&self, name: String, meta: String) -> Result<bool> {
-		self.accounts.clone()
+		self.accounts
 			.set_vault_meta(&name, &meta)
 			.map_err(|e| errors::account("Could not update vault metadata.", e))
 			.map(|_| true)
@@ -303,7 +271,7 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn derive_key_index(&self, addr: RpcH160, password: String, derivation: DeriveHierarchical, save_as_account: bool) -> Result<RpcH160> {
 		let addr: Address = addr.into();
-		self.accounts.clone()
+		self.accounts
 			.derive_account(
 				&addr,
 				Some(password),
@@ -316,7 +284,7 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn derive_key_hash(&self, addr: RpcH160, password: String, derivation: DeriveHash, save_as_account: bool) -> Result<RpcH160> {
 		let addr: Address = addr.into();
-		self.accounts.clone()
+		self.accounts
 			.derive_account(
 				&addr,
 				Some(password),
@@ -329,7 +297,7 @@ impl ParityAccounts for ParityAccountsClient {
 
 	fn export_account(&self, addr: RpcH160, password: String) -> Result<KeyFile> {
 		let addr = addr.into();
-		self.accounts.clone()
+		self.accounts
 			.export_account(
 				&addr,
 				password,
@@ -339,7 +307,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn sign_message(&self, addr: RpcH160, password: String, message: RpcH256) -> Result<RpcH520> {
-		self.accounts.clone()
+		self.accounts
 			.sign(
 				addr.into(),
 				Some(password),
@@ -350,8 +318,7 @@ impl ParityAccounts for ParityAccountsClient {
 	}
 
 	fn hardware_pin_matrix_ack(&self, path: String, pin: String) -> Result<bool> {
-		let store = self.accounts.clone();
-		Ok(store.hardware_pin_matrix_ack(&path, &pin).map_err(|e| errors::account("Error communicating with hardware wallet.", e))?)
+		Ok(self.accounts.hardware_pin_matrix_ack(&path, &pin).map_err(|e| errors::account("Error communicating with hardware wallet.", e))?)
 	}
 }
 

--- a/rpc/src/v1/impls/personal.rs
+++ b/rpc/src/v1/impls/personal.rs
@@ -55,16 +55,12 @@ impl<D: Dispatcher> PersonalClient<D> {
 			allow_perm_unlock,
 		}
 	}
-
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
 }
 
 impl<D: Dispatcher + 'static> PersonalClient<D> {
 	fn do_sign_transaction(&self, meta: Metadata, request: TransactionRequest, password: String) -> BoxFuture<(PendingTransaction, D)> {
 		let dispatcher = self.dispatcher.clone();
-		let accounts = try_bf!(self.account_provider());
+		let accounts = self.accounts.clone();
 
 		let default = match request.from.as_ref() {
 			Some(account) => Ok(account.clone().into()),
@@ -94,22 +90,19 @@ impl<D: Dispatcher + 'static> Personal for PersonalClient<D> {
 	type Metadata = Metadata;
 
 	fn accounts(&self) -> Result<Vec<RpcH160>> {
-		let store = self.account_provider()?;
-		let accounts = store.accounts().map_err(|e| errors::account("Could not fetch accounts.", e))?;
+		let accounts = self.accounts.accounts().map_err(|e| errors::account("Could not fetch accounts.", e))?;
 		Ok(accounts.into_iter().map(Into::into).collect::<Vec<RpcH160>>())
 	}
 
 	fn new_account(&self, pass: String) -> Result<RpcH160> {
-		let store = self.account_provider()?;
-
-		store.new_account(&pass)
+		self.accounts.new_account(&pass)
 			.map(Into::into)
 			.map_err(|e| errors::account("Could not create account.", e))
 	}
 
 	fn unlock_account(&self, account: RpcH160, account_pass: String, duration: Option<RpcU128>) -> Result<bool> {
 		let account: Address = account.into();
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let duration = match duration {
 			None => None,
 			Some(duration) => {
@@ -141,7 +134,7 @@ impl<D: Dispatcher + 'static> Personal for PersonalClient<D> {
 
 	fn sign(&self, data: RpcBytes, account: RpcH160, password: String) -> BoxFuture<RpcH520> {
 		let dispatcher = self.dispatcher.clone();
-		let accounts = try_bf!(self.account_provider());
+		let accounts = self.accounts.clone();
 
 		let payload = RpcConfirmationPayload::EthSignMessage((account.clone(), data).into());
 

--- a/rpc/src/v1/impls/secretstore.rs
+++ b/rpc/src/v1/impls/secretstore.rs
@@ -45,8 +45,7 @@ impl SecretStoreClient {
 
 	/// Decrypt public key using account' private key
 	fn decrypt_key(&self, address: H160, password: String, key: Bytes) -> Result<Vec<u8>> {
-		let store = self.accounts.clone();
-		store.decrypt(address.into(), Some(password), &DEFAULT_MAC, &key.0)
+		self.accounts.decrypt(address.into(), Some(password), &DEFAULT_MAC, &key.0)
 			.map_err(|e| errors::account("Could not decrypt key.", e))
 	}
 
@@ -59,8 +58,7 @@ impl SecretStoreClient {
 
 impl SecretStore for SecretStoreClient {
 	fn generate_document_key(&self, address: H160, password: String, server_key_public: H512) -> Result<EncryptedDocumentKey> {
-		let store = self.accounts.clone();
-		let account_public = store.account_public(address.into(), &password)
+		let account_public = self.accounts.account_public(address.into(), &password)
 			.map_err(|e| errors::account("Could not read account public.", e))?;
 		generate_document_key(account_public, server_key_public.into())
 	}
@@ -90,8 +88,7 @@ impl SecretStore for SecretStoreClient {
 	}
 
 	fn sign_raw_hash(&self, address: H160, password: String, raw_hash: H256) -> Result<Bytes> {
-		let store = self.accounts.clone();
-		store
+		self.accounts
 			.sign(address.into(), Some(password), raw_hash.into())
 			.map(|s| Bytes::new((*s).to_vec()))
 			.map_err(|e| errors::account("Could not sign raw hash.", e))

--- a/rpc/src/v1/impls/secretstore.rs
+++ b/rpc/src/v1/impls/secretstore.rs
@@ -43,15 +43,9 @@ impl SecretStoreClient {
 		}
 	}
 
-	/// Attempt to get the `Arc<AccountProvider>`, errors if provider was not
-	/// set.
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
-
 	/// Decrypt public key using account' private key
 	fn decrypt_key(&self, address: H160, password: String, key: Bytes) -> Result<Vec<u8>> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		store.decrypt(address.into(), Some(password), &DEFAULT_MAC, &key.0)
 			.map_err(|e| errors::account("Could not decrypt key.", e))
 	}
@@ -65,7 +59,7 @@ impl SecretStoreClient {
 
 impl SecretStore for SecretStoreClient {
 	fn generate_document_key(&self, address: H160, password: String, server_key_public: H512) -> Result<EncryptedDocumentKey> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		let account_public = store.account_public(address.into(), &password)
 			.map_err(|e| errors::account("Could not read account public.", e))?;
 		generate_document_key(account_public, server_key_public.into())
@@ -96,7 +90,7 @@ impl SecretStore for SecretStoreClient {
 	}
 
 	fn sign_raw_hash(&self, address: H160, password: String, raw_hash: H256) -> Result<Bytes> {
-		let store = self.account_provider()?;
+		let store = self.accounts.clone();
 		store
 			.sign(address.into(), Some(password), raw_hash.into())
 			.map(|s| Bytes::new((*s).to_vec()))

--- a/rpc/src/v1/impls/signer.rs
+++ b/rpc/src/v1/impls/signer.rs
@@ -83,7 +83,6 @@ impl<D: Dispatcher + 'static> SignerClient<D> {
 		T::Future: Send + 'static
 	{
 		let id = id.into();
-		let accounts = self.accounts.clone();
 		let dispatcher = self.dispatcher.clone();
 		let signer = self.signer.clone();
 
@@ -106,7 +105,7 @@ impl<D: Dispatcher + 'static> SignerClient<D> {
 					request.condition = condition.clone().map(Into::into);
 				}
 			}
-			let fut = f(dispatcher, accounts, payload);
+			let fut = f(dispatcher, self.accounts.clone(), payload);
 			Either::A(fut.into_future().then(move |result| {
 				// Execute
 				if let Ok(ref response) = result {

--- a/rpc/src/v1/impls/signer.rs
+++ b/rpc/src/v1/impls/signer.rs
@@ -77,17 +77,13 @@ impl<D: Dispatcher + 'static> SignerClient<D> {
 		}
 	}
 
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
-
 	fn confirm_internal<F, T>(&self, id: U256, modification: TransactionModification, f: F) -> BoxFuture<WithToken<ConfirmationResponse>> where
 		F: FnOnce(D, Arc<AccountProvider>, ConfirmationPayload) -> T,
 		T: IntoFuture<Item=WithToken<ConfirmationResponse>, Error=Error>,
 		T::Future: Send + 'static
 	{
 		let id = id.into();
-		let accounts = try_bf!(self.account_provider());
+		let accounts = self.accounts.clone();
 		let dispatcher = self.dispatcher.clone();
 		let signer = self.signer.clone();
 

--- a/rpc/src/v1/impls/signing.rs
+++ b/rpc/src/v1/impls/signing.rs
@@ -108,12 +108,8 @@ impl<D: Dispatcher + 'static> SigningQueueClient<D> {
 		}
 	}
 
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
-
 	fn dispatch(&self, payload: RpcConfirmationPayload, default_account: DefaultAccount, origin: Origin) -> BoxFuture<DispatchResult> {
-		let accounts = try_bf!(self.account_provider());
+		let accounts = self.accounts.clone();
 		let default_account = match default_account {
 			DefaultAccount::Provided(acc) => acc,
 			DefaultAccount::ForDapp(dapp) => accounts.dapp_default_address(dapp).ok().unwrap_or_default(),
@@ -143,7 +139,7 @@ impl<D: Dispatcher + 'static> ParitySigning for SigningQueueClient<D> {
 	type Metadata = Metadata;
 
 	fn compose_transaction(&self, meta: Metadata, transaction: RpcTransactionRequest) -> BoxFuture<RpcTransactionRequest> {
-		let accounts = try_bf!(self.account_provider());
+		let accounts = self.accounts.clone();
 		let default_account = accounts.dapp_default_address(meta.dapp_id().into()).ok().unwrap_or_default();
 		Box::new(self.dispatcher.fill_optional_fields(transaction.into(), default_account, true).map(Into::into))
 	}

--- a/rpc/src/v1/impls/signing.rs
+++ b/rpc/src/v1/impls/signing.rs
@@ -139,8 +139,7 @@ impl<D: Dispatcher + 'static> ParitySigning for SigningQueueClient<D> {
 	type Metadata = Metadata;
 
 	fn compose_transaction(&self, meta: Metadata, transaction: RpcTransactionRequest) -> BoxFuture<RpcTransactionRequest> {
-		let accounts = self.accounts.clone();
-		let default_account = accounts.dapp_default_address(meta.dapp_id().into()).ok().unwrap_or_default();
+		let default_account = self.accounts.dapp_default_address(meta.dapp_id().into()).ok().unwrap_or_default();
 		Box::new(self.dispatcher.fill_optional_fields(transaction.into(), default_account, true).map(Into::into))
 	}
 

--- a/rpc/src/v1/impls/signing_unsafe.rs
+++ b/rpc/src/v1/impls/signing_unsafe.rs
@@ -51,12 +51,8 @@ impl<D: Dispatcher + 'static> SigningUnsafeClient<D> {
 		}
 	}
 
-	fn account_provider(&self) -> Result<Arc<AccountProvider>> {
-		Ok(self.accounts.clone())
-	}
-
 	fn handle(&self, payload: RpcConfirmationPayload, account: DefaultAccount) -> BoxFuture<RpcConfirmationResponse> {
-		let accounts = try_bf!(self.account_provider());
+		let accounts = self.accounts.clone();
 		let default = match account {
 			DefaultAccount::Provided(acc) => acc,
 			DefaultAccount::ForDapp(dapp) => accounts.dapp_default_address(dapp).ok().unwrap_or_default(),
@@ -107,7 +103,7 @@ impl<D: Dispatcher + 'static> ParitySigning for SigningUnsafeClient<D> {
 	type Metadata = Metadata;
 
 	fn compose_transaction(&self, meta: Metadata, transaction: RpcTransactionRequest) -> BoxFuture<RpcTransactionRequest> {
-		let accounts = try_bf!(self.account_provider());
+		let accounts = self.accounts.clone();
 		let default_account = accounts.dapp_default_address(meta.dapp_id().into()).ok().unwrap_or_default();
 		Box::new(self.dispatcher.fill_optional_fields(transaction.into(), default_account, true).map(Into::into))
 	}

--- a/rpc/src/v1/tests/mocked/parity.rs
+++ b/rpc/src/v1/tests/mocked/parity.rs
@@ -81,8 +81,6 @@ impl Dependencies {
 	}
 
 	pub fn client(&self, signer: Option<Arc<SignerService>>) -> TestParityClient {
-		let opt_accounts = self.accounts.clone();
-
 		ParityClient::new(
 			self.client.clone(),
 			self.miner.clone(),
@@ -90,7 +88,7 @@ impl Dependencies {
 			self.updater.clone(),
 			self.network.clone(),
 			self.health.clone(),
-			opt_accounts.clone(),
+			self.accounts.clone(),
 			self.logger.clone(),
 			self.settings.clone(),
 			signer,

--- a/rpc/src/v1/tests/mocked/personal.rs
+++ b/rpc/src/v1/tests/mocked/personal.rs
@@ -52,13 +52,12 @@ fn miner_service() -> Arc<TestMinerService> {
 
 fn setup() -> PersonalTester {
 	let accounts = accounts_provider();
-	let opt_accounts = accounts.clone();
 	let client = blockchain_client();
 	let miner = miner_service();
 	let reservations = Arc::new(Mutex::new(nonce::Reservations::new()));
 
 	let dispatcher = FullDispatcher::new(client, miner.clone(), reservations, 50);
-	let personal = PersonalClient::new(&opt_accounts, dispatcher, false);
+	let personal = PersonalClient::new(&accounts, dispatcher, false);
 
 	let mut io = IoHandler::default();
 	io.extend_with(personal.to_delegate());

--- a/rpc/src/v1/tests/mocked/signer.rs
+++ b/rpc/src/v1/tests/mocked/signer.rs
@@ -58,7 +58,6 @@ fn miner_service() -> Arc<TestMinerService> {
 fn signer_tester() -> SignerTester {
 	let signer = Arc::new(SignerService::new_test(false));
 	let accounts = accounts_provider();
-	let opt_accounts = accounts.clone();
 	let client = blockchain_client();
 	let miner = miner_service();
 	let reservations = Arc::new(Mutex::new(nonce::Reservations::new()));
@@ -66,7 +65,7 @@ fn signer_tester() -> SignerTester {
 
 	let dispatcher = FullDispatcher::new(client, miner.clone(), reservations, 50);
 	let mut io = IoHandler::default();
-	io.extend_with(SignerClient::new(&opt_accounts, dispatcher, &signer, event_loop.remote()).to_delegate());
+	io.extend_with(SignerClient::new(&accounts, dispatcher, &signer, event_loop.remote()).to_delegate());
 
 	SignerTester {
 		signer: signer,

--- a/rpc/src/v1/tests/mocked/signing.rs
+++ b/rpc/src/v1/tests/mocked/signing.rs
@@ -56,7 +56,6 @@ impl Default for SigningTester {
 		let client = Arc::new(TestBlockChainClient::default());
 		let miner = Arc::new(TestMinerService::default());
 		let accounts = Arc::new(AccountProvider::transient_provider());
-		let opt_accounts = accounts.clone();
 		let reservations = Arc::new(Mutex::new(nonce::Reservations::new()));
 		let mut io = IoHandler::default();
 
@@ -64,9 +63,9 @@ impl Default for SigningTester {
 
 		let remote = Remote::new_thread_per_future();
 
-		let rpc = SigningQueueClient::new(&signer, dispatcher.clone(), remote.clone(), &opt_accounts);
+		let rpc = SigningQueueClient::new(&signer, dispatcher.clone(), remote.clone(), &accounts);
 		io.extend_with(EthSigning::to_delegate(rpc));
-		let rpc = SigningQueueClient::new(&signer, dispatcher, remote, &opt_accounts);
+		let rpc = SigningQueueClient::new(&signer, dispatcher, remote, &accounts);
 		io.extend_with(ParitySigning::to_delegate(rpc));
 
 		SigningTester {


### PR DESCRIPTION
#8758 (part of #8649) removes the `Option` from the `AccountProvider` dependency, so we can remove the redundant wrapping/unwrapping of a `Result`. Previously the `Option` was converted into a `Result`.