### PR TITLE
Make work-notify an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ winapi = { version = "0.3.4", features = ["winsock2", "winuser", "shellapi"] }
 daemonize = { git = "https://github.com/paritytech/daemonize" }
 
 [features]
-default = ["dapps"]
+default = ["dapps", "work-notify"]
 dapps = ["parity-dapps"]
 json-tests = ["ethcore/json-tests"]
 test-heavy = ["ethcore/test-heavy"]
@@ -106,6 +106,7 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 # `valgrind --tool=massif /path/to/parity <parity params>`
 # and `massif-visualizer` for visualization
 memory_profiling = []
+work-notify = ["ethcore/work-notify"]
 
 [lib]
 path = "parity/lib.rs"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -97,3 +97,4 @@ test-heavy = []
 benches = []
 # Compile test helpers
 test-helpers = ["tempdir"]
+work-notify = ["ethcore-miner/work-notify"]

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -24,6 +24,7 @@ use engines::{EthEngine, Seal};
 use error::{Error, ErrorKind, ExecutionError};
 use ethcore_miner::gas_pricer::GasPricer;
 use ethcore_miner::pool::{self, TransactionQueue, VerifiedTransaction, QueueStatus, PrioritizationStrategy};
+#[cfg(feature = "work-notify")]
 use ethcore_miner::work_notify::NotifyWork;
 use ethereum_types::{H256, U256, Address};
 use parking_lot::{Mutex, RwLock};
@@ -200,6 +201,7 @@ pub struct Miner {
 	// NOTE [ToDr]  When locking always lock in this order!
 	sealing: Mutex<SealingWork>,
 	params: RwLock<AuthoringParams>,
+	#[cfg(feature = "work-notify")]
 	listeners: RwLock<Vec<Box<NotifyWork>>>,
 	nonce_cache: RwLock<HashMap<Address, U256>>,
 	gas_pricer: Mutex<GasPricer>,
@@ -211,6 +213,7 @@ pub struct Miner {
 }
 
 impl Miner {
+	#[cfg(feature = "work-notify")]
 	/// Push listener that will handle new jobs
 	pub fn add_work_listener(&self, notifier: Box<NotifyWork>) {
 		self.listeners.write().push(notifier);
@@ -238,6 +241,7 @@ impl Miner {
 				last_request: None,
 			}),
 			params: RwLock::new(AuthoringParams::default()),
+			#[cfg(feature = "work-notify")]
 			listeners: RwLock::new(vec![]),
 			gas_pricer: Mutex::new(gas_pricer),
 			nonce_cache: RwLock::new(HashMap::with_capacity(1024)),
@@ -491,7 +495,14 @@ impl Miner {
 	/// 1. --force-sealing CLI parameter is provided
 	/// 2. There are listeners awaiting new work packages (e.g. remote work notifications or stratum).
 	fn forced_sealing(&self) -> bool {
-		self.options.force_sealing || !self.listeners.read().is_empty()
+		let listeners_empty = {
+			#[cfg(feature = "work-notify")]
+			{ self.listeners.read().is_empty() }
+			#[cfg(not(feature = "work-notify"))]
+			{ true }
+		};
+
+		self.options.force_sealing || !listeners_empty
 	}
 
 	/// Check is reseal is allowed and necessary.
@@ -639,9 +650,13 @@ impl Miner {
 				let is_new = original_work_hash.map_or(true, |h| h != block_hash);
 
 				sealing.queue.push(block);
-				// If push notifications are enabled we assume all work items are used.
-				if is_new && !self.listeners.read().is_empty() {
-					sealing.queue.use_last_ref();
+
+				#[cfg(feature = "work-notify")]
+				{
+					// If push notifications are enabled we assume all work items are used.
+					if is_new && !self.listeners.read().is_empty() {
+						sealing.queue.use_last_ref();
+					}
 				}
 
 				(Some((block_hash, *block_header.difficulty(), block_header.number())), is_new)
@@ -655,12 +670,23 @@ impl Miner {
 			);
 			(work, is_new)
 		};
-		if is_new {
-			work.map(|(pow_hash, difficulty, number)| {
-				for notifier in self.listeners.read().iter() {
-					notifier.notify(pow_hash, difficulty, number)
-				}
-			});
+
+		#[cfg(feature = "work-notify")]
+		{
+			if is_new {
+				work.map(|(pow_hash, difficulty, number)| {
+					for notifier in self.listeners.read().iter() {
+						notifier.notify(pow_hash, difficulty, number)
+					}
+				});
+			}
+		}
+
+		// NB: hack to use variables to avoid warning.
+		#[cfg(not(feature = "work-notify"))]
+		{
+			let _work = work;
+			let _is_new = is_new;
 		}
 	}
 
@@ -1405,6 +1431,7 @@ mod tests {
 		assert!(!miner.is_currently_sealing());
 	}
 
+	#[cfg(feature = "work-notify")]
 	#[test]
 	fn should_mine_if_fetch_work_request() {
 		struct DummyNotifyWork;

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -8,11 +8,11 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 # Only work_notify, consider a separate crate
-ethash = { path = "../ethash" }
-fetch = { path = "../util/fetch" }
-hyper = "0.11"
-parity-reactor = { path = "../util/reactor" }
-url = "1"
+ethash = { path = "../ethash", optional = true }
+fetch = { path = "../util/fetch", optional = true }
+hyper = { version = "0.11", optional = true }
+parity-reactor = { path = "../util/reactor", optional = true }
+url = { version = "1", optional = true }
 
 # Miner
 ansi_term = "0.10"
@@ -35,3 +35,6 @@ transaction-pool = { path = "../transaction-pool" }
 env_logger = "0.4"
 ethkey = { path = "../ethkey" }
 rustc-hex = "1.0"
+
+[features]
+work-notify = ["ethash", "fetch", "hyper", "parity-reactor", "url"]

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -49,4 +49,5 @@ extern crate env_logger;
 pub mod external;
 pub mod gas_pricer;
 pub mod pool;
+#[cfg(feature = "work-notify")]
 pub mod work_notify;

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -31,6 +31,7 @@ use ethcore::verification::queue::VerifierSettings;
 use ethcore_logger::{Config as LogConfig, RotatingLogger};
 use ethcore_service::ClientService;
 use sync::{self, SyncConfig};
+#[cfg(feature = "work-notify")]
 use miner::work_notify::WorkPoster;
 use futures_cpupool::CpuPool;
 use hash_fetch::{self, fetch};
@@ -528,11 +529,16 @@ fn execute_impl<Cr, Rr>(cmd: RunCmd, logger: Arc<RotatingLogger>, on_client_rq: 
 	miner.set_author(cmd.miner_extras.author, None).expect("Fails only if password is Some; password is None; qed");
 	miner.set_gas_range_target(cmd.miner_extras.gas_range_target);
 	miner.set_extra_data(cmd.miner_extras.extra_data);
-	if !cmd.miner_extras.work_notify.is_empty() {
-		miner.add_work_listener(Box::new(
-			WorkPoster::new(&cmd.miner_extras.work_notify, fetch.clone(), event_loop.remote())
-		));
+
+	#[cfg(feature = "work-notify")]
+	{
+		if !cmd.miner_extras.work_notify.is_empty() {
+			miner.add_work_listener(Box::new(
+				WorkPoster::new(&cmd.miner_extras.work_notify, fetch.clone(), event_loop.remote())
+			));
+		}
 	}
+
 	let engine_signer = cmd.miner_extras.engine_signer;
 	if engine_signer != Default::default() {
 		// Check if engine signer exists


### PR DESCRIPTION
This is a step towards making depending on parity components a bit lighter.
I'm a bit unsure on if `Stratum` is still needed at all when the work-notify feature is disabled. I think in _principle_ yes, but `work-notify` seems to be all it is currently used for.

My ultimate goal is to make depending on hyper and tokio optional when we don't need to access external services, like when testing smart contracts. Removing those two dependencies transitively would remove a large chunks of crates being compiled when depending on ethcore.