### PR TITLE
Fixed blooms dir creation

### DIFF
--- a/ethcore/src/test_helpers.rs
+++ b/ethcore/src/test_helpers.rs
@@ -331,8 +331,8 @@ pub fn restoration_db_handler(config: kvdb_rocksdb::DatabaseConfig) -> Box<Block
 			let key_value = Arc::new(kvdb_rocksdb::Database::open(&self.config, &db_path.to_string_lossy())?);
 			let blooms_path = db_path.join("blooms");
 			let trace_blooms_path = db_path.join("trace_blooms");
-			fs::create_dir(&blooms_path)?;
-			fs::create_dir(&trace_blooms_path)?;
+			fs::create_dir_all(&blooms_path)?;
+			fs::create_dir_all(&trace_blooms_path)?;
 			let blooms = blooms_db::Database::open(blooms_path).unwrap();
 			let trace_blooms = blooms_db::Database::open(trace_blooms_path).unwrap();
 			let db = RestorationDB {

--- a/parity/db/rocksdb/mod.rs
+++ b/parity/db/rocksdb/mod.rs
@@ -105,8 +105,8 @@ pub fn open_database(client_path: &str, config: &DatabaseConfig) -> Result<Arc<B
 
 	let blooms_path = path.join("blooms");
 	let trace_blooms_path = path.join("trace_blooms");
-	fs::create_dir(&blooms_path)?;
-	fs::create_dir(&trace_blooms_path)?;
+	fs::create_dir_all(&blooms_path)?;
+	fs::create_dir_all(&trace_blooms_path)?;
 
 	let db = AppDB {
 		key_value: Arc::new(Database::open(&config, client_path)?),


### PR DESCRIPTION
@debris I've just replaced `create_dir` with `create_dir_all`, but could you please check that the `blooms` path is what you've expected. On my Ubuntu machine it is `/home/svyatonik/.local/share/io.parity.ethereum/chains/DevelopmentChain/db/1484bce8c021f2ca/overlayrecent/db/blooms`. I haven't reviewed the blooms PR, so not sure - if this is correct.
@Tbaut Sorry - had a yesterday's morning master without this PR merged in :) This PR should fix the issue