### PR TITLE
Tentative fix for missing dependency error

### DIFF
--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -67,7 +67,7 @@ keccak-hash = { path = "../util/hash" }
 triehash = { path = "../util/triehash" }
 unexpected = { path = "../util/unexpected" }
 journaldb = { path = "../util/journaldb" }
-tempdir = { version = "0.3", optional = true }
+tempdir = "0.3"
 kvdb-rocksdb = { path = "../util/kvdb-rocksdb" }
 
 [dev-dependencies]
@@ -84,10 +84,10 @@ evm-debug-tests = ["evm-debug", "evm/evm-debug-tests"]
 # EVM debug traces are printed.
 slow-blocks = []
 # Run JSON consensus tests.
-json-tests = ["ethcore-transaction/json-tests", "test-helpers", "tempdir"]
+json-tests = ["ethcore-transaction/json-tests", "test-helpers"]
 # Run memory/cpu heavy tests.
 test-heavy = []
 # Compile benches
 benches = []
 # Compile test helpers
-test-helpers = ["tempdir"]
+test-helpers = []

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -109,7 +109,6 @@ extern crate vm;
 extern crate wasm;
 extern crate memory_cache;
 extern crate journaldb;
-#[cfg(any(test, feature = "json-tests", feature = "test-helpers"))]
 extern crate tempdir;
 
 #[macro_use]


### PR DESCRIPTION
A recent merge seems to have broken the dependency resolution. The `tempdir` crate is needed for a normal build, not optional.