### PR TITLE
Check whether we need resealing in miner and unwrap has_account in account_provider

### DIFF
--- a/ethcore/src/account_provider/mod.rs
+++ b/ethcore/src/account_provider/mod.rs
@@ -272,8 +272,8 @@ impl AccountProvider {
 	}
 
 	/// Checks whether an account with a given address is present.
-	pub fn has_account(&self, address: Address) -> Result<bool, Error> {
-		Ok(self.sstore.account_ref(&address).is_ok() && !self.blacklisted_accounts.contains(&address))
+	pub fn has_account(&self, address: Address) -> bool {
+		self.sstore.account_ref(&address).is_ok() && !self.blacklisted_accounts.contains(&address)
 	}
 
 	/// Returns addresses of all accounts.

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -691,6 +691,8 @@ impl Miner {
 
 	/// Prepare pending block, check whether sealing is needed, and then update sealing.
 	fn prepare_and_update_sealing<C: miner::BlockChainClient>(&self, chain: &C) {
+		use miner::MinerService;
+
 		// Make sure to do it after transaction is imported and lock is dropped.
 		// We need to create pending block and enable sealing.
 		if self.engine.seals_internally().unwrap_or(false) || !self.prepare_pending_block(chain) {

--- a/ethcore/src/miner/pool_client.rs
+++ b/ethcore/src/miner/pool_client.rs
@@ -124,7 +124,7 @@ impl<'a, C: 'a> pool::client::Client for PoolClient<'a, C> where
 		pool::client::AccountDetails {
 			nonce: self.cached_nonces.account_nonce(address),
 			balance: self.chain.latest_balance(address),
-			is_local: self.accounts.map_or(false, |accounts| accounts.has_account(*address).unwrap_or(false)),
+			is_local: self.accounts.map_or(false, |accounts| accounts.has_account(*address)),
 		}
 	}
 

--- a/ethcore/src/snapshot/tests/proof_of_authority.rs
+++ b/ethcore/src/snapshot/tests/proof_of_authority.rs
@@ -214,7 +214,7 @@ fn fixed_to_contract_only() {
 		secret!("dog42"),
 	]);
 
-	assert!(provider.has_account(*RICH_ADDR).unwrap());
+	assert!(provider.has_account(*RICH_ADDR));
 
 	let client = make_chain(provider, 3, vec![
 		Transition::Manual(3, vec![addrs[2], addrs[3], addrs[5], addrs[7]]),
@@ -247,7 +247,7 @@ fn fixed_to_contract_to_contract() {
 		secret!("dog42"),
 	]);
 
-	assert!(provider.has_account(*RICH_ADDR).unwrap());
+	assert!(provider.has_account(*RICH_ADDR));
 
 	let client = make_chain(provider, 3, vec![
 		Transition::Manual(3, vec![addrs[2], addrs[3], addrs[5], addrs[7]]),

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -533,7 +533,7 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 	let engine_signer = cmd.miner_extras.engine_signer;
 	if engine_signer != Default::default() {
 		// Check if engine signer exists
-		if !account_provider.has_account(engine_signer).unwrap_or(false) {
+		if !account_provider.has_account(engine_signer) {
 			return Err(format!("Consensus signer account not found for the current chain. {}", build_create_account_hint(&cmd.spec, &cmd.dirs.keys)));
 		}
 
@@ -1028,7 +1028,7 @@ fn prepare_account_provider(spec: &SpecType, dirs: &Directories, data_dir: &str,
 
 	for a in cfg.unlocked_accounts {
 		// Check if the account exists
-		if !account_provider.has_account(a).unwrap_or(false) {
+		if !account_provider.has_account(a) {
 			return Err(format!("Account {} not found for the current chain. {}", a, build_create_account_hint(spec, &dirs.keys)));
 		}
 
@@ -1053,7 +1053,7 @@ fn prepare_account_provider(spec: &SpecType, dirs: &Directories, data_dir: &str,
 fn insert_dev_account(account_provider: &AccountProvider) {
 	let secret: ethkey::Secret = "4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7".into();
 	let dev_account = ethkey::KeyPair::from_secret(secret.clone()).expect("Valid secret produces valid key;qed");
-	if let Ok(false) = account_provider.has_account(dev_account.address()) {
+	if !account_provider.has_account(dev_account.address() {
 		match account_provider.insert_account(secret, "") {
 			Err(e) => warn!("Unable to add development account: {}", e),
 			Ok(address) => {

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -1053,7 +1053,7 @@ fn prepare_account_provider(spec: &SpecType, dirs: &Directories, data_dir: &str,
 fn insert_dev_account(account_provider: &AccountProvider) {
 	let secret: ethkey::Secret = "4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7".into();
 	let dev_account = ethkey::KeyPair::from_secret(secret.clone()).expect("Valid secret produces valid key;qed");
-	if !account_provider.has_account(dev_account.address() {
+	if !account_provider.has_account(dev_account.address()) {
 		match account_provider.insert_account(secret, "") {
 			Err(e) => warn!("Unable to add development account: {}", e),
 			Ok(address) => {

--- a/parity/secretstore.rs
+++ b/parity/secretstore.rs
@@ -144,7 +144,7 @@ mod server {
 					KeyPair::from_secret(secret).map_err(|e| format!("invalid secret: {}", e))?)),
 				Some(NodeSecretKey::KeyStore(account)) => {
 					// Check if account exists
-					if !deps.account_provider.has_account(account.clone()).unwrap_or(false) {
+					if !deps.account_provider.has_account(account.clone()) {
 						return Err(format!("Account {} passed as secret store node key is not found", account));
 					}
 


### PR DESCRIPTION
This PR does two things:

* Unwrap the result in `AccountProvider::has_account`. We never return Err for that.
* Check whether resealing is needed before update sealing for external transactions. We do this check for local transactions already.