### PR TITLE
A last bunch of transaction queue performance optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ name = "parity"
 [profile.dev]
 
 [profile.release]
-debug = false
+debug = true
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ name = "parity"
 [profile.dev]
 
 [profile.release]
-debug = true
+debug = false
 
 [workspace]
 members = [

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -1065,12 +1065,17 @@ impl miner::MinerService for Miner {
 		// 2. We ignore blocks that are `invalid` because it doesn't have any meaning in terms of the transactions that
 		//    are in those blocks
 
-		// Clear nonce cache
-		self.nonce_cache.write().clear();
+		let has_new_best_block = enacted.len() > 0;
+
+		if has_new_best_block {
+			// Clear nonce cache
+			self.nonce_cache.write().clear();
+		}
 
 		// First update gas limit in transaction queue and minimal gas price.
 		let gas_limit = *chain.best_block_header().gas_limit();
 		self.update_transaction_queue_limits(gas_limit);
+
 
 		// Then import all transactions...
 		let client = self.pool_client(chain);
@@ -1091,10 +1096,12 @@ impl miner::MinerService for Miner {
 				});
 		}
 
-		// ...and at the end remove the old ones
-		self.transaction_queue.cull(client);
+		if has_new_best_block {
+			// ...and at the end remove the old ones
+			self.transaction_queue.cull(client);
+		}
 
-		if enacted.len() > 0 || (imported.len() > 0 && self.options.reseal_on_uncle) {
+		if has_new_best_block || (imported.len() > 0 && self.options.reseal_on_uncle) {
 			// Reset `next_allowed_reseal` in case a block is imported.
 			// Even if min_period is high, we will always attempt to create
 			// new pending block.

--- a/ethcore/src/miner/pool_client.rs
+++ b/ethcore/src/miner/pool_client.rs
@@ -201,13 +201,12 @@ impl<'a, C: 'a> NonceClient for CachedNonceClient<'a, C> where
 	  let mut cache = self.cache.0.write();
 	  let nonce = self.client.latest_nonce(address);
 	  cache.insert(*address, nonce);
-	  warn!("NonceCache: inserting: [{:?}]", address);
 
 	  if cache.len() < self.cache.1 {
 		  return nonce
 	  }
 
-	  warn!("NonceCache: reached limit.");
+	  debug!(target: "txpool", "NonceCache: reached limit.");
 	  trace_time!("nonce_cache:clear");
 
 	  // Remove excessive amount of entries from the cache

--- a/ethcore/sync/src/api.rs
+++ b/ethcore/sync/src/api.rs
@@ -384,7 +384,6 @@ impl NetworkProtocolHandler for SyncProtocolHandler {
 	}
 
 	fn read(&self, io: &NetworkContext, peer: &PeerId, packet_id: u8, data: &[u8]) {
-		trace_time!("sync::read");
 		ChainSync::dispatch_packet(&self.sync, &mut NetSyncIo::new(io, &*self.chain, &*self.snapshot_service, &self.overlay), *peer, packet_id, data);
 	}
 

--- a/miner/src/pool/queue.rs
+++ b/miner/src/pool/queue.rs
@@ -326,6 +326,7 @@ impl TransactionQueue {
 		&self,
 		client: C,
 	) {
+		trace_time!("pool::cull");
 		// We don't care about future transactions, so nonce_cap is not important.
 		let nonce_cap = None;
 		// We want to clear stale transactions from the queue as well.

--- a/transaction-pool/src/pool.rs
+++ b/transaction-pool/src/pool.rs
@@ -399,6 +399,11 @@ impl<T, S, L> Pool<T, S, L> where
 			|| self.mem_usage >= self.options.max_mem_usage
 	}
 
+	/// Returns senders ordered by priority of their transactions.
+	pub fn senders(&self) -> impl Iterator<Item=&T::Sender> {
+		self.best_transactions.iter().map(|tx| tx.transaction.sender())
+	}
+
 	/// Returns an iterator of pending (ready) transactions.
 	pub fn pending<R: Ready<T>>(&self, ready: R) -> PendingIterator<T, R, S, L> {
 		PendingIterator {


### PR DESCRIPTION
- [x] Nonce cache size dependent on the pool size. Currently it was hardcoded to 4k entires, now it depends on the size of the pool (but never less than 4k). I've noticed that the cache was very often saturated when we run with large pool size.

- [x] Optimize order of `cull` and `update_sealing` in `miner::chain_new_blocks`. Since `cull` can take significant amount of time (seconds, for large pools) it's better to first attempt to construct pending block. We only need couple (hundreds) of best transactions and `Readiness` will make sure that they are not stale anyway. After pending block is created we attempt to clean up the pool. This should allow miners to start mining on the new block much earlier and reduce orphan rate because of that.

- [x] Split `cull` into chunks. To prevent acquiring `write()` lock of the queue for long time we are cleaning up the queue in chunks (1024 senders each chunk). This allows other threads to jump in between.