### PR TITLE
Fix concurrent access to signer queue

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -65,6 +65,7 @@ stats = { path = "../util/stats" }
 vm = { path = "../ethcore/vm" }
 
 [dev-dependencies]
+ethcore = { path = "../ethcore", features = ["test-helpers"] }
 ethcore-network = { path = "../util/network" }
 fake-fetch = { path = "../util/fake-fetch" }
 kvdb-memorydb = { path = "../util/kvdb-memorydb" }

--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -44,7 +44,7 @@ pub use self::requests::{
 	TransactionRequest, FilledTransactionRequest, ConfirmationRequest, ConfirmationPayload, CallRequest,
 };
 pub use self::signing_queue::{
-	ConfirmationsQueue, ConfirmationReceiver, ConfirmationResult,
+	ConfirmationsQueue, ConfirmationReceiver, ConfirmationResult, ConfirmationSender,
 	SigningQueue, QueueEvent, DefaultAccount,
 	QUEUE_LIMIT as SIGNING_QUEUE_LIMIT,
 };

--- a/rpc/src/v1/helpers/signing_queue.rs
+++ b/rpc/src/v1/helpers/signing_queue.rs
@@ -204,7 +204,7 @@ impl SigningQueue for ConfirmationsQueue {
 	}
 
 	fn request_confirmed(&self, sender: ConfirmationSender, result: ConfirmationResult) -> Option<ConfirmationRequest> {
-		debug!(target: "own_tx", "Signer: Transaction confirmed ({:?}).", sender.request.id);
+		debug!(target: "own_tx", "Signer: Request confirmed ({:?}).", sender.request.id);
 		self.notify_result(sender, Some(result))
 	}
 

--- a/rpc/src/v1/helpers/signing_queue.rs
+++ b/rpc/src/v1/helpers/signing_queue.rs
@@ -83,6 +83,9 @@ pub trait SigningQueue: Send + Sync {
 	/// Notifies possible token holders that request was confirmed and given hash was assigned.
 	fn request_confirmed(&self, sender: ConfirmationSender, result: ConfirmationResult) -> Option<ConfirmationRequest>;
 
+	/// Put a taken request back to the queue.
+	fn request_untouched(&self, sender: ConfirmationSender);
+
 	/// Returns and removes a request if it is contained in the queue.
 	fn take(&self, id: &U256) -> Option<ConfirmationSender>;
 
@@ -205,6 +208,10 @@ impl SigningQueue for ConfirmationsQueue {
 	fn request_confirmed(&self, sender: ConfirmationSender, result: ConfirmationResult) -> Option<ConfirmationRequest> {
 		debug!(target: "own_tx", "Signer: Transaction confirmed ({:?}).", sender.request.id);
 		self.request_notify(sender, Some(result))
+	}
+
+	fn request_untouched(&self, sender: ConfirmationSender) {
+		self.queue.write().insert(sender.request.id, sender);
 	}
 
 	fn requests(&self) -> Vec<ConfirmationRequest> {

--- a/rpc/src/v1/impls/signer.rs
+++ b/rpc/src/v1/impls/signer.rs
@@ -110,6 +110,8 @@ impl<D: Dispatcher + 'static> SignerClient<D> {
 				// Execute
 				if let Ok(ref response) = result {
 					signer.request_confirmed(sender, Ok((*response).clone()));
+				} else {
+					signer.request_untouched(sender);
 				}
 
 				result
@@ -220,6 +222,8 @@ impl<D: Dispatcher + 'static> Signer for SignerClient<D> {
 			};
 			if let Ok(ref response) = result {
 				self.signer.request_confirmed(sender, Ok(response.clone()));
+			} else {
+				self.signer.request_untouched(sender);
 			}
 			result
 		}).unwrap_or_else(|| Err(errors::invalid_params("Unknown RequestID", id)))

--- a/rpc/src/v1/impls/signer.rs
+++ b/rpc/src/v1/impls/signer.rs
@@ -86,11 +86,11 @@ impl<D: Dispatcher + 'static> SignerClient<D> {
 		let dispatcher = self.dispatcher.clone();
 		let signer = self.signer.clone();
 
-		Box::new(signer.peek(&id).map(|confirmation| {
-			let mut payload = confirmation.payload.clone();
+		Box::new(signer.take(&id).map(|sender| {
+			let mut payload = sender.request.payload.clone();
 			// Modify payload
 			if let ConfirmationPayload::SendTransaction(ref mut request) = payload {
-				if let Some(sender) = modification.sender.clone() {
+				if let Some(sender) = modification.sender {
 					request.from = sender.into();
 					// Altering sender should always reset the nonce.
 					request.nonce = None;
@@ -109,7 +109,7 @@ impl<D: Dispatcher + 'static> SignerClient<D> {
 			Either::A(fut.into_future().then(move |result| {
 				// Execute
 				if let Ok(ref response) = result {
-					signer.request_confirmed(id, Ok((*response).clone()));
+					signer.request_confirmed(sender, Ok((*response).clone()));
 				}
 
 				result
@@ -188,8 +188,9 @@ impl<D: Dispatcher + 'static> Signer for SignerClient<D> {
 	fn confirm_request_raw(&self, id: U256, bytes: Bytes) -> Result<ConfirmationResponse> {
 		let id = id.into();
 
-		self.signer.peek(&id).map(|confirmation| {
-			let result = match confirmation.payload {
+		self.signer.take(&id).map(|sender| {
+			let payload = sender.request.payload.clone();
+			let result = match payload {
 				ConfirmationPayload::SendTransaction(request) => {
 					Self::verify_transaction(bytes, request, |pending_transaction| {
 						self.dispatcher.dispatch_transaction(pending_transaction)
@@ -218,14 +219,14 @@ impl<D: Dispatcher + 'static> Signer for SignerClient<D> {
 				},
 			};
 			if let Ok(ref response) = result {
-				self.signer.request_confirmed(id, Ok(response.clone()));
+				self.signer.request_confirmed(sender, Ok(response.clone()));
 			}
 			result
 		}).unwrap_or_else(|| Err(errors::invalid_params("Unknown RequestID", id)))
 	}
 
 	fn reject_request(&self, id: U256) -> Result<bool> {
-		let res = self.signer.request_rejected(id.into());
+		let res = self.signer.take(&id.into()).map(|sender| self.signer.request_rejected(sender));
 		Ok(res.is_some())
 	}
 

--- a/rpc/src/v1/tests/mocked/signing.rs
+++ b/rpc/src/v1/tests/mocked/signing.rs
@@ -109,7 +109,8 @@ fn should_add_sign_to_queue() {
 	::std::thread::spawn(move || loop {
 		if signer.requests().len() == 1 {
 			// respond
-			signer.request_confirmed(1.into(), Ok(ConfirmationResponse::Signature(0.into())));
+			let sender = signer.take(&1.into()).unwrap();
+			signer.request_confirmed(sender, Ok(ConfirmationResponse::Signature(0.into())));
 			break
 		}
 		::std::thread::sleep(Duration::from_millis(100))
@@ -187,7 +188,8 @@ fn should_check_status_of_request_when_its_resolved() {
 		"id": 1
 	}"#;
 	tester.io.handle_request_sync(&request).expect("Sent");
-	tester.signer.request_confirmed(1.into(), Ok(ConfirmationResponse::Signature(1.into())));
+	let sender = tester.signer.take(&1.into()).unwrap();
+	tester.signer.request_confirmed(sender, Ok(ConfirmationResponse::Signature(1.into())));
 
 	// This is not ideal, but we need to give futures some time to be executed, and they need to run in a separate thread
 	thread::sleep(Duration::from_millis(20));
@@ -258,7 +260,8 @@ fn should_add_transaction_to_queue() {
 	::std::thread::spawn(move || loop {
 		if signer.requests().len() == 1 {
 			// respond
-			signer.request_confirmed(1.into(), Ok(ConfirmationResponse::SendTransaction(0.into())));
+			let sender = signer.take(&1.into()).unwrap();
+			signer.request_confirmed(sender, Ok(ConfirmationResponse::SendTransaction(0.into())));
 			break
 		}
 		::std::thread::sleep(Duration::from_millis(100))
@@ -334,7 +337,8 @@ fn should_add_sign_transaction_to_the_queue() {
 	::std::thread::spawn(move || loop {
 		if signer.requests().len() == 1 {
 			// respond
-			signer.request_confirmed(1.into(), Ok(ConfirmationResponse::SignTransaction(
+			let sender = signer.take(&1.into()).unwrap();
+			signer.request_confirmed(sender, Ok(ConfirmationResponse::SignTransaction(
 				RichRawTransaction::from_signed(t.into(), 0x0, u64::max_value())
 			)));
 			break
@@ -440,7 +444,8 @@ fn should_add_decryption_to_the_queue() {
 	::std::thread::spawn(move || loop {
 		if signer.requests().len() == 1 {
 			// respond
-			signer.request_confirmed(1.into(), Ok(ConfirmationResponse::Decrypt(vec![0x1, 0x2].into())));
+			let sender = signer.take(&1.into()).unwrap();
+			signer.request_confirmed(sender, Ok(ConfirmationResponse::Decrypt(vec![0x1, 0x2].into())));
 			break
 		}
 		::std::thread::sleep(Duration::from_millis(10))


### PR DESCRIPTION
Fixes #8799.

`SignerQueue::peek` is changed to `SignerQueue::take`, which takes the request out of the queue. Subsequent redundant confirmations will not find the sender. The caller then takes the request as the handle, and gives it back to `request_confirmed` or `request_rejected` to notify senders.