### PR TITLE
Remove a weird emoji in new_social docs

### DIFF
--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -81,7 +81,7 @@ pub fn new_easthub<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
 	load(params.into(), include_bytes!("../../res/ethereum/easthub.json"))
 }
 
-/// Create a new Ethereum Social mainnet chain spec ¯\_(ツ)_/¯ .
+/// Create a new Ethereum Social mainnet chain spec.
 pub fn new_social<'a, T: Into<SpecParams<'a>>>(params: T) -> Spec {
 	load(params.into(), include_bytes!("../../res/ethereum/social.json"))
 }


### PR DESCRIPTION
`¯\_(ツ)_/¯`

(Spotted in #8912. But looks like the author decided to close the PR.)