### PR TITLE
Fix subcrate test compile

### DIFF
--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -38,6 +38,7 @@ memory-cache = { path = "../../util/memory_cache" }
 error-chain = { version = "0.11", default-features = false }
 
 [dev-dependencies]
+ethcore = { path = "..", features = ["test-helpers"] }
 kvdb-memorydb = { path = "../../util/kvdb-memorydb" }
 tempdir = "0.3"
 

--- a/ethcore/node_filter/Cargo.toml
+++ b/ethcore/node_filter/Cargo.toml
@@ -19,6 +19,7 @@ ethabi-contract = "5.0"
 lru-cache = "0.1"
 
 [dev-dependencies]
+ethcore = { path = "..", features = ["test-helpers"] }
 kvdb-memorydb = { path = "../../util/kvdb-memorydb" }
 ethcore-io = { path = "../../util/io" }
 tempdir = "0.3"

--- a/ethcore/service/Cargo.toml
+++ b/ethcore/service/Cargo.toml
@@ -16,5 +16,6 @@ stop-guard = { path = "../../util/stop-guard" }
 trace-time = { path = "../../util/trace-time" }
 
 [dev-dependencies]
+ethcore = { path = "..", features = ["test-helpers"] }
 tempdir = "0.3"
 kvdb-rocksdb = { path = "../../util/kvdb-rocksdb" }

--- a/ipfs/Cargo.toml
+++ b/ipfs/Cargo.toml
@@ -15,3 +15,6 @@ rlp = { path = "../util/rlp" }
 cid = "0.2"
 multihash = "0.7"
 unicase = "2.0"
+
+[dev-dependencies]
+ethcore = { path = "../ethcore", features = ["test-helpers"] }

--- a/local-store/Cargo.toml
+++ b/local-store/Cargo.toml
@@ -16,5 +16,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
+ethcore = { path = "../ethcore", features = ["test-helpers"] }
 ethkey = { path = "../ethkey" }
 kvdb-memorydb = { path = "../util/kvdb-memorydb" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -65,6 +65,7 @@ stats = { path = "../util/stats" }
 vm = { path = "../ethcore/vm" }
 
 [dev-dependencies]
+ethcore = { path = "../ethcore", features = ["test-helpers"] }
 ethcore-network = { path = "../util/network" }
 fake-fetch = { path = "../util/fake-fetch" }
 kvdb-memorydb = { path = "../util/kvdb-memorydb" }

--- a/secret_store/Cargo.toml
+++ b/secret_store/Cargo.toml
@@ -39,5 +39,6 @@ ethabi-derive = "5.0"
 ethabi-contract = "5.0"
 
 [dev-dependencies]
+ethcore = { path = "../ethcore", features = ["test-helpers"] }
 tempdir = "0.3"
 kvdb-rocksdb = { path = "../util/kvdb-rocksdb" }

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -25,5 +25,6 @@ path = { path = "../util/path" }
 rand = "0.4"
 
 [dev-dependencies]
+ethcore = { path = "../ethcore", features = ["test-helpers"] }
 tempdir = "0.3"
 matches = "0.1"


### PR DESCRIPTION
After #8743, several subcrate dev-dependency features are missed. Because Cargo takes union of feature sets, it's not directly visible when testing against the top-level crate. This PR appends all the missing ones.