### PR TITLE
rpc: cap gas limit of local calls

### DIFF
--- a/rpc/src/v1/helpers/fake_sign.rs
+++ b/rpc/src/v1/helpers/fake_sign.rs
@@ -15,7 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use transaction::{Transaction, SignedTransaction, Action};
-use ethereum_types::U256;
 
 use jsonrpc_core::Error;
 use v1::helpers::CallRequest;
@@ -29,7 +28,7 @@ pub fn sign_call(request: CallRequest, gas_cap: bool) -> Result<SignedTransactio
 		}
 		Some(gas) => gas,
 		None if gas_cap => max_gas,
-		None => U256::from(2) << 50,
+		None => max_gas * 10,
 	};
 	let from = request.from.unwrap_or(0.into());
 


### PR DESCRIPTION
Currently we have effectively unlimited gas for local calls, this leads to issues with unbounded loops in contracts that never end. I've decreased the cap to 500 million gas, which should still be more than enough for local calls.

Fixes #8904, fixes #8311.