### PR TITLE
parity-version: stable release 1.10.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "parity"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1915,7 +1915,7 @@ dependencies = [
  "parity-rpc 1.9.0",
  "parity-rpc-client 1.4.0",
  "parity-updater 1.9.0",
- "parity-version 1.10.6",
+ "parity-version 1.10.7",
  "parity-whisper 0.1.0",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.0",
@@ -1964,7 +1964,7 @@ dependencies = [
  "parity-reactor 0.1.0",
  "parity-ui 1.9.0",
  "parity-ui-deprecation 1.10.0",
- "parity-version 1.10.6",
+ "parity-version 1.10.7",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2115,7 +2115,7 @@ dependencies = [
  "order-stat 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-reactor 0.1.0",
  "parity-updater 1.9.0",
- "parity-version 1.10.6",
+ "parity-version 1.10.7",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2232,7 +2232,7 @@ dependencies = [
  "ethsync 1.9.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-hash-fetch 1.9.0",
- "parity-version 1.10.6",
+ "parity-version 1.10.7",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "path 0.1.0",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "parity-version"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "ethcore-bytes 0.1.0",
  "rlp 0.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Parity Ethereum client"
 name = "parity"
 # NOTE Make sure to update util/version/Cargo.toml as well
-version = "1.10.6"
+version = "1.10.7"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/mac/Parity.pkgproj
+++ b/mac/Parity.pkgproj
@@ -462,7 +462,7 @@
 				<key>OVERWRITE_PERMISSIONS</key>
 				<false/>
 				<key>VERSION</key>
-				<string>1.10.6</string>
+				<string>1.10.7</string>
 			</dict>
 			<key>UUID</key>
 			<string>2DCD5B81-7BAF-4DA1-9251-6274B089FD36</string>

--- a/nsis/installer.nsi
+++ b/nsis/installer.nsi
@@ -10,7 +10,7 @@
 !define DESCRIPTION "Fast, light, robust Ethereum implementation"
 !define VERSIONMAJOR 1
 !define VERSIONMINOR 10
-!define VERSIONBUILD 6
+!define VERSIONBUILD 7
 !define ARGS ""
 !define FIRST_START_ARGS "--mode=passive ui"
 

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -12,14 +12,13 @@ build = "build.rs"
 # Used by auto-updater and for Parity version string.
 track = "stable"
 
-# Indicates a critical release in this track (i.e. consensus issue)
-critical = true
-
-# Latest supported fork blocks for various networks. Used ONLY by auto-updater.
-[package.metadata.forks]
-foundation = 4370000
-ropsten = 10
-kovan = 6600000
+# Network specific settings, used ONLY by auto-updater.
+# Latest supported fork blocks.
+# Indicates a critical release in this track (i.e. consensus issue).
+[package.metadata.networks]
+foundation = { forkBlock = 4370000, critical = false }
+ropsten = { forkBlock = 10, critical = false }
+kovan = { forkBlock = 6600000, critical = false }
 
 [dependencies]
 ethcore-bytes = { path = "../bytes" }

--- a/util/version/Cargo.toml
+++ b/util/version/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "parity-version"
 # NOTE: this value is used for Parity version string (via env CARGO_PKG_VERSION)
-version = "1.10.6"
+version = "1.10.7"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
- backports network-specific release flag (#8821)
- unsets critical release flag
- bumps stable to 1.10.7