### PR TITLE
Fix CLI return code on --help for ethkey, ethstore & whisper

### DIFF
--- a/ethkey/cli/src/main.rs
+++ b/ethkey/cli/src/main.rs
@@ -166,10 +166,11 @@ fn main() {
 
 	match execute(env::args()) {
 		Ok(ok) => println!("{}", ok),
+		Err(Error::Docopt(ref e)) => e.exit(),
 		Err(err) => {
 			println!("{}", err);
 			process::exit(1);
-		},
+		}
 	}
 }
 

--- a/ethstore/cli/src/main.rs
+++ b/ethstore/cli/src/main.rs
@@ -149,6 +149,7 @@ fn main() {
 
 	match execute(env::args()) {
 		Ok(result) => println!("{}", result),
+		Err(Error::Docopt(ref e)) => e.exit(),
 		Err(err) => {
 			println!("{}", err);
 			process::exit(1);

--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -190,11 +190,12 @@ fn main() {
 		Ok(_) => {
 			println!("whisper-cli terminated");
 			process::exit(1);
-		}
+		},
+		Err(Error::Docopt(ref e)) => e.exit(),
 		Err(err) => {
 			println!("{}", err);
 			process::exit(1);
-		},
+		}
 	}
 }
 


### PR DESCRIPTION
Docopt handles `--help` automatically for us, however we've handled those
Errors the same as all others: by exiting with Return Code `1`, which is wrong
for a totally appropriate a quit on `--help`. Fortunately `docopt:Error`
provides an `exit` helper function that discriminates properly between fatal
and non-fatal errors and exist appropriately.

This patch makes sure we use that handy function in case we encounter such an
error in the CLI of ethkey, ethstore and whisper. Thus those are now giving
the appropriate Return code on `--help`.

fixes #8851