### PR TITLE
Publish keccak-hasher to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "patricia-trie 0.2.0",
  "patricia-trie-ethereum 0.1.0",
- "plain_hasher 0.2.0",
+ "plain_hasher 0.1.0",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1",
  "rlp_derive 0.1.0",
@@ -912,7 +912,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "macros 0.1.0",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plain_hasher 0.2.0",
+ "plain_hasher 0.1.0",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,7 +1416,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memorydb 0.2.0",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "plain_hasher 0.2.0",
+ "plain_hasher 0.1.0",
  "rlp 0.2.1",
  "util-error 0.1.0",
 ]
@@ -1532,7 +1532,7 @@ version = "0.1.0"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashdb 0.2.0",
- "plain_hasher 0.2.0",
+ "plain_hasher 0.1.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1733,7 +1733,7 @@ dependencies = [
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.2",
  "keccak-hasher 0.1.0",
- "plain_hasher 0.2.0",
+ "plain_hasher 0.1.0",
  "rlp 0.2.1",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "plain_hasher"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/sync/Cargo.toml
+++ b/ethcore/sync/Cargo.toml
@@ -17,7 +17,7 @@ ethcore-transaction = { path = "../transaction" }
 ethcore = { path = ".." }
 ethereum-types = "0.3"
 hashdb = { version = "0.2", path = "../../util/hashdb" }
-plain_hasher = { version = "0.2", path = "../../util/plain_hasher" }
+plain_hasher = { version = "0.1", path = "../../util/plain_hasher" }
 rlp = { path = "../../util/rlp" }
 rustc-hex = "1.0"
 keccak-hash = { path = "../../util/hash" }

--- a/util/hashdb/Cargo.toml
+++ b/util/hashdb/Cargo.toml
@@ -2,7 +2,8 @@
 name = "hashdb"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-description = "trait for hash-keyed databases."
+description = "Trait for hash-keyed databases."
+repository = "https://github.com/paritytech/parity/"
 license = "GPL-3.0"
 
 [dependencies]

--- a/util/keccak-hasher/Cargo.toml
+++ b/util/keccak-hasher/Cargo.toml
@@ -3,10 +3,11 @@ name = "keccak-hasher"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
+repository = "https://github.com/paritytech/parity/"
 license = "GPL-3.0"
 
 [dependencies]
 ethereum-types = "0.3"
 tiny-keccak = "1.4.2"
-hashdb = { path = "../hashdb" }
-plain_hasher = { path = "../plain_hasher" }
+hashdb = { version = "0.2.0", path = "../hashdb" }
+plain_hasher = {  version = "0.2.0", path = "../plain_hasher" }

--- a/util/keccak-hasher/Cargo.toml
+++ b/util/keccak-hasher/Cargo.toml
@@ -10,4 +10,4 @@ license = "GPL-3.0"
 ethereum-types = "0.3"
 tiny-keccak = "1.4.2"
 hashdb = { version = "0.2.0", path = "../hashdb" }
-plain_hasher = {  version = "0.2.0", path = "../plain_hasher" }
+plain_hasher = {  version = "0.1.0", path = "../plain_hasher" }

--- a/util/plain_hasher/Cargo.toml
+++ b/util/plain_hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plain_hasher"
 description = "Hasher for 32-bit keys."
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 keywords = ["hash", "hasher"]


### PR DESCRIPTION
Related to https://github.com/paritytech/parity/issues/9011

The tests for `memorydb` has `keccak_hasher` as a dev-dependency. We don't want `keccak-hasher` in `parity-common`. To get around that I published `keccak-hasher` to crates.io and this PR simply tweaks the Cargo.toml and versions to make that possible.