### PR TITLE
Stable: Backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,20 +1986,6 @@ dependencies = [
 [[package]]
 name = "parity-dapps-glue"
 version = "1.9.1"
-dependencies = [
- "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime_guess 2.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parity-dapps-glue"
-version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2528,14 +2514,6 @@ dependencies = [
  "syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quasi_macros"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3743,7 +3721,6 @@ dependencies = [
 "checksum pwasm-utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d51e9954a77aab7b4b606dc315a49cbed187924f163b6750cdf6d5677dbf0839"
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
 "checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
-"checksum quasi_macros 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29cec87bc2816766d7e4168302d505dd06b0a825aed41b00633d296e922e02dd"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ panic = "abort"
 [workspace]
 members = [
 	"chainspec",
-	"dapps/js-glue",
 	"ethcore/wasm/run",
 	"ethcore/types",
 	"ethkey/cli",

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -1425,18 +1425,24 @@ impl BlockChain {
 
 	/// Returns general blockchain information
 	pub fn chain_info(&self) -> BlockChainInfo {
+		// Make sure to call internal methods first to avoid
+		// recursive locking of `best_block`.
+		let first_block_hash = self.first_block();
+		let first_block_number = self.first_block_number().into();
+		let genesis_hash = self.genesis_hash();
+
 		// ensure data consistencly by locking everything first
 		let best_block = self.best_block.read();
 		let best_ancient_block = self.best_ancient_block.read();
 		BlockChainInfo {
 			total_difficulty: best_block.total_difficulty.clone(),
 			pending_total_difficulty: best_block.total_difficulty.clone(),
-			genesis_hash: self.genesis_hash(),
+			genesis_hash,
 			best_block_hash: best_block.hash,
 			best_block_number: best_block.number,
 			best_block_timestamp: best_block.timestamp,
-			first_block_hash: self.first_block(),
-			first_block_number: From::from(self.first_block_number()),
+			first_block_hash,
+			first_block_number,
 			ancient_block_hash: best_ancient_block.as_ref().map(|b| b.hash),
 			ancient_block_number: best_ancient_block.as_ref().map(|b| b.number),
 		}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,8 @@ parts:
   parity:
     source: .
     plugin: rust
+  # rust-channel: stable  # @TODO enable after https://bugs.launchpad.net/snapcraft/+bug/1778530
+    rust-revision: 1.26.2 # @TODO remove after https://bugs.launchpad.net/snapcraft/+bug/1778530
     build-attributes: [no-system-libraries]
     build-packages: [g++, libudev-dev, libssl-dev, make, pkg-config]
     stage-packages: [libc6, libssl1.0.0, libudev1, libstdc++6]


### PR DESCRIPTION
- [x] snap: downgrade rust to revision 1.26.2 (#8984)
- [x] ethcore: fix deadlock in blockchain. (#8977)
- [x] dapps: remove js-glue from workspace