### PR TITLE
fetch: replace futures-timer with tokio-timer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,11 +1112,11 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1187,14 +1187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "futures-timer"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3978,7 +3970,6 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5cedfe9b6dc756220782cc1ba5bcb1fa091cdcba155e40d3556159c3db58043"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -19,9 +19,9 @@ mkdir -p $KCOV_TARGET
 echo "Cover RUST"
 for FILE in `find target/debug/deps ! -name "*.*"`
 do
-  timeout --signal=SIGKILL 5m kcov --include-path=$(pwd) $KCOV_FLAGS $KCOV_TARGET $FILE
+  timeout --signal=SIGKILL 5m kcov --include-path=$(pwd) --exclude-path=$(pwd)/target $KCOV_FLAGS $KCOV_TARGET $FILE
 done
-timeout --signal=SIGKILL 5m kcov --include-path=$(pwd) $KCOV_FLAGS $KCOV_TARGET target/debug/parity-*
+timeout --signal=SIGKILL 5m kcov --include-path=$(pwd) --exclude-path=$(pwd)/target $KCOV_FLAGS $KCOV_TARGET target/debug/parity-*
 echo "Cover JS"
 cd js
 npm install&&npm run test:coverage

--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -15,18 +15,17 @@ set -x
 RUSTFLAGS="-C link-dead-code" cargo test --all --no-run || exit $?
 KCOV_TARGET="target/cov"
 KCOV_FLAGS="--verify"
-EXCLUDE="/usr/lib,/usr/include,$HOME/.cargo,$HOME/.multirust,rocksdb,secp256k1"
 mkdir -p $KCOV_TARGET
 echo "Cover RUST"
 for FILE in `find target/debug/deps ! -name "*.*"`
-  do
-   timeout --signal=SIGKILL 5m kcov --exclude-pattern $EXCLUDE $KCOV_FLAGS $KCOV_TARGET $FILE
-  done
-timeout --signal=SIGKILL 5m kcov --exclude-pattern $EXCLUDE $KCOV_FLAGS $KCOV_TARGET target/debug/parity-*
+do
+  timeout --signal=SIGKILL 5m kcov --include-path=$(pwd) $KCOV_FLAGS $KCOV_TARGET $FILE
+done
+timeout --signal=SIGKILL 5m kcov --include-path=$(pwd) $KCOV_FLAGS $KCOV_TARGET target/debug/parity-*
 echo "Cover JS"
 cd js
 npm install&&npm run test:coverage
 cd ..
 bash <(curl -s https://codecov.io/bash)&&
-echo "Uploaded code coverage"
+  echo "Uploaded code coverage"
 exit 0

--- a/util/fetch/Cargo.toml
+++ b/util/fetch/Cargo.toml
@@ -8,11 +8,11 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 futures = "0.1"
-futures-timer = "0.1"
 hyper = "0.11"
 hyper-rustls = "0.11"
 log = "0.4"
 tokio-core = "0.1"
+tokio-timer = "0.1"
 url = "1"
 bytes = "0.4"
 

--- a/util/fetch/src/lib.rs
+++ b/util/fetch/src/lib.rs
@@ -23,12 +23,12 @@ extern crate log;
 
 #[macro_use]
 extern crate futures;
-extern crate futures_timer;
 
 extern crate hyper;
 extern crate hyper_rustls;
 
 extern crate tokio_core;
+extern crate tokio_timer;
 extern crate url;
 extern crate bytes;
 


### PR DESCRIPTION
Currently the coverage build fails because `futures-timer` fails to compile with `-C link-dead-code` (https://gitlab.parity.io/parity/parity/-/jobs/91245). This issue has been reported to `futures-timer` (https://github.com/alexcrichton/futures-timer/issues/2) but has remained unsolved for months. It should be fixed by rustc eventually (https://github.com/rust-lang/rust/issues/45629).

