### PR TITLE
Bump error-chain and quick_error versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "eth-secp256k1"
 version = "0.5.7"
 source = "git+https://github.com/paritytech/rust-secp256k1#db81cfea59014b4d176f10f86ed52e1a130b6822"
@@ -519,7 +527,7 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0",
  "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-contract 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-derive 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -624,7 +632,7 @@ name = "ethcore-light"
 version = "1.12.0"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
  "ethcore-bytes 0.1.0",
  "ethcore-io 1.12.0",
@@ -677,7 +685,7 @@ version = "1.12.0"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethash 1.12.0",
  "ethcore-transaction 0.1.0",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -705,7 +713,7 @@ name = "ethcore-network"
 version = "1.12.0"
 dependencies = [
  "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-crypto 0.1.0",
  "ethcore-io 1.12.0",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -723,7 +731,7 @@ dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-bytes 0.1.0",
  "ethcore-crypto 0.1.0",
  "ethcore-io 1.12.0",
@@ -756,7 +764,7 @@ dependencies = [
 name = "ethcore-private-tx"
 version = "1.0.0"
 dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-contract 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-derive 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -831,7 +839,7 @@ name = "ethcore-service"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
  "ethcore-io 1.12.0",
  "ethcore-private-tx 1.0.0",
@@ -1495,7 +1503,7 @@ name = "kvdb"
 version = "0.1.0"
 dependencies = [
  "elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-bytes 0.1.0",
 ]
 
@@ -1677,7 +1685,7 @@ dependencies = [
 name = "migration-rocksdb"
 version = "0.1.0"
 dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0",
  "kvdb-rocksdb 0.1.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3459,7 +3467,7 @@ dependencies = [
 name = "transaction-pool"
 version = "1.12.1"
 dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3611,7 +3619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "util-error"
 version = "0.1.0"
 dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0",
  "rlp 0.2.1",
@@ -3858,6 +3866,7 @@ dependencies = [
 "checksum elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4851b005ef16de812ea9acdb7bece2f0a40dd86c07b85631d7dafa54537bb"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)" = "<none>"
 "checksum ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05e33a914b94b763f0a92333e4e5c95c095563f06ef7d6b295b3d3c2cf31e21f"
 "checksum ethabi-contract 5.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "210c9e21d164c15b6ef64fe601e0e12a3c84a031d5ef558e38463e53edbd22ed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ name = "ethcore-crypto"
 version = "0.1.0"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (git+https://github.com/paritytech/ring)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -963,7 +963,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mem 0.1.0",
  "parity-wordlist 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3987,7 +3987,7 @@ dependencies = [
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
 "checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
 "checksum quasi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29cec87bc2816766d7e4168302d505dd06b0a825aed41b00633d296e922e02dd"
-"checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0ff51282f28dc1b53fd154298feaa2e77c5ea0dba68e1fd8b03b72fbe13d2a"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -21,7 +21,7 @@ hashdb = { path = "../util/hashdb" }
 memorydb = { path = "../util/memorydb" }
 patricia-trie = { path = "../util/patricia_trie" }
 ethcore-crypto = { path = "crypto" }
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 ethcore-io = { path = "../util/io" }
 ethcore-logger = { path = "../logger" }
 ethcore-miner = { path = "../miner" }

--- a/ethcore/crypto/Cargo.toml
+++ b/ethcore/crypto/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 ethereum-types = "0.3"
-quick-error = "1.2"
+quick-error = "1.2.2"
 ring = "0.12"
 rust-crypto = "0.2.36"
 tiny-keccak = "1.4"

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -35,7 +35,7 @@ keccak-hash = { path = "../../util/hash" }
 triehash = { path = "../../util/triehash" }
 kvdb = { path = "../../util/kvdb" }
 memory-cache = { path = "../../util/memory_cache" }
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 ethcore = { path = "..", features = ["test-helpers"] }

--- a/ethcore/private-tx/Cargo.toml
+++ b/ethcore/private-tx/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 ethabi = "5.1"
 ethabi-contract = "5.0"
 ethabi-derive = "5.0"

--- a/ethcore/service/Cargo.toml
+++ b/ethcore/service/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 ansi_term = "0.10"
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 ethcore = { path = ".." }
 ethcore-io = { path = "../../util/io" }
 ethcore-private-tx = { path = "../private-tx" }

--- a/ethkey/Cargo.toml
+++ b/ethkey/Cargo.toml
@@ -13,7 +13,7 @@ lazy_static = "1.0"
 log = "0.3"
 mem = { path = "../util/mem" }
 parity-wordlist = "1.2"
-quick-error = "1.2"
+quick-error = "1.2.2"
 rand = "0.4"
 rustc-hex = "1.0"
 serde = "1.0"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -16,7 +16,7 @@ url = "1"
 
 # Miner
 ansi_term = "0.10"
-error-chain = "0.11"
+error-chain = "0.12"
 ethcore-transaction = { path = "../ethcore/transaction" }
 ethereum-types = "0.3"
 futures = "0.1"

--- a/transaction-pool/Cargo.toml
+++ b/transaction-pool/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-error-chain = "0.11"
+error-chain = "0.12"
 log = "0.3"
 smallvec = "0.4"
 trace-time = { path = "../util/trace-time", version = "0.1" }

--- a/util/error/Cargo.toml
+++ b/util/error/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Parity Technologies <admin@parity.io>"]
 rlp = { path = "../rlp" }
 kvdb = { path = "../kvdb" }
 ethereum-types = "0.3"
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 rustc-hex = "1.0"

--- a/util/kvdb/Cargo.toml
+++ b/util/kvdb/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 elastic-array = "0.10"
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 ethcore-bytes = { path = "../bytes" }

--- a/util/migration-rocksdb/Cargo.toml
+++ b/util/migration-rocksdb/Cargo.toml
@@ -8,7 +8,7 @@ log = "0.3"
 macros = { path = "../macros" }
 kvdb = { path = "../kvdb" }
 kvdb-rocksdb = { path = "../kvdb-rocksdb" }
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/util/network-devp2p/Cargo.toml
+++ b/util/network-devp2p/Cargo.toml
@@ -34,7 +34,7 @@ snappy = { git = "https://github.com/paritytech/rust-snappy" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
-error-chain = { version = "0.11", default-features = false }
+error-chain = { version = "0.12", default-features = false }
 ethcore-crypto = { path = "../../ethcore/crypto" }
 ethcore-io = { path = "../io" }
 ethereum-types = "0.3"


### PR DESCRIPTION
Both crates released minor releases to address warning-spam in latest nightlies.