### PR TITLE
Allow Poll Lifetime to be configured via CLI

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -732,6 +732,10 @@ usage! {
 			"--gas-price-percentile=[PCT]",
 			"Set PCT percentile gas price value from last 100 blocks as default gas price when sending transactions.",
 
+			ARG arg_poll_lifetime: (u32) = 60u32, or |c: &Config| c.mining.as_ref()?.poll_lifetime.clone(),
+			"--poll-lifetime=[S]",
+			"Set the lifetime of the internal index filter to S seconds.",
+
 			ARG arg_author: (Option<String>) = None, or |c: &Config| c.mining.as_ref()?.author.clone(),
 			"--author=[ADDRESS]",
 			"Specify the block author (aka \"coinbase\") address for sending block rewards from sealed blocks. NOTE: MINING WILL NOT WORK WITHOUT THIS OPTION.", // Sealing/Mining Option
@@ -1241,6 +1245,7 @@ struct Mining {
 	relay_set: Option<String>,
 	min_gas_price: Option<u64>,
 	gas_price_percentile: Option<usize>,
+	poll_lifetime: Option<u32>,
 	usd_per_tx: Option<String>,
 	usd_per_eth: Option<String>,
 	price_update_period: Option<String>,
@@ -1664,6 +1669,7 @@ mod tests {
 			arg_min_gas_price: Some(0u64),
 			arg_usd_per_tx: "0.0001".into(),
 			arg_gas_price_percentile: 50usize,
+			arg_poll_lifetime: 60u32,
 			arg_usd_per_eth: "auto".into(),
 			arg_price_update_period: "hourly".into(),
 			arg_gas_floor_target: "4700000".into(),
@@ -1924,6 +1930,7 @@ mod tests {
 				relay_set: None,
 				min_gas_price: None,
 				gas_price_percentile: None,
+				poll_lifetime: None,
 				usd_per_tx: None,
 				usd_per_eth: None,
 				price_update_period: Some("hourly".into()),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -356,6 +356,7 @@ impl Configuration {
 				logger_config: logger_config.clone(),
 				miner_options: self.miner_options()?,
 				gas_price_percentile: self.args.arg_gas_price_percentile,
+				poll_lifetime: self.args.arg_poll_lifetime,
 				ntp_servers: self.ntp_servers(),
 				ws_conf: ws_conf,
 				http_conf: http_conf,
@@ -1398,6 +1399,7 @@ mod tests {
 			logger_config: Default::default(),
 			miner_options: Default::default(),
 			gas_price_percentile: 50,
+			poll_lifetime: 60,
 			ntp_servers: vec![
 				"0.parity.pool.ntp.org:123".into(),
 				"1.parity.pool.ntp.org:123".into(),

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -235,6 +235,7 @@ pub struct FullDependencies {
 	pub remote: parity_reactor::Remote,
 	pub whisper_rpc: Option<::whisper::RpcFactory>,
 	pub gas_price_percentile: usize,
+	pub poll_lifetime: u32,
 }
 
 impl FullDependencies {
@@ -288,12 +289,13 @@ impl FullDependencies {
 							allow_pending_receipt_query: !self.geth_compatibility,
 							send_block_number_in_get_work: !self.geth_compatibility,
 							gas_price_percentile: self.gas_price_percentile,
+							poll_lifetime: self.poll_lifetime
 						}
 					);
 					handler.extend_with(client.to_delegate());
 
 					if !for_generic_pubsub {
-						let filter_client = EthFilterClient::new(self.client.clone(), self.miner.clone());
+						let filter_client = EthFilterClient::new(self.client.clone(), self.miner.clone(), self.poll_lifetime);
 						handler.extend_with(filter_client.to_delegate());
 
 						add_signing_methods!(EthSigning, handler, self, nonces.clone());
@@ -447,6 +449,7 @@ pub struct LightDependencies<T> {
 	pub whisper_rpc: Option<::whisper::RpcFactory>,
 	pub private_tx_service: Option<Arc<PrivateTransactionManager>>,
 	pub gas_price_percentile: usize,
+	pub poll_lifetime: u32,
 }
 
 impl<C: LightChainClient + 'static> LightDependencies<C> {
@@ -504,6 +507,7 @@ impl<C: LightChainClient + 'static> LightDependencies<C> {
 						self.secret_store.clone(),
 						self.cache.clone(),
 						self.gas_price_percentile,
+						self.poll_lifetime,
 					);
 					handler.extend_with(Eth::to_delegate(client.clone()));
 

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -90,6 +90,7 @@ pub struct RunCmd {
 	pub logger_config: LogConfig,
 	pub miner_options: MinerOptions,
 	pub gas_price_percentile: usize,
+	pub poll_lifetime: u32,
 	pub ntp_servers: Vec<String>,
 	pub ws_conf: rpc::WsConfiguration,
 	pub http_conf: rpc::HttpConfiguration,
@@ -350,6 +351,7 @@ fn execute_light_impl(cmd: RunCmd, logger: Arc<RotatingLogger>) -> Result<Runnin
 		whisper_rpc: whisper_factory,
 		private_tx_service: None, //TODO: add this to client.
 		gas_price_percentile: cmd.gas_price_percentile,
+		poll_lifetime: cmd.poll_lifetime
 	});
 
 	let dependencies = rpc::Dependencies {
@@ -779,6 +781,7 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 		whisper_rpc: whisper_factory,
 		private_tx_service: Some(private_tx_service.clone()),
 		gas_price_percentile: cmd.gas_price_percentile,
+		poll_lifetime: cmd.poll_lifetime,
 	});
 
 	let dependencies = rpc::Dependencies {

--- a/rpc/src/v1/helpers/poll_manager.rs
+++ b/rpc/src/v1/helpers/poll_manager.rs
@@ -18,9 +18,6 @@
 
 use transient_hashmap::{TransientHashMap, Timer, StandardTimer};
 
-/// Lifetime of poll (in seconds).
-const POLL_LIFETIME: u32 = 60;
-
 pub type PollId = usize;
 
 /// Indexes all poll requests.
@@ -32,17 +29,17 @@ pub struct PollManager<F, T = StandardTimer> where T: Timer {
 }
 
 impl<F> PollManager<F, StandardTimer> {
-	/// Creates new instance of indexer.
-	pub fn new() -> Self {
-		PollManager::new_with_timer(Default::default())
+	/// Creates new instance of indexer
+	pub fn new(lifetime: u32) -> Self {
+		PollManager::new_with_timer(Default::default(), lifetime)
 	}
 }
 
 impl<F, T> PollManager<F, T> where T: Timer {
 
-	pub fn new_with_timer(timer: T) -> Self {
+	pub fn new_with_timer(timer: T, lifetime: u32) -> Self {
 		PollManager {
-			polls: TransientHashMap::new_with_timer(POLL_LIFETIME, timer),
+			polls: TransientHashMap::new_with_timer(lifetime, timer),
 			next_available_id: 0,
 		}
 	}
@@ -102,7 +99,7 @@ mod tests {
 			time: &time,
 		};
 
-		let mut indexer = PollManager::new_with_timer(timer);
+		let mut indexer = PollManager::new_with_timer(timer,60);
 		assert_eq!(indexer.create_poll(20), 0);
 		assert_eq!(indexer.create_poll(20), 1);
 

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -65,6 +65,8 @@ pub struct EthClientOptions {
 	pub send_block_number_in_get_work: bool,
 	/// Gas Price Percentile used as default gas price.
 	pub gas_price_percentile: usize,
+	/// Set the timeout for the internal poll manager
+	pub poll_lifetime: u32
 }
 
 impl EthClientOptions {
@@ -83,6 +85,7 @@ impl Default for EthClientOptions {
 			pending_nonce_from_queue: false,
 			allow_pending_receipt_query: true,
 			send_block_number_in_get_work: true,
+			poll_lifetime: 60u32,
 			gas_price_percentile: 50,
 		}
 	}

--- a/rpc/src/v1/impls/eth_filter.rs
+++ b/rpc/src/v1/impls/eth_filter.rs
@@ -66,11 +66,11 @@ pub struct EthFilterClient<C, M> {
 
 impl<C, M> EthFilterClient<C, M> {
 	/// Creates new Eth filter client.
-	pub fn new(client: Arc<C>, miner: Arc<M>) -> Self {
+	pub fn new(client: Arc<C>, miner: Arc<M>, poll_lifetime: u32) -> Self {
 		EthFilterClient {
 			client: client,
 			miner: miner,
-			polls: Mutex::new(PollManager::new()),
+			polls: Mutex::new(PollManager::new(poll_lifetime)),
 		}
 	}
 }

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -62,6 +62,7 @@ pub struct EthClient<T> {
 	accounts: Arc<AccountProvider>,
 	cache: Arc<Mutex<LightDataCache>>,
 	polls: Mutex<PollManager<PollFilter>>,
+	poll_lifetime: u32,
 	gas_price_percentile: usize,
 }
 
@@ -92,7 +93,8 @@ impl<T> Clone for EthClient<T> {
 			transaction_queue: self.transaction_queue.clone(),
 			accounts: self.accounts.clone(),
 			cache: self.cache.clone(),
-			polls: Mutex::new(PollManager::new()),
+			polls: Mutex::new(PollManager::new(self.poll_lifetime)),
+			poll_lifetime: self.poll_lifetime,
 			gas_price_percentile: self.gas_price_percentile,
 		}
 	}
@@ -109,6 +111,7 @@ impl<T: LightChainClient + 'static> EthClient<T> {
 		accounts: Arc<AccountProvider>,
 		cache: Arc<Mutex<LightDataCache>>,
 		gas_price_percentile: usize,
+		poll_lifetime: u32
 	) -> Self {
 		EthClient {
 			sync,
@@ -117,7 +120,8 @@ impl<T: LightChainClient + 'static> EthClient<T> {
 			transaction_queue,
 			accounts,
 			cache,
-			polls: Mutex::new(PollManager::new()),
+			polls: Mutex::new(PollManager::new(poll_lifetime)),
+			poll_lifetime,
 			gas_price_percentile,
 		}
 	}

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -92,8 +92,9 @@ impl EthTester {
 		let hashrates = Arc::new(Mutex::new(HashMap::new()));
 		let external_miner = Arc::new(ExternalMiner::new(hashrates.clone()));
 		let gas_price_percentile = options.gas_price_percentile;
+		let poll_lifetime = options.poll_lifetime;
 		let eth = EthClient::new(&client, &snapshot, &sync, &opt_ap, &miner, &external_miner, options).to_delegate();
-		let filter = EthFilterClient::new(client.clone(), miner.clone()).to_delegate();
+		let filter = EthFilterClient::new(client.clone(), miner.clone(), poll_lifetime).to_delegate();
 		let reservations = Arc::new(Mutex::new(nonce::Reservations::new()));
 
 		let dispatcher = FullDispatcher::new(client.clone(), miner.clone(), reservations, gas_price_percentile);


### PR DESCRIPTION
... rather than it being a hard-coded constant. fixes #5484 .

However, in order to allow this to be configurable, we have to pass through the from the CLI through a range of structs, for which this is unrelated until it finally reaches the internally used PollManager. To achieve this I had to modify, among others, `EthClient` and `EthClientOptions` both of which are public structs exposed by `parity-rpc`. Thus means, these are technically backwards incompatible API-changes, which - under [SemVer](https://semver.org/) - would mean we have to bump the Major version of this crate...? Not sure if we want to do that.

Secondly, I am not super certain I traced the entire flow everywhere and there isn't still a `::Default()` somewhere that creates poll-lifetimes other than what the CLI specifies. Happy for any more experienced reviewer to point them out if I missed any!