### PR TITLE
Clearing up the reason behind "Ethereum Signed Message"

### DIFF
--- a/rpc/src/v1/helpers/dispatch.rs
+++ b/rpc/src/v1/helpers/dispatch.rs
@@ -237,7 +237,7 @@ pub fn fetch_gas_price_corpus(
 
 /// Returns a eth_sign-compatible hash of data to sign.
 /// The data is prepended with special message to prevent
-/// chosen-plaintext attacks.
+/// malicious DApps from using the function to sign forged transactions.
 pub fn eth_data_hash(mut data: Bytes) -> H256 {
 	let mut message_data =
 		format!("\x19Ethereum Signed Message:\n{}", data.len())


### PR DESCRIPTION
I think this makes more sense.
First because there aren't really chosen-plaintext attacks against asymmetric encryption keys out there.
Second because faking a transaction to be signed by the user is a viable attack vector.