### PR TITLE
scripts: fix docker build tag on latest using master

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -2,6 +2,10 @@
 cd docker/hub
 DOCKER_BUILD_TAG=$1
 echo "Docker build tag: " $DOCKER_BUILD_TAG
-docker build --build-arg BUILD_TAG=$DOCKER_BUILD_TAG --no-cache=true --tag parity/parity:$DOCKER_BUILD_TAG .
+if [[ "$DOCKER_BUILD_TAG" = "latest" ]]; then
+	docker build --build-arg BUILD_TAG="master" --no-cache=true --tag parity/parity:$DOCKER_BUILD_TAG .
+else
+	docker build --build-arg BUILD_TAG=$DOCKER_BUILD_TAG --no-cache=true --tag parity/parity:$DOCKER_BUILD_TAG .
+fi
 docker run -it parity/parity:$DOCKER_BUILD_TAG -v
 docker push parity/parity:$DOCKER_BUILD_TAG


### PR DESCRIPTION
Fixes https://gitlab.parity.io/parity/parity/-/jobs/90379

`error: pathspec 'latest' did not match any file(s) known to git.`