### PR TITLE
Fix evmbin compilation

### DIFF
--- a/evmbin/Cargo.toml
+++ b/evmbin/Cargo.toml
@@ -10,7 +10,7 @@ path = "./src/main.rs"
 
 [dependencies]
 docopt = "0.8"
-ethcore = { path = "../ethcore" }
+ethcore = { path = "../ethcore", features = ["test-helpers"] }
 ethjson = { path = "../json" }
 ethcore-bytes = { path = "../util/bytes" }
 ethcore-transaction = { path = "../ethcore/transaction" }
@@ -27,5 +27,4 @@ pretty_assertions = "0.1"
 tempdir = "0.3"
 
 [features]
-default = ["ethcore/test-helpers"]
 evm-debug = ["ethcore/evm-debug-tests"]

--- a/evmbin/Cargo.toml
+++ b/evmbin/Cargo.toml
@@ -27,4 +27,5 @@ pretty_assertions = "0.1"
 tempdir = "0.3"
 
 [features]
+default = ["ethcore/test-helpers"]
 evm-debug = ["ethcore/evm-debug-tests"]


### PR DESCRIPTION
EvmTestClient now requires the test-helpers feature in ethcore.