### PR TITLE
docker: Fix alpine build

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.7
+FROM alpine:edge
 
 WORKDIR /build
 
 # install tools and dependencies
-RUN apk add --no-cache gcc musl-dev openssl-dev pkgconfig g++ make curl \
-					   eudev-dev rust cargo git file binutils libusb-dev \
-					   linux-headers
+RUN apk add --no-cache gcc musl-dev pkgconfig g++ make curl \
+						eudev-dev rust cargo git file binutils \
+						libusb-dev linux-headers perl
 
 # show backtraces
 ENV RUST_BACKTRACE 1


### PR DESCRIPTION
- Switch to alpine edge for recent rustc version
- Remove openssl libs
- Add perl (needed for building ring)