### PR TITLE
Attempt to graceful shutdown in case of panics

### DIFF
--- a/ethkey/cli/src/main.rs
+++ b/ethkey/cli/src/main.rs
@@ -161,7 +161,7 @@ impl DisplayMode {
 }
 
 fn main() {
-	panic_hook::set();
+	panic_hook::set_abort();
 	env_logger::init().expect("Logger initialized only once.");
 
 	match execute(env::args()) {

--- a/ethstore/cli/src/main.rs
+++ b/ethstore/cli/src/main.rs
@@ -145,7 +145,7 @@ impl fmt::Display for Error {
 }
 
 fn main() {
-	panic_hook::set();
+	panic_hook::set_abort();
 
 	match execute(env::args()) {
 		Ok(result) => println!("{}", result),

--- a/evmbin/src/main.rs
+++ b/evmbin/src/main.rs
@@ -91,7 +91,7 @@ General options:
 "#;
 
 fn main() {
-	panic_hook::set();
+	panic_hook::set_abort();
 
 	let args: Args = Docopt::new(USAGE).and_then(|d| d.deserialize()).unwrap_or_else(|e| e.exit());
 

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -150,6 +150,11 @@ fn main_direct(force_can_restart: bool) -> i32 {
 			ExecutionAction::Instant(Some(s)) => { println!("{}", s); 0 },
 			ExecutionAction::Instant(None) => 0,
 			ExecutionAction::Running(client) => {
+				panic_hook::set_with({
+					let e = exit.clone();
+					move || { e.1.notify_all(); }
+				});
+
 				CtrlC::set_handler({
 					let e = exit.clone();
 					move || { e.1.notify_all(); }
@@ -195,7 +200,7 @@ macro_rules! trace_main {
 }
 
 fn main() {
-	panic_hook::set();
+	panic_hook::set_abort();
 
 	// assuming the user is not running with `--force-direct`, then:
 	// if argv[0] == "parity" and this executable != ~/.parity-updates/parity, run that instead.

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -153,6 +153,8 @@ fn main_direct(force_can_restart: bool) -> i32 {
 		spec_name_override: None
 	}), Condvar::new()));
 
+	// Double panic can happen. So when we lock `ExitStatus` after the main thread is notified, it cannot be locked
+	// again.
 	let exiting = Arc::new(AtomicBool::new(false));
 
 	let exec = if can_restart {

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -117,13 +117,13 @@ const PLEASE_RESTART_EXIT_CODE: i32 = 69;
 /// Status used to exit or restart the program.
 struct ExitStatus {
 	/// Whether the program panicked.
-	pub panicking: bool,
+	panicking: bool,
 	/// Whether the program should exit.
-	pub should_exit: bool,
+	should_exit: bool,
 	/// Whether the program should restart.
-	pub should_restart: bool,
+	should_restart: bool,
 	/// If a restart happens, whether a new chain spec should be used.
-	pub spec_name_override: Option<String>,
+	spec_name_override: Option<String>,
 }
 
 // Run our version of parity.

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -112,6 +112,18 @@ fn run_parity() -> Option<i32> {
 
 const PLEASE_RESTART_EXIT_CODE: i32 = 69;
 
+/// Status used to exit or restart the program.
+struct ExitStatus {
+	/// Whetehr the program panicked.
+	pub panicking: bool,
+	/// Whether the program should exit.
+	pub should_exit: bool,
+	/// Whether the program should restart.
+	pub should_restart: bool,
+	/// If a restart happens, whether a new chain spec should be used.
+	pub spec_name_override: Option<String>,
+}
+
 // Run our version of parity.
 // Returns the exit error code.
 fn main_direct(force_can_restart: bool) -> i32 {
@@ -132,14 +144,42 @@ fn main_direct(force_can_restart: bool) -> i32 {
 	// increase max number of open files
 	raise_fd_limit();
 
-	let exit = Arc::new((Mutex::new((false, None)), Condvar::new()));
+	let exit = Arc::new((Mutex::new(ExitStatus {
+		panicking: false,
+		should_exit: false,
+		should_restart: false,
+		spec_name_override: None
+	}), Condvar::new()));
 
 	let exec = if can_restart {
-		let e1 = exit.clone();
-		let e2 = exit.clone();
-		start(conf,
-			move |new_chain: String| { *e1.0.lock() = (true, Some(new_chain)); e1.1.notify_all(); },
-			move || { *e2.0.lock() = (true, None); e2.1.notify_all(); })
+		start(
+			conf,
+			{
+				let e = exit.clone();
+				move |new_chain: String| {
+					*e.0.lock() = ExitStatus {
+						panicking: false,
+						should_exit: true,
+						should_restart: true,
+						spec_name_override: Some(new_chain),
+					};
+					e.1.notify_all();
+				}
+			},
+			{
+				let e = exit.clone();
+				move || {
+					*e.0.lock() = ExitStatus {
+						panicking: false,
+						should_exit: true,
+						should_restart: true,
+						spec_name_override: None,
+					};
+					e.1.notify_all();
+				}
+			}
+		)
+
 	} else {
 		trace!(target: "mode", "Not hypervised: not setting exit handlers.");
 		start(conf, move |_| {}, move || {})
@@ -152,28 +192,49 @@ fn main_direct(force_can_restart: bool) -> i32 {
 			ExecutionAction::Running(client) => {
 				panic_hook::set_with({
 					let e = exit.clone();
-					move || { e.1.notify_all(); }
+					move || {
+						*e.0.lock() = ExitStatus {
+							panicking: true,
+							should_exit: true,
+							should_restart: false,
+							spec_name_override: None,
+						};
+						e.1.notify_all();
+					}
 				});
 
 				CtrlC::set_handler({
 					let e = exit.clone();
-					move || { e.1.notify_all(); }
+					move || {
+						*e.0.lock() = ExitStatus {
+							panicking: false,
+							should_exit: true,
+							should_restart: false,
+							spec_name_override: None,
+						};
+						e.1.notify_all();
+					}
 				});
 
 				// Wait for signal
 				let mut lock = exit.0.lock();
-				let _ = exit.1.wait(&mut lock);
+				if !lock.should_exit {
+					let _ = exit.1.wait(&mut lock);
+				}
 
 				client.shutdown();
 
-				match &*lock {
-					&(true, ref spec_name_override) => {
-						if let &Some(ref spec_name) = spec_name_override {
-							set_spec_name_override(spec_name.clone());
-						}
-						PLEASE_RESTART_EXIT_CODE
-					},
-					_ => 0,
+				if lock.should_restart {
+					if let Some(ref spec_name) = lock.spec_name_override {
+						set_spec_name_override(spec_name.clone());
+					}
+					PLEASE_RESTART_EXIT_CODE
+				} else {
+					if lock.panicking {
+						1
+					} else {
+						0
+					}
 				}
 			},
 		},

--- a/util/panic_hook/src/lib.rs
+++ b/util/panic_hook/src/lib.rs
@@ -29,7 +29,7 @@ pub fn set_abort() {
 	set_with(|| process::abort());
 }
 
-/// Set the panic hook with an optional Condvar to be notified
+/// Set the panic hook with a closure to be called afterwards.
 pub fn set_with<F: Fn() + Send + Sync + 'static>(f: F) {
 	panic::set_hook(Box::new(move |info| {
 		panic_hook(info);

--- a/util/panic_hook/src/lib.rs
+++ b/util/panic_hook/src/lib.rs
@@ -25,8 +25,16 @@ use std::process;
 use backtrace::Backtrace;
 
 /// Set the panic hook
-pub fn set() {
-	panic::set_hook(Box::new(panic_hook));
+pub fn set_abort() {
+	set_with(|| process::abort());
+}
+
+/// Set the panic hook with an optional Condvar to be notified
+pub fn set_with<F: Fn() + Send + Sync + 'static>(f: F) {
+	panic::set_hook(Box::new(move |info| {
+		panic_hook(info);
+		f();
+	}));
 }
 
 static ABOUT_PANIC: &str = "
@@ -67,5 +75,4 @@ fn panic_hook(info: &PanicInfo) {
 	);
 
 	let _ = writeln!(stderr, "{}", ABOUT_PANIC);
-	process::abort();
 }

--- a/whisper/cli/src/main.rs
+++ b/whisper/cli/src/main.rs
@@ -184,7 +184,7 @@ impl fmt::Display for Error {
 }
 
 fn main() {
-	panic_hook::set();
+	panic_hook::set_abort();
 
 	match execute(env::args()) {
 		Ok(_) => {


### PR DESCRIPTION
Panics in our code indicates logic errors. However, it still happens. And if it does, the current behavior causes all Drop handlers not being called and possibly lead to resources not being freed or shutdown. This can lead to a "slippery slop", where if panic happens to an user, it can lead to other panics in the future (with a totally unrelated reason that won't help us to debug the issue). This possibly resulted in the "transaction/block not found in the database; qed" and other panic errors we occasionally see in some issue reports.

This PR makes it so that it still aborts on panic initially when the program starts. After it has started, at the first occasion when we can, switch to graceful shutdown.

* `std::panic::set_hook` is thread-safe as it internally uses Mutex.
* The `should_exit` boolean is added to `ExitStatus`, because we may have a situation where a panic happens after `panic_hook::set_with`, but before we can wait on `exit.1`.
* The `exiting` atomic boolean is used because double panic can happen, and as we lock `ExitStatus` after the main thread is notified, it cannot be locked again.