### PR TITLE
Use system allocator when profiling memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,13 @@ slow-blocks = ["ethcore/slow-blocks"]
 secretstore = ["ethcore-secretstore"]
 final = ["parity-version/final"]
 deadlock_detection = ["parking_lot/deadlock_detection"]
+# to create a memory profile (requires nightly rust), use e.g.
+# `heaptrack /path/to/parity <parity params>`,
+# to visualize a memory profile, use `heaptrack_gui`
+# or
+# `valgrind --tool=massif /path/to/parity <parity params>`
+# and `massif-visualizer` for visualization
+memory_profiling = []
 
 [lib]
 path = "parity/lib.rs"

--- a/parity/lib.rs
+++ b/parity/lib.rs
@@ -17,6 +17,7 @@
 //! Ethcore client application.
 
 #![warn(missing_docs)]
+#![cfg_attr(feature = "memory_profiling", feature(alloc_system, global_allocator, allocator_api))]
 
 extern crate ansi_term;
 extern crate docopt;
@@ -91,6 +92,9 @@ extern crate pretty_assertions;
 #[cfg(test)]
 extern crate tempdir;
 
+#[cfg(feature = "memory_profiling")]
+extern crate alloc_system;
+
 mod account;
 mod blockchain;
 mod cache;
@@ -125,9 +129,15 @@ use cli::Args;
 use configuration::{Cmd, Execute};
 use deprecated::find_deprecated;
 use ethcore_logger::setup_log;
+#[cfg(feature = "memory_profiling")]
+use alloc_system::System;
 
 pub use self::configuration::Configuration;
 pub use self::run::RunningClient;
+
+#[cfg(feature = "memory_profiling")]
+#[global_allocator]
+static A: System = System;
 
 fn print_hash_of(maybe_file: Option<String>) -> Result<String, String> {
 	if let Some(file) = maybe_file {


### PR DESCRIPTION
With this patch, I was able to profile memory with both `valgrind --tool=massif` and `heaptrack`.
To use this feature a nightly compiler is required though.

![massif-visualizer](https://user-images.githubusercontent.com/4211399/41071386-118fae70-6a00-11e8-9fbf-71da9ffe3f9c.png)
