### PR TITLE
Multiple improvements to discovery ping handling

### DIFF
--- a/util/network-devp2p/src/host.rs
+++ b/util/network-devp2p/src/host.rs
@@ -243,7 +243,7 @@ pub struct Host {
 	udp_socket: Mutex<Option<UdpSocket>>,
 	tcp_listener: Mutex<TcpListener>,
 	sessions: Arc<RwLock<Slab<SharedSession>>>,
-	discovery: Mutex<Option<Discovery>>,
+	discovery: Mutex<Option<Discovery<'static>>>,
 	nodes: RwLock<NodeTable>,
 	handlers: RwLock<HashMap<ProtocolId, Arc<NetworkProtocolHandler + Sync>>>,
 	timers: RwLock<HashMap<TimerToken, ProtocolTimer>>,

--- a/util/network-devp2p/src/node_table.rs
+++ b/util/network-devp2p/src/node_table.rs
@@ -33,7 +33,7 @@ use rand::{self, Rng};
 /// Node public key
 pub type NodeId = H512;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 /// Node address info
 pub struct NodeEndpoint {
 	/// IP(V4 or V6) address


### PR DESCRIPTION
This addresses some of the problems listed in https://github.com/paritytech/parity/issues/8757. The PR is rather large, so it is best reviewed commit by commit and could be split into multiple PRs if reviewers would like.

There are a few behavior changes:
- Nodes are only added to the k-buckets *after* responding to a PING
- The echo hash on PONG messages is verified against the request packet
- FIND_NODE request timeouts are handled similarly to PING timeouts
- Selection of the last seen node in a k-bucket is improved
- A node is allowed 5 consecutive request timeouts before being evicted from a k-bucket

There are more improvements to come (the k-buckets are still not limited to k entries), but I think this is a step in the right direction.