### PR TITLE
Print public key of the SS node on start

### DIFF
--- a/parity/secretstore.rs
+++ b/parity/secretstore.rs
@@ -118,7 +118,7 @@ mod server {
 	use std::sync::Arc;
 	use ethcore_secretstore;
 	use ethkey::KeyPair;
-	use ansi_term::Colour::Red;
+	use ansi_term::Colour::{Red, White};
 	use db;
 	use super::{Configuration, Dependencies, NodeSecretKey, ContractAddress};
 
@@ -137,10 +137,6 @@ mod server {
 	impl KeyServer {
 		/// Create new key server
 		pub fn new(mut conf: Configuration, deps: Dependencies) -> Result<Self, String> {
-			if conf.acl_check_contract_address.is_none() {
-				warn!("Running SecretStore with disabled ACL check: {}", Red.bold().paint("everyone has access to stored keys"));
-			}
-
 			let self_secret: Arc<ethcore_secretstore::NodeKeyPair> = match conf.self_secret.take() {
 				Some(NodeSecretKey::Plain(secret)) => Arc::new(ethcore_secretstore::PlainNodeKeyPair::new(
 					KeyPair::from_secret(secret).map_err(|e| format!("invalid secret: {}", e))?)),
@@ -164,6 +160,11 @@ mod server {
 				},
 				None => return Err("self secret is required when using secretstore".into()),
 			};
+
+			info!("Starting SecretStore node: {}", White.bold().paint(format!("{:?}", self_secret.public())));
+			if conf.acl_check_contract_address.is_none() {
+				warn!("Running SecretStore with disabled ACL check: {}", Red.bold().paint("everyone has access to stored keys"));
+			}
 
 			let key_server_name = format!("{}:{}", conf.interface, conf.port);
 			let mut cconf = ethcore_secretstore::ServiceConfiguration {


### PR DESCRIPTION
Background:
- every SS node should have a key pair;
- every SS node should know every other node public key;
- the `self_secret` config option could be: a 64-char secret key or the 40-char address of the account (on this node) that is used to sign/encrypt messages.

Getting the node' public key is especially hard in the 2nd case - afaik we do not have an RPC for getting the account public (it could be recovered from the signature, but it is too hard anyway). So I usually use `./ethstore public <address>` in my scripts. But as @Tbaut has suggested it still isn't the best way to describe in the private transactions tutorial. So I suggest to print it on start (similar to how we're printing enode). This is for `--features secretstore` only, so won't spoil usual output:
```bash
2018-06-22 10:31:26  main INFO parity::secretstore::server  Starting SecretStore node: 0xcac6c205eb06c8308d65156ff6c862c62b000b8ead121a4455a8ddeff7248128d895692136f240d5d1614dc7cc4147b1bd584bd617e30560bb872064d09ea325
2018-06-22 10:31:26  main WARN parity::secretstore::server  Running SecretStore with disabled ACL check: everyone has access to stored keys
```