### PR TITLE
Only return error log for rustls

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -71,7 +71,7 @@ pub fn setup_log(config: &Config) -> Result<Arc<RotatingLogger>, String> {
 	builder.filter(Some("ws"), LogLevelFilter::Warn);
 	builder.filter(Some("reqwest"), LogLevelFilter::Warn);
 	builder.filter(Some("hyper"), LogLevelFilter::Warn);
-	builder.filter(Some("rustls"), LogLevelFilter::Warn);
+	builder.filter(Some("rustls"), LogLevelFilter::Error);
 	// Enable info for others.
 	builder.filter(None, LogLevelFilter::Info);
 


### PR DESCRIPTION
`rustls` appears to be sending too many logs. Especially sometimes you will see:

```
Sending warning alert CloseNotify
```

However, according to RFC 5246 section 7.2 (https://tools.ietf.org/html/rfc5246#section-7.2), this close notify message is just indication that the connection is being closed. However, this sometimes frightens user.

This PR modifies `rustls` log level from warning to error.