### PR TITLE
Add option for user to set max size limit for RPC requests

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -482,6 +482,10 @@ usage! {
 			"--jsonrpc-server-threads=[NUM]",
 			"Enables multiple threads handling incoming connections for HTTP JSON-RPC server.",
 
+			ARG arg_jsonrpc_max_payload: (Option<usize>) = None, or |c: &Config| c.rpc.as_ref()?.max_payload,
+			"--jsonrpc-max-size=[NUM]",
+			"Specify maximum size for RPC requests in megabytes.",
+
 		["API and Console Options – WebSockets"]
 			FLAG flag_no_ws: (bool) = false, or |c: &Config| c.websockets.as_ref()?.disable.clone(),
 			"--no-ws",
@@ -1165,6 +1169,7 @@ struct Rpc {
 	hosts: Option<Vec<String>>,
 	server_threads: Option<usize>,
 	processing_threads: Option<usize>,
+	max_payload: Option<usize>,
 }
 
 #[derive(Default, Debug, PartialEq, Deserialize)]

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -879,6 +879,10 @@ impl Configuration {
 				_ => 1,
 			},
 			processing_threads: self.args.arg_jsonrpc_threads,
+			max_payload: match self.args.arg_jsonrpc_max_payload {
+				Some(max) if max > 0 => max as usize,
+				_ => 5usize,
+			},
 		};
 
 		Ok(conf)

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -45,6 +45,7 @@ pub struct HttpConfiguration {
 	pub hosts: Option<Vec<String>>,
 	pub server_threads: usize,
 	pub processing_threads: usize,
+	pub max_payload: usize,
 }
 
 impl HttpConfiguration {
@@ -64,6 +65,7 @@ impl Default for HttpConfiguration {
 			hosts: Some(vec![]),
 			server_threads: 1,
 			processing_threads: 4,
+			max_payload: 5,
 		}
 	}
 }
@@ -232,6 +234,7 @@ pub fn new_http<D: rpc_apis::Dependencies>(
 		rpc::RpcExtractor,
 		middleware,
 		conf.server_threads,
+		conf.max_payload,
 	);
 
 	match start_result {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -140,6 +140,7 @@ pub fn start_http<M, S, H, T, R>(
 	extractor: T,
 	middleware: Option<R>,
 	threads: usize,
+	max_payload: usize,
 ) -> ::std::io::Result<HttpServer> where
 	M: jsonrpc_core::Metadata,
 	S: jsonrpc_core::Middleware<M>,
@@ -152,7 +153,8 @@ pub fn start_http<M, S, H, T, R>(
 		.threads(threads)
 		.event_loop_remote(remote)
 		.cors(cors_domains.into())
-		.allowed_hosts(allowed_hosts.into());
+		.allowed_hosts(allowed_hosts.into())
+		.max_request_body_size(max_payload * 1024 * 1024);
 
 	if let Some(dapps) = middleware {
 		builder = builder.request_middleware(dapps)


### PR DESCRIPTION
Add option for user to set max size limit for RPC requests. This was requested in #8961.