### PR TITLE
Fix `deadlock_detection` feature branch compilation

### DIFF
--- a/parity/lib.rs
+++ b/parity/lib.rs
@@ -144,6 +144,7 @@ fn run_deadlock_detection_thread() {
 	use std::thread;
 	use std::time::Duration;
 	use parking_lot::deadlock;
+	use ansi_term::Style;
 
 	info!("Starting deadlock detection thread.");
 	// Create a background thread which checks for deadlocks every 10s


### PR DESCRIPTION
The compilation of `cargo build --features deadlock_detection` broke in #8783.
But CI ignores it anyway.