### PR TITLE
Updater verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 # `valgrind --tool=massif /path/to/parity <parity params>`
 # and `massif-visualizer` for visualization
 memory_profiling = []
+# use harcoded version 1.3.7 of parity to force an update
+# and to manually test that parity fall-over the local version
+# in case of invalid or depricated command line arguments
+test-updater = ["parity-updater/test-updater"]
 
 [lib]
 path = "parity/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,9 +106,9 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 # `valgrind --tool=massif /path/to/parity <parity params>`
 # and `massif-visualizer` for visualization
 memory_profiling = []
-# use harcoded version 1.3.7 of parity to force an update
-# and to manually test that parity fall-over the local version
-# in case of invalid or depricated command line arguments
+# hardcode version number 1.3.7 of parity to force an update
+# in order to manually test that parity fall-over to the local version
+# in case of invalid or deprecated command line arguments are entered
 test-updater = ["parity-updater/test-updater"]
 
 [lib]

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -2380,7 +2380,7 @@ mod tests {
 		let (new_hash, new_block) = get_good_dummy_block_hash();
 
 		let go = {
-			// Separate thread uncommited transaction
+			// Separate thread uncommitted transaction
 			let go = Arc::new(AtomicBool::new(false));
 			let go_thread = go.clone();
 			let another_client = client.clone();

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -103,7 +103,7 @@ impl Configuration {
 	/// # Example
 	///
 	/// ```
-	/// let _cfg = parity::Configuration::parse_cli(&["--light", "--chain", "koven"]).unwrap();
+	/// let _cfg = parity::Configuration::parse_cli(&["--light", "--chain", "kovan"]).unwrap();
 	/// ```
 	pub fn parse_cli<S: AsRef<str>>(command: &[S]) -> Result<Self, ArgsError> {
 		let config = Configuration {

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -17,8 +17,7 @@
 //! Ethcore client application.
 
 #![warn(missing_docs)]
-
-extern crate parity;
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
 
 extern crate ctrlc;
 extern crate dir;
@@ -26,6 +25,7 @@ extern crate fdlimit;
 #[macro_use]
 extern crate log;
 extern crate panic_hook;
+extern crate parity;
 extern crate parking_lot;
 
 #[cfg(windows)] extern crate winapi;
@@ -46,7 +46,7 @@ use std::fs::{remove_file, metadata, File, create_dir_all};
 use std::io::{self as stdio, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::{process, env};
+use std::{process, env, ffi::OsString};
 
 const PLEASE_RESTART_EXIT_CODE: i32 = 69;
 
@@ -58,7 +58,7 @@ enum Error {
 }
 
 fn update_path(name: &str) -> PathBuf {
-	let mut dest = PathBuf::from(default_hypervisor_path());
+	let mut dest = default_hypervisor_path();
 	dest.push(name);
 	dest
 }
@@ -88,7 +88,7 @@ fn latest_binary_is_newer(current_binary: &Option<PathBuf>, latest_binary: &Opti
 	}
 }
 
-fn set_spec_name_override(spec_name: String) {
+fn set_spec_name_override(spec_name: & str) {
 	if let Err(e) = create_dir_all(default_hypervisor_path())
 		.and_then(|_| File::create(update_path("spec_name_override"))
 		.and_then(|mut f| f.write_all(spec_name.as_bytes())))
@@ -138,8 +138,7 @@ fn global_cleanup() {}
 // Starts ~/.parity-updates/parity and returns the code it exits with.
 fn run_parity() -> Result<(), Error> {
 	global_init();
-	use ::std::ffi::OsString;
-	let prefix = vec![OsString::from("--can-restart"), OsString::from("--force-direct"), OsString::from("--foo")];
+	let prefix = vec![OsString::from("--can-restart"), OsString::from("--force-direct")];
 	
 	let res: Result<(), Error> = latest_exe_path()
 		.and_then(|exe| process::Command::new(exe)
@@ -354,13 +353,21 @@ fn main() {
 	// the binary is named `parity`
 	let same_name = exe_path
 		.as_ref()
-		.map(|p| { 
+		.map_or(false, |p| { 
 			p.file_stem().map_or(false, |n| n == "parity") && p.extension().map_or(false, |ext| ext == "exe")
-		})
-		.unwrap_or(false);
+		});
 
-	trace_main!("Starting up {} (force-direct: {}, development: {}, same-name: {})", std::env::current_exe().map(|x| format!("{}", x.display())).unwrap_or("<unknown>".to_owned()), force_direct, development, same_name);
-	trace_main!("Starting up {} (force-direct: {}, development: {}, same-name: {})", std::env::current_exe().map(|x| format!("{}", x.display())).unwrap_or("<unknown>".to_owned()), force_direct, development, same_name);
+	trace_main!("Starting up {} (force-direct: {}, development: {}, same-name: {})", 
+				std::env::current_exe().ok().map_or_else(|| "<unknown>".into(), |x| format!("{}", x.display())), 
+				force_direct, 
+				development, 
+				same_name);
+
+	trace_main!("Starting up {} (force-direct: {}, development: {}, same-name: {})", 
+				std::env::current_exe().ok().map_or_else(|| "<unknown>".into(), |x| format!("{}", x.display())), 
+				force_direct, 
+				development, 
+				same_name);
 
 	if !force_direct && !development && same_name {
 		// Try to run the latest installed version of `parity`, 

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -717,8 +717,8 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 	// the updater service
 	let updater_fetch = fetch.clone();
 	let updater = Updater::new(
-		Arc::downgrade(&(service.client() as Arc<BlockChainClient>)),
-		Arc::downgrade(&sync_provider),
+		&Arc::downgrade(&(service.client() as Arc<BlockChainClient>)),
+		&Arc::downgrade(&sync_provider),
 		update_policy,
 		hash_fetch::Client::with_fetch(contract_client.clone(), cpu_pool.clone(), updater_fetch, event_loop.remote())
 	);

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -30,7 +30,7 @@ tempdir = "0.3"
 matches = "0.1"
 
 [features]
-# use harcoded version 1.3.7 of parity to force an update
-# and to manually test that parity fall-over the local version
-# in case of invalid or depricated command line arguments
+# hardcode version number 1.3.7 of parity to force an update
+# in order to manually test that parity fall-over to the local version
+# in case of invalid or deprecated command line arguments are entered
 test-updater = []

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -28,3 +28,9 @@ rand = "0.4"
 ethcore = { path = "../ethcore", features = ["test-helpers"] }
 tempdir = "0.3"
 matches = "0.1"
+
+[features]
+# use harcoded version 1.3.7 of parity to force an update
+# and to manually test that parity fall-over the local version
+# in case of invalid or depricated command line arguments
+test-updater = []

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -16,6 +16,9 @@
 
 //! Updater for Parity executables
 
+#![warn(missing_docs)]
+#![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
+
 extern crate ethabi;
 extern crate ethcore;
 extern crate ethcore_bytes as bytes;

--- a/updater/src/lib.rs
+++ b/updater/src/lib.rs
@@ -17,7 +17,6 @@
 //! Updater for Parity executables
 
 #![warn(missing_docs)]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
 
 extern crate ethabi;
 extern crate ethcore;

--- a/updater/src/service.rs
+++ b/updater/src/service.rs
@@ -16,6 +16,7 @@
 
 use types::{CapState, ReleaseInfo, OperationsInfo, VersionInfo};
 
+/// Parity updater service trait
 pub trait Service: Send + Sync {
 	/// Is the currently running client capable of supporting the current chain?
 	/// We default to true if there's no clear information.

--- a/updater/src/types/version_info.rs
+++ b/updater/src/types/version_info.rs
@@ -55,14 +55,14 @@ impl VersionInfo {
 		let t = track.into();
 		VersionInfo {
 			version: Version {
-				major: (semver >> 16) as u64,
-				minor: ((semver >> 8) & 0xff) as u64,
-				patch: (semver & 0xff) as u64,
+				major: u64::from(semver >> 16),
+				minor: u64::from((semver >> 8) & 0xff),
+				patch: u64::from(semver & 0xff),
 				build: vec![],
 				pre: vec![],
 			},
 			track: t,
-			hash: hash,
+			hash,
 		}
 	}
 }

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -38,7 +38,6 @@ use types::{ReleaseInfo, OperationsInfo, CapState, VersionInfo, ReleaseTrack};
 use version;
 use semver::Version;
 
-
 use_contract!(operations_contract, "Operations", "res/operations.json");
 
 /// Filter for releases.
@@ -151,13 +150,13 @@ pub struct Updater<O = OperationsContractClient, F = fetch::Client, T = StdTimeP
 	rng: R,
 
 	// Our version info (static)
-    this: VersionInfo,
+	this: VersionInfo,
 
 	// All the other info - this changes so leave it behind a Mutex.
 	state: Mutex<UpdaterState>,
 }
 
-const CLIENT_ID: &'static str = "parity";
+const CLIENT_ID: &str = "parity";
 
 lazy_static! {
 	static ref CLIENT_ID_HASH: H256 = CLIENT_ID.as_bytes().into();
@@ -191,7 +190,7 @@ pub trait OperationsClient: Send + Sync + 'static {
 	fn release_block_number(&self, from: BlockNumber, release: &ReleaseInfo) -> Option<BlockNumber>;
 }
 
-/// OperationsClient that delegates calls to the operations contract.
+/// `OperationsClient` that delegates calls to the operations contract.
 pub struct OperationsContractClient {
 	operations_contract: operations_contract::Operations,
 	client: Weak<BlockChainClient>,
@@ -269,7 +268,7 @@ impl OperationsClient for OperationsContractClient {
 		// get the release info for the latest version in track
 		let in_track = self.release_info(latest_in_track, &do_call)?;
 		let mut in_minor = Some(in_track.clone());
-		const PROOF: &'static str = "in_minor initialized and assigned with Some; loop breaks if None assigned; qed";
+		const PROOF: &str = "in_minor initialized and assigned with Some; loop breaks if None assigned; qed";
 
 		// if the minor version has changed, let's check the minor version on a different track
 		while in_minor.as_ref().expect(PROOF).version.version.minor != this.version.minor {
@@ -310,7 +309,7 @@ impl OperationsClient for OperationsContractClient {
 			from_block: BlockId::Number(from),
 			to_block: BlockId::Latest,
 			address: Some(vec![address]),
-			topics: topics,
+			topics,
 			limit: None,
 		};
 
@@ -335,7 +334,7 @@ pub trait TimeProvider: Send + Sync + 'static {
 	fn now(&self) -> Instant;
 }
 
-/// TimeProvider implementation that delegates calls to std::time.
+/// `TimeProvider` implementation that delegates calls to `std::time`.
 pub struct StdTimeProvider;
 
 impl TimeProvider for StdTimeProvider {
@@ -351,7 +350,7 @@ pub trait GenRange: Send + Sync + 'static {
 	fn gen_range(&self, low: u64, high: u64) -> u64;
 }
 
-/// GenRange implementation that uses a rand::thread_rng for randomness.
+/// `GenRange` implementation that uses a `rand::thread_rng` for randomness.
 pub struct ThreadRngGenRange;
 
 impl GenRange for ThreadRngGenRange {
@@ -361,14 +360,15 @@ impl GenRange for ThreadRngGenRange {
 }
 
 impl Updater {
+    /// `Updater` constructor
 	pub fn new(
-		client: Weak<BlockChainClient>,
-		sync: Weak<SyncProvider>,
+		client: &Weak<BlockChainClient>,
+		sync: &Weak<SyncProvider>,
 		update_policy: UpdatePolicy,
 		fetcher: fetch::Client,
 	) -> Arc<Updater> {
 		let r = Arc::new(Updater {
-			update_policy: update_policy,
+			update_policy,
 			weak_self: Mutex::new(Default::default()),
 			client: client.clone(),
 			sync: Some(sync.clone()),
@@ -378,12 +378,12 @@ impl Updater {
 				client.clone()),
 			exit_handler: Mutex::new(None),
 			// this: VersionInfo::this(),
-            // TODO: Remove hardcoded dummy version for this
-            this: VersionInfo {
-                track: ReleaseTrack::Stable,
-                version: Version::new(1, 3, 7),
-                hash: 0.into(),
-            },
+			// TODO: Remove hardcoded dummy version for this
+			this: VersionInfo {
+				track: ReleaseTrack::Stable,
+				version: Version::new(1, 3, 7),
+				hash: 0.into(),
+			},
 			time_provider: StdTimeProvider,
 			rng: ThreadRngGenRange,
 			state: Mutex::new(Default::default()),
@@ -455,7 +455,7 @@ impl<O: OperationsClient, F: HashFetch, T: TimeProvider, R: GenRange> Updater<O,
 				},
 				// There was an error fetching the update, apply a backoff delay before retrying
 				Err(err) => {
-					let delay = 2usize.pow(retries) as u64;
+					let delay = 2_usize.pow(retries) as u64;
 					// cap maximum backoff to 1 day
 					let delay = cmp::min(delay, 24 * 60 * 60);
 					let backoff = (retries, self.time_provider.now() + Duration::from_secs(delay));
@@ -614,7 +614,7 @@ impl<O: OperationsClient, F: HashFetch, T: TimeProvider, R: GenRange> Updater<O,
 		// Only check for updates every n blocks
 		let current_block_number = self.client.upgrade().map_or(0, |c| c.block_number(BlockId::Latest).unwrap_or(0));
 		// if current_block_number % cmp::max(self.update_policy.frequency, 1) != 0 {
-		//     return;
+		//	return;
 		// }
 
 		let mut state = self.state.lock();
@@ -647,16 +647,16 @@ impl<O: OperationsClient, F: HashFetch, T: TimeProvider, R: GenRange> Updater<O,
 			// There's a new release available
 			if state.latest.as_ref() != Some(&latest) {
 				trace!(target: "updater", "Latest release in our track is v{} it is {}critical ({} binary is {})",
-					   latest.track.version,
-					   if latest.track.is_critical {""} else {"non-"},
-					   *PLATFORM,
-					   latest.track.binary.map(|b| format!("{}", b)).unwrap_or_else(|| "unreleased".into()));
+					latest.track.version,
+					if latest.track.is_critical {""} else {"non-"},
+					*PLATFORM,
+					latest.track.binary.map_or_else(|| "unreleased".into(), |b| format!("{}", b)));
 
 				trace!(target: "updater", "Fork: this/current/latest/latest-known: {}/#{}/#{}/#{}",
-					   latest.this_fork.map(|f| format!("#{}", f)).unwrap_or_else(|| "unreleased".into()),
-					   current_block_number,
-					   latest.track.fork,
-					   latest.fork);
+					latest.this_fork.map_or_else(|| "unreleased".into(), |f| format!("#{}", f)),
+					current_block_number,
+					latest.track.fork,
+					latest.fork);
 
 				// Update latest release
 				state.latest = Some(latest);

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -27,13 +27,13 @@ use target_info::Target;
 
 use bytes::Bytes;
 use ethcore::BlockNumber;
-use ethcore::filter::Filter;
 use ethcore::client::{BlockId, BlockChainClient, ChainNotify, ChainRoute};
+use ethcore::filter::Filter;
 use ethereum_types::H256;
-use sync::{SyncProvider};
 use hash_fetch::{self as fetch, HashFetch};
 use path::restrict_permissions_owner;
 use service::Service;
+use sync::{SyncProvider};
 use types::{ReleaseInfo, OperationsInfo, CapState, VersionInfo, ReleaseTrack};
 use version;
 
@@ -605,9 +605,9 @@ impl<O: OperationsClient, F: HashFetch, T: TimeProvider, R: GenRange> Updater<O,
 
 		// Only check for updates every n blocks
 		let current_block_number = self.client.upgrade().map_or(0, |c| c.block_number(BlockId::Latest).unwrap_or(0));
-		if current_block_number % cmp::max(self.update_policy.frequency, 1) != 0 {
-			return;
-		}
+		// if current_block_number % cmp::max(self.update_policy.frequency, 1) != 0 {
+		//     return;
+		// }
 
 		let mut state = self.state.lock();
 
@@ -642,10 +642,10 @@ impl<O: OperationsClient, F: HashFetch, T: TimeProvider, R: GenRange> Updater<O,
 					   latest.track.version,
 					   if latest.track.is_critical {""} else {"non-"},
 					   *PLATFORM,
-					   latest.track.binary.map(|b| format!("{}", b)).unwrap_or("unreleased".into()));
+					   latest.track.binary.map(|b| format!("{}", b)).unwrap_or_else(|| "unreleased".into()));
 
 				trace!(target: "updater", "Fork: this/current/latest/latest-known: {}/#{}/#{}/#{}",
-					   latest.this_fork.map(|f| format!("#{}", f)).unwrap_or("unknown".into()),
+					   latest.this_fork.map(|f| format!("#{}", f)).unwrap_or_else(|| "unreleased".into()),
 					   current_block_number,
 					   latest.track.fork,
 					   latest.fork);

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -360,7 +360,7 @@ impl GenRange for ThreadRngGenRange {
 }
 
 impl Updater {
-    /// `Updater` constructor
+	/// `Updater` constructor
 	pub fn new(
 		client: &Weak<BlockChainClient>,
 		sync: &Weak<SyncProvider>,
@@ -389,6 +389,9 @@ impl Updater {
 			state: Mutex::new(Default::default()),
 		});
 		*r.weak_self.lock() = Arc::downgrade(&r);
+
+		info!("this is hardcoded to an old version this must be fixed before merging {}:{}", file!(), line!());
+
 		r.poll();
 		r
 	}
@@ -608,14 +611,16 @@ impl<O: OperationsClient, F: HashFetch, T: TimeProvider, R: GenRange> Updater<O,
 
 		// We rely on a secure state. Bail if we're unsure about it.
 		if self.client.upgrade().map_or(true, |c| !c.chain_info().security_level().is_full()) {
-			return;
+			info!("The `security_level` check is DISABLED!!!!! It is just diabled to test the updater-verification and should be removed later, {}:{}", file!(), line!());
+			// return;
 		}
 
 		// Only check for updates every n blocks
 		let current_block_number = self.client.upgrade().map_or(0, |c| c.block_number(BlockId::Latest).unwrap_or(0));
-		// if current_block_number % cmp::max(self.update_policy.frequency, 1) != 0 {
-		//	return;
-		// }
+		if current_block_number % cmp::max(self.update_policy.frequency, 1) != 0 {
+			info!("The `updater_policy frequency` check is DISABLED!!!!!. This check is just diabled to test the updater and should be removed later, {}:{}", file!(), line!());
+			// return;
+		}
 
 		let mut state = self.state.lock();
 

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -269,7 +269,7 @@ impl OperationsClient for OperationsContractClient {
 		// get the release info for the latest version in track
 		let in_track = self.release_info(latest_in_track, &do_call)?;
 		let mut in_minor = Some(in_track.clone());
-		const PROOF: &'static str = "in_minor initialised and assigned with Some; loop breaks if None assigned; qed";
+		const PROOF: &'static str = "in_minor initialized and assigned with Some; loop breaks if None assigned; qed";
 
 		// if the minor version has changed, let's check the minor version on a different track
 		while in_minor.as_ref().expect(PROOF).version.version.minor != this.version.minor {

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -36,6 +36,8 @@ use service::Service;
 use sync::{SyncProvider};
 use types::{ReleaseInfo, OperationsInfo, CapState, VersionInfo, ReleaseTrack};
 use version;
+use semver::Version;
+
 
 use_contract!(operations_contract, "Operations", "res/operations.json");
 
@@ -149,7 +151,7 @@ pub struct Updater<O = OperationsContractClient, F = fetch::Client, T = StdTimeP
 	rng: R,
 
 	// Our version info (static)
-	this: VersionInfo,
+    this: VersionInfo,
 
 	// All the other info - this changes so leave it behind a Mutex.
 	state: Mutex<UpdaterState>,
@@ -375,7 +377,13 @@ impl Updater {
 				operations_contract::Operations::default(),
 				client.clone()),
 			exit_handler: Mutex::new(None),
-			this: VersionInfo::this(),
+			// this: VersionInfo::this(),
+            // TODO: Remove hardcoded dummy version for this
+            this: VersionInfo {
+                track: ReleaseTrack::Stable,
+                version: Version::new(1, 3, 7),
+                hash: 0.into(),
+            },
 			time_provider: StdTimeProvider,
 			rng: ThreadRngGenRange,
 			state: Mutex::new(Default::default()),

--- a/updater/src/updater.rs
+++ b/updater/src/updater.rs
@@ -658,7 +658,7 @@ impl<O: OperationsClient, F: HashFetch, T: TimeProvider, R: GenRange> Updater<O,
 					latest.track.binary.map_or_else(|| "unreleased".into(), |b| format!("{}", b)));
 
 				trace!(target: "updater", "Fork: this/current/latest/latest-known: {}/#{}/#{}/#{}",
-					latest.this_fork.map_or_else(|| "unreleased".into(), |f| format!("#{}", f)),
+					latest.this_fork.map_or_else(|| "unknown".into(), |f| format!("#{}", f)),
 					current_block_number,
 					latest.track.fork,
 					latest.fork);


### PR DESCRIPTION
Attempt to close #8178 

## Abstract

In the entry point in `parity/main` we first try run the latest installed version of parity if not `--force-restart` is explicitly specified. If we try to run the latest version of parity(`run_parity`) it will return Some(ErrorCode) unless the downloaded binary is not found. Thus, if unsupported CLI args are entered for example it will terminate (return the exit code) instead of falling back to local version.
In other words, only if the binary is not found we fall back to the local version!

So, high-level this PR changes so `run_parity()` return `Result<(), ErrorCode>` and if an error received while running parity we fall back to the local version! That's it still, I think it's okay still store the newer version try it if, for example, other CLI args may be valid. Otherwise, it is easy to add a flag for that or change the timestamp of binary to disable it the entering the `updater loop`. But, the downloaded binary should be probably not be removed otherwise the updater will fetch the same binary over and over again!

## Manual tests
```bash
$ cargo build --features=test-updater
```

### Incompatible CLI args
```bash
➜  updater ./parity --auto-update=all --auto-update-delay=0 -l updater=trace
2018-06-04 21:03:24  main INFO parity::run  Starting Parity/v1.12.0-unstable-e2a90ce15-20180604/x86_64-linux-gnu/rustc1.26.1
2018-06-04 21:03:24  main INFO parity::run  Keys path /home/niklasad1/.local/share/io.parity.ethereum/keys/Foundation
2018-06-04 21:03:24  main INFO parity::run  DB path /home/niklasad1/.local/share/io.parity.ethereum/chains/ethereum/db/906a34e69aec8c0d
2018-06-04 21:03:24  main INFO parity::run  Path to dapps /home/niklasad1/.local/share/io.parity.ethereum/dapps
2018-06-04 21:03:24  main INFO parity::run  State DB configuration: fast
2018-06-04 21:03:24  main INFO parity::run  Operating mode: active
2018-06-04 21:03:24  main INFO ethcore_service::service  Configured for Foundation using Ethash engine
2018-06-04 21:03:25  main INFO parity_updater::updater  this is hardcoded to an old version this must be fixed before merging updater/src/updater.rs:393
2018-06-04 21:03:25  main TRACE updater  Current release is 1.3.7-stable-0x0000…0000 (0x0000000000000000000000000000000000000000)
2018-06-04 21:03:25  main INFO parity_updater::updater  The `security_level` check is DISABLED!!!!! It is just diabled to test the updater-verification and should be removed later, updater/src/updater.rs:614
2018-06-04 21:03:25  main INFO parity_updater::updater  The `updater_policy frequency` check is DISABLED!!!!!. This check is just diabled to test the updater and should be removed later, updater/src/updater.rs:621
2018-06-04 21:03:25  main TRACE updater  Looking up this_fork for our release: parity/0x0000000000000000000000000000000000000000
2018-06-04 21:03:25  main TRACE updater  Latest release in our track is v1.9.5-stable-0xff82…8db2 it is non-critical (x86_64-unknown-linux-gnu binary is 0xf447…3769)
2018-06-04 21:03:25  main TRACE updater  Fork: this/current/latest/latest-known: unreleased/#5732312/#4370000/#2675000
2018-06-04 21:03:25  main INFO updater  Update for binary 0xf447…3769 triggered
2018-06-04 21:03:25  main INFO updater  Attempting to get parity binary 0xf447…3769
2018-06-04 21:03:25  IO Worker #2 INFO network  Public node URL: enode://682b250793ef93e61a9f19918dd63e56695e24ef329a66d017a006b9145fc8b015a4d4a77954e1ef59febde23e17c26b12e087ae59cf03a8367de565208a8fdc@192.168.178.66:30303
2018-06-04 21:03:25  fetch WARN rustls::session  Sending warning alert CloseNotify
2018-06-04 21:03:25   INFO miner  Updated conversion rate to Ξ1 = US$589.22 (8081709 wei/gas)
2018-06-04 21:03:26  IO Worker #0 WARN discovery  Received ping from self
2018-06-04 21:03:26  IO Worker #0 WARN discovery  Received ping from self
2018-06-04 21:03:32   INFO updater  Fetched latest version (1.9.5-stable-0xff82…8db2) OK to /tmp/ECzpH9bP3JyQ
2018-06-04 21:03:33   INFO updater  Copied updated binary to /home/niklasad1/.local/share/io.parity.ethereum-updates/parity-1.9.5-ff821daf1da42865f229aee35f2e74e7b2dd8db2
2018-06-04 21:03:33   INFO updater  Completed upgrade to 1.9.5-stable-0xff82…8db2
2018-06-04 21:03:33  main INFO parity::run  Finishing work, please wait...
2018-06-04 21:03:36  main TRACE updater  Re-running updater loop
2018-06-04 21:03:36  main TRACE updater  latest binary path: File { fd: 3, path: "/home/niklasad1/.local/share/io.parity.ethereum-updates/latest", read: true, write: false }
2018-06-04 21:03:36  main TRACE updater  latest binary path: File { fd: 3, path: "/home/niklasad1/.local/share/io.parity.ethereum-updates/latest", read: true, write: false }
error: Found argument '--auto-update-delay' which wasn't expected, or isn't valid in this context
        Did you mean --auto-update?

USAGE:
    parity-1.9.5-ff821daf1da42865f229aee35f2e74e7b2dd8db2 [SUBCOMMAND]

For more information try --help
2018-06-04 21:03:36  main ERROR updater  Updated binary could not be executed error: StatusCode(1). Falling back to local version
2018-06-04 21:03:36  main INFO parity::run  Starting Parity/v1.12.0-unstable-e2a90ce15-20180604/x86_64-linux-gnu/rustc1.26.1
2018-06-04 21:03:36  main INFO parity::run  Keys path /home/niklasad1/.local/share/io.parity.ethereum/keys/Foundation
2018-06-04 21:03:36  main INFO parity::run  DB path /home/niklasad1/.local/share/io.parity.ethereum/chains/ethereum/db/906a34e69aec8c0d
2018-06-04 21:03:36  main INFO parity::run  Path to dapps /home/niklasad1/.local/share/io.parity.ethereum/dapps
2018-06-04 21:03:36  main INFO parity::run  State DB configuration: fast
2018-06-04 21:03:36  main INFO parity::run  Operating mode: active
2018-06-04 21:03:36  main INFO ethcore_service::service  Configured for Foundation using Ethash engine
2018-06-04 21:03:37  main INFO parity_updater::updater  this is hardcoded to an old version this must be fixed before merging updater/src/updater.rs:393
2018-06-04 21:03:37  main TRACE updater  Current release is 1.3.7-stable-0x0000…0000 (0x0000000000000000000000000000000000000000)
2018-06-04 21:03:37  main INFO parity_updater::updater  The `security_level` check is DISABLED!!!!! It is just diabled to test the updater-verification and should be removed later, updater/src/updater.rs:614
2018-06-04 21:03:37  main INFO parity_updater::updater  The `updater_policy frequency` check is DISABLED!!!!!. This check is just diabled to test the updater and should be removed later, updater/src/updater.rs:621
2018-06-04 21:03:37  main TRACE updater  Looking up this_fork for our release: parity/0x0000000000000000000000000000000000000000
2018-06-04 21:03:37  main TRACE updater  Latest release in our track is v1.9.5-stable-0xff82…8db2 it is non-critical (x86_64-unknown-linux-gnu binary is 0xf447…3769)
2018-06-04 21:03:37  main TRACE updater  Fork: this/current/latest/latest-known: unreleased/#5732321/#4370000/#2675000
2018-06-04 21:03:37  main INFO updater  Already fetched binary.
2018-06-04 21:03:37  main INFO updater  Completed upgrade to 1.9.5-stable-0xff82…8db2
2018-06-04 21:03:37  main INFO updater  Update installed, ready for restart.
2018-06-04 21:03:37  IO Worker #1 INFO network  Public node URL: enode://682b250793ef93e61a9f19918dd63e56695e24ef329a66d017a006b9145fc8b015a4d4a77954e1ef59febde23e17c26b12e087ae59cf03a8367de565208a8fdc@192.168.178.66:30303
2018-06-04 21:03:38  fetch WARN rustls::session  Sending warning alert CloseNotify
2018-06-04 21:03:38   INFO miner  Updated conversion rate to Ξ1 = US$589.22 (8081709 wei/gas)
^C2018-06-04 21:03:47  IO Worker #3 INFO import  Syncing #5732331 0x5a89…8961   1.00 blk/s  101.9 tx/s    8 Mgas/s      0+    7 Qed  #5732337    3/25 peers   549 KiB chain 98 MiB db 758 KiB queue 23 KiB sync  RPC:  0 conn,    0 req/s,    0 µs
2018-06-04 21:03:50  IO Worker #2 TRACE updater  Current release is 1.3.7-stable-0x0000…0000 (0x0000000000000000000000000000000000000000)
2018-06-04 21:03:50  IO Worker #2 INFO parity_updater::updater  The `security_level` check is DISABLED!!!!! It is just diabled to test the updater-verification and should be removed later, updater/src/updater.rs:614
2018-06-04 21:03:50  IO Worker #2 INFO parity_updater::updater  The `updater_policy frequency` check is DISABLED!!!!!. This check is just diabled to test the updater and should be removed later, updater/src/updater.rs:621
2018-06-04 21:03:50  IO Worker #2 TRACE updater  Looking up this_fork for our release: parity/0x0000000000000000000000000000000000000000
2018-06-04 21:03:50  IO Worker #2 INFO import  Imported #5732341 0xc6eb…fc62 (178 txs, 7.96 Mgas, 756 ms, 28.13 KiB) + another 2 block(s) containing 263 tx(s)
```

### Compatible CLI args
```bash
➜  updater ./parity --auto-update=all -l updater=trace
2018-06-04 21:06:02  main INFO parity::run  Starting Parity/v1.9.5-stable-ff821da-20180321/x86_64-linux-gnu/rustc1.24.1
2018-06-04 21:06:02  main INFO parity::run  Keys path /home/niklasad1/.local/share/io.parity.ethereum/keys/Foundation
2018-06-04 21:06:02  main INFO parity::run  DB path /home/niklasad1/.local/share/io.parity.ethereum/chains/ethereum/db/906a34e69aec8c0d
2018-06-04 21:06:02  main INFO parity::run  Path to dapps /home/niklasad1/.local/share/io.parity.ethereum/dapps
2018-06-04 21:06:02  main INFO parity::run  State DB configuration: fast
2018-06-04 21:06:02  main INFO parity::run  Operating mode: active
2018-06-04 21:06:02  main INFO ethcore::service  Configured for Foundation using Ethash engine
2018-06-04 21:06:03  main WARN ethcore_network::node_table  Error reading node table file: ErrorImpl { code: Message("missing field `attempts`"), line: 8, column: 5 }
2018-06-04 21:06:03  main TRACE updater  Current release is 1.9.5-stable-ff82…8db2 (ff821daf1da42865f229aee35f2e74e7b2dd8db2)
2018-06-04 21:06:03   WARN jsonrpc_ipc_server::server  Removed existing file '/home/niklasad1/.local/share/io.parity.ethereum/jsonrpc.ipc'.
2018-06-04 21:06:03  IO Worker #3 INFO network  Public node URL: enode://682b250793ef93e61a9f19918dd63e56695e24ef329a66d017a006b9145fc8b015a4d4a77954e1ef59febde23e17c26b12e087ae59cf03a8367de565208a8fdc@192.168.178.66:30303
2018-06-04 21:06:03   INFO miner  Updated conversion rate to Ξ1 = US$589.22 (202042740 wei/gas)
2018-06-04 21:06:14  IO Worker #2 TRACE updater  Current release is 1.9.5-stable-ff82…8db2 (ff821daf1da42865f229aee35f2e74e7b2dd8db2)
2018-06-04 21:06:14  IO Worker #2 INFO import  Imported #5732348 c4ba…e5dd (130 txs, 7.99 Mgas, 456.96 ms, 27.09 KiB) + another 1 block(s) containing 91 tx(s)
2018-06-04 21:06:28  Verifier #7 TRACE updater  Current release is 1.9.5-stable-ff82…8db2 (ff821daf1da42865f229aee35f2e74e7b2dd8db2)
```

/cc @tomusdrw @andresilva 