### PR TITLE
rpc: fix address formatting in TransactionRequest Display

### DIFF
--- a/rpc/src/v1/types/transaction_request.rs
+++ b/rpc/src/v1/types/transaction_request.rs
@@ -70,7 +70,9 @@ impl fmt::Display for TransactionRequest {
 				"{} ETH from {} to 0x{:?}",
 				Colour::White.bold().paint(format_ether(eth)),
 				Colour::White.bold().paint(
-					self.from.as_ref().map(|f| format!("0x{:?}", f)).unwrap_or("?".to_string())),
+					self.from.as_ref()
+						.map(|f| format!("0x{:?}", f))
+						.unwrap_or_else(|| "?".to_string())),
 				to
 			),
 			None => write!(
@@ -78,7 +80,9 @@ impl fmt::Display for TransactionRequest {
 				"{} ETH from {} for contract creation",
 				Colour::White.bold().paint(format_ether(eth)),
 				Colour::White.bold().paint(
-					self.from.as_ref().map(|f| format!("0x{:?}", f)).unwrap_or("?".to_string())),
+					self.from.as_ref()
+						.map(|f| format!("0x{:?}", f))
+						.unwrap_or_else(|| "?".to_string())),
 			),
 		}
 	}

--- a/rpc/src/v1/types/transaction_request.rs
+++ b/rpc/src/v1/types/transaction_request.rs
@@ -69,14 +69,16 @@ impl fmt::Display for TransactionRequest {
 				f,
 				"{} ETH from {} to 0x{:?}",
 				Colour::White.bold().paint(format_ether(eth)),
-				Colour::White.bold().paint(format!("0x{:?}", self.from)),
+				Colour::White.bold().paint(
+					self.from.as_ref().map(|f| format!("0x{:?}", f)).unwrap_or("?".to_string())),
 				to
 			),
 			None => write!(
 				f,
 				"{} ETH from {} for contract creation",
 				Colour::White.bold().paint(format_ether(eth)),
-				Colour::White.bold().paint(format!("0x{:?}", self.from)),
+				Colour::White.bold().paint(
+					self.from.as_ref().map(|f| format!("0x{:?}", f)).unwrap_or("?".to_string())),
 			),
 		}
 	}


### PR DESCRIPTION
This is how the from address looked using the signer cli:

```
❯ ./target/debug/parity signer sign
Password:

#1: 1 ETH from 0xSome(00a329c0648769a73afac7f9381e08fb43dbea72) to 0x00a329c0648769a73afac7f9381e08fb43dbea72 coming from http://127.0.0.1:8180 via UI (session: bd..74)
Sign this transaction? (y)es/(N)o/(r)eject: y
```