### PR TITLE
Add separate database directory for light client (#8927)

### DIFF
--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -970,10 +970,12 @@ impl Configuration {
 		let data_path = replace_home("", &base_path);
 		let is_using_base_path = self.args.arg_base_path.is_some();
 		// If base_path is set and db_path is not we default to base path subdir instead of LOCAL.
-		let base_db_path = if is_using_base_path && self.args.arg_db_path.is_none() && self.args.flag_light {
-			"$BASE/chains_light"
-		} else if is_using_base_path && self.args.arg_db_path.is_none() {
-			"$BASE/chains"
+		let base_db_path = if is_using_base_path && self.args.arg_db_path.is_none() {
+			if self.args.flag_light {
+				"$BASE/chains_light"
+			} else {
+				"$BASE/chains"
+			}
 		} else if self.args.flag_light {
 			self.args.arg_db_path.as_ref().map_or(dir::CHAINS_PATH_LIGHT, |s| &s)
 		} else {

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -970,8 +970,12 @@ impl Configuration {
 		let data_path = replace_home("", &base_path);
 		let is_using_base_path = self.args.arg_base_path.is_some();
 		// If base_path is set and db_path is not we default to base path subdir instead of LOCAL.
-		let base_db_path = if is_using_base_path && self.args.arg_db_path.is_none() {
+		let base_db_path = if is_using_base_path && self.args.arg_db_path.is_none() && self.args.flag_light {
+			"$BASE/chains_light"
+		} else if is_using_base_path && self.args.arg_db_path.is_none() {
 			"$BASE/chains"
+		} else if self.args.flag_light {
+			self.args.arg_db_path.as_ref().map_or(dir::CHAINS_PATH_LIGHT, |s| &s)
 		} else {
 			self.args.arg_db_path.as_ref().map_or(dir::CHAINS_PATH, |s| &s)
 		};

--- a/util/dir/src/lib.rs
+++ b/util/dir/src/lib.rs
@@ -34,10 +34,14 @@ use platform::*;
 
 pub use dirs::home_dir;
 
-/// Platform-specific chains path - Windows only
+/// Platform-specific chains path for standard client - Windows only
 #[cfg(target_os = "windows")] pub const CHAINS_PATH: &str = "$LOCAL/chains";
-/// Platform-specific chains path
+/// Platform-specific chains path for light client - Windows only
+#[cfg(target_os = "windows")] pub const CHAINS_PATH_LIGHT: &str = "$LOCAL/chains_light";
+/// Platform-specific chains path for standard client
 #[cfg(not(target_os = "windows"))] pub const CHAINS_PATH: &str = "$BASE/chains";
+/// Platform-specific chains path for light client
+#[cfg(not(target_os = "windows"))] pub const CHAINS_PATH_LIGHT: &str = "$BASE/chains_light";
 
 /// Platform-specific cache path - Windows only
 #[cfg(target_os = "windows")] pub const CACHE_PATH: &str = "$LOCAL/cache";


### PR DESCRIPTION
This allows for the full and light client to run at the same time when using portshift. This adds a new database directory for the light client. I don't immediately see a reason to make unique directories for any others, but please let me know if I've missed something.  

I've tested this on both Linux and Windows. 