### PR TITLE
Preserve the current abort behavior

### DIFF
--- a/util/panic_hook/src/lib.rs
+++ b/util/panic_hook/src/lib.rs
@@ -21,6 +21,7 @@ extern crate backtrace;
 use std::io::{self, Write};
 use std::panic::{self, PanicInfo};
 use std::thread;
+use std::process;
 use backtrace::Backtrace;
 
 /// Set the panic hook
@@ -66,4 +67,5 @@ fn panic_hook(info: &PanicInfo) {
 	);
 
 	let _ = writeln!(stderr, "{}", ABOUT_PANIC);
+	process::abort();
 }


### PR DESCRIPTION
While removing panic=abort fixed the build, another issue is that our process is currently expected to be aborted if any of the threads fail. So this adds explicit process abort at the end of the panic hook.