### PR TITLE
Fixes for misbehavior reporting in AuthorityRound

### DIFF
--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1114,8 +1114,10 @@ impl Engine<EthereumMachine> for AuthorityRound {
 
 		match verify_timestamp(&self.step.inner, header_step(header, self.empty_steps_transition)?) {
 			Err(BlockError::InvalidSeal) => {
-				let set_number = self.epoch_set(header)?.1;
-				self.validators.report_benign(header.author(), set_number, header.number());
+				if let Ok((_, set_number)) = self.epoch_set(header) {
+					self.validators.report_benign(header.author(), set_number, header.number());
+				}
+
 				Err(BlockError::InvalidSeal.into())
 			}
 			Err(e) => Err(e.into()),

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1129,9 +1129,9 @@ impl Engine<EthereumMachine> for AuthorityRound {
 					let skipped_primary = step_proposer(&*self.validators, &parent.hash(), s);
 					// Do not report this signer.
 					if skipped_primary != me {
-						self.validators.report_benign(&skipped_primary, set_number, header.number());
 						// Stop reporting once validators start repeating.
 						if !reported.insert(skipped_primary) { break; }
+						self.validators.report_benign(&skipped_primary, set_number, header.number());
  					}
  				}
 			}

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1605,7 +1605,6 @@ mod tests {
 		parent_header.set_seal(vec![encode(&1usize).into_vec()]);
 		parent_header.set_gas_limit("222222".parse::<U256>().unwrap());
 		let mut header: Header = Header::default();
-		header.set_number(1);
 		header.set_gas_limit("222222".parse::<U256>().unwrap());
 		header.set_seal(vec![encode(&3usize).into_vec()]);
 
@@ -1615,8 +1614,15 @@ mod tests {
 
 		aura.set_signer(Arc::new(AccountProvider::transient_provider()), Default::default(), "".into());
 
+		// Do not report on steps skipped between genesis and first block.
+		header.set_number(1);
 		assert!(aura.verify_block_family(&header, &parent_header).is_ok());
-		assert_eq!(last_benign.load(AtomicOrdering::SeqCst), 1);
+		assert_eq!(last_benign.load(AtomicOrdering::SeqCst), 0);
+
+		// Report on skipped steps otherwise.
+		header.set_number(2);
+		assert!(aura.verify_block_family(&header, &parent_header).is_ok());
+		assert_eq!(last_benign.load(AtomicOrdering::SeqCst), 2);
 	}
 
 	#[test]

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -1086,7 +1086,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 		let step = header_step(header, self.empty_steps_transition)?;
 		let parent_step = header_step(parent, self.empty_steps_transition)?;
 
-		let (_, set_number) = self.epoch_set(header)?;
+		let (validators, set_number) = self.epoch_set(header)?;
 
 		// Ensure header is from the step after parent.
 		if step == parent_step
@@ -1113,7 +1113,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 							format!("empty step proof for invalid parent hash: {:?}", empty_step.parent_hash)))?;
 					}
 
-					if !empty_step.verify(&*self.validators).unwrap_or(false) {
+					if !empty_step.verify(&validators).unwrap_or(false) {
 						Err(EngineError::InsufficientProof(
 							format!("invalid empty step proof: {:?}", empty_step)))?;
 					}
@@ -1133,7 +1133,7 @@ impl Engine<EthereumMachine> for AuthorityRound {
 					   header.author(), step, parent_step);
 				let mut reported = HashSet::new();
 				for s in parent_step + 1..step {
-					let skipped_primary = step_proposer(&*self.validators, &parent.hash(), s);
+					let skipped_primary = step_proposer(&validators, &parent.hash(), s);
 					// Do not report this signer.
 					if skipped_primary != me {
 						// Stop reporting once validators start repeating.

--- a/ethcore/src/engines/authority_round/mod.rs
+++ b/ethcore/src/engines/authority_round/mod.rs
@@ -721,6 +721,11 @@ impl AuthorityRound {
 	}
 
 	fn report_skipped(&self, header: &Header, current_step: usize, parent_step: usize, validators: &ValidatorSet, set_number: u64) {
+		// we're building on top of the genesis block so don't report any skipped steps
+		if header.number() == 1 {
+			return;
+		}
+
 		if let (true, Some(me)) = (current_step > parent_step + 1, self.signer.read().address()) {
 			debug!(target: "engine", "Author {} built block with step gap. current step: {}, parent step: {}",
 				   header.author(), current_step, parent_step);

--- a/ethcore/src/engines/validator_set/mod.rs
+++ b/ethcore/src/engines/validator_set/mod.rs
@@ -53,7 +53,7 @@ pub fn new_validator_set(spec: ValidatorSpec) -> Box<ValidatorSet> {
 }
 
 /// A validator set.
-pub trait ValidatorSet: Send + Sync {
+pub trait ValidatorSet: Send + Sync + 'static {
 	/// Get the default "Call" helper, for use in general operation.
 	// TODO [keorn]: this is a hack intended to migrate off of
 	// a strict dependency on state always being available.

--- a/ethcore/src/engines/validator_set/simple_list.rs
+++ b/ethcore/src/engines/validator_set/simple_list.rs
@@ -104,6 +104,12 @@ impl ValidatorSet for SimpleList {
 	}
 }
 
+impl AsRef<ValidatorSet> for SimpleList {
+    fn as_ref(&self) -> &ValidatorSet {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
 	use std::str::FromStr;


### PR DESCRIPTION
- Use the epoch set when validating
- Always report on the contract (`self.validators`)
- Use correct epoch number when reporting
- Report skipped primaries when generating seal (otherwise the current sealer won't report misbehavior since it won't verify his own block)