### PR TITLE
[Backports] old stable 1.8

### DIFF
--- a/ethcore/src/transaction.rs
+++ b/ethcore/src/transaction.rs
@@ -391,6 +391,10 @@ impl UnverifiedTransaction {
 		if check_low_s && !(allow_empty_signature && self.is_unsigned()) {
 			self.check_low_s()?;
 		}
+		// Disallow unsigned transactions in case EIP-86 is disabled.
+		if !allow_empty_signature && self.is_unsigned() {
+			return Err(ethkey::Error::InvalidSignature.into());
+		}
 		// EIP-86: Transactions of this form MUST have gasprice = 0, nonce = 0, value = 0, and do NOT increment the nonce of account 0.
 		if allow_empty_signature && self.is_unsigned() && !(self.gas_price.is_zero() && self.value.is_zero() && self.nonce.is_zero()) {
 			return Err(EthkeyError::InvalidSignature.into())


### PR DESCRIPTION
* Disallow unsigned transactions in case EIP-86 is disabled (#8802)