### PR TITLE
Replace `std::env::home_dir` with `dirs::home_dir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,11 +384,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dir"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "app_dirs 1.2.1 (git+https://github.com/paritytech/app-dirs-rs)",
+ "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "journaldb 0.2.0",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -761,7 +771,7 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "path 0.1.0",
+ "path 0.1.1",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1008,7 +1018,7 @@ dependencies = [
 name = "ethstore"
 version = "0.2.0"
 dependencies = [
- "dir 0.1.0",
+ "dir 0.1.1",
  "ethcore-crypto 0.1.0",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethkey 0.3.0",
@@ -1033,7 +1043,7 @@ dependencies = [
 name = "ethstore-cli"
 version = "0.1.0"
 dependencies = [
- "dir 0.1.0",
+ "dir 0.1.1",
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethstore 0.2.0",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2070,7 +2080,7 @@ dependencies = [
  "clap 2.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)",
  "daemonize 0.2.3 (git+https://github.com/paritytech/daemonize)",
- "dir 0.1.0",
+ "dir 0.1.1",
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 1.12.0",
@@ -2116,7 +2126,7 @@ dependencies = [
  "parity-version 1.12.0",
  "parity-whisper 0.1.0",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "path 0.1.0",
+ "path 0.1.1",
  "pretty_assertions 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "registrar 0.0.1",
@@ -2381,7 +2391,7 @@ dependencies = [
  "parity-hash-fetch 1.12.0",
  "parity-version 1.12.0",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "path 0.1.0",
+ "path 0.1.1",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2472,7 +2482,10 @@ dependencies = [
 
 [[package]]
 name = "path"
-version = "0.1.0"
+version = "0.1.1"
+dependencies = [
+ "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "patricia-trie"
@@ -3952,6 +3965,7 @@ dependencies = [
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum daemonize 0.2.3 (git+https://github.com/paritytech/daemonize)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
+"checksum dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37a76dd8b997af7107d0bb69d43903cf37153a18266f8b3fdb9911f28efb5444"
 "checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum edit-distance 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6a34f5204fbc13582de418611cf3a7dcdd07c6d312a5b631597ba72c06b9d9c9"

--- a/parity/upgrade.rs
+++ b/parity/upgrade.rs
@@ -17,13 +17,12 @@
 //! Parity upgrade logic
 
 use semver::{Version, SemVerError};
-use std::collections::*;
+use std::collections::HashMap;
 use std::fs::{self, File, create_dir_all};
-use std::env;
 use std::io;
 use std::io::{Read, Write};
 use std::path::{PathBuf, Path};
-use dir::{DatabaseDirectories, default_data_path};
+use dir::{DatabaseDirectories, default_data_path, home_dir};
 use dir::helpers::replace_home;
 use journaldb::Algorithm;
 
@@ -106,7 +105,7 @@ fn with_locked_version<F>(db_path: Option<&str>, script: F) -> Result<usize, Err
 	where F: Fn(&Version) -> Result<usize, Error>
 {
 	let mut path = db_path.map_or({
-		let mut path = env::home_dir().expect("Applications should have a home dir");
+		let mut path = home_dir().expect("Applications should have a home dir");
 		path.push(".parity");
 		path
 	}, PathBuf::from);

--- a/util/dir/Cargo.toml
+++ b/util/dir/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "dir"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
+license = "GPL3"
 
 [dependencies]
 ethereum-types = "0.3"
 journaldb = { path = "../journaldb" }
 app_dirs = { git = "https://github.com/paritytech/app-dirs-rs" }
+dirs = "1.0.2"

--- a/util/dir/src/helpers.rs
+++ b/util/dir/src/helpers.rs
@@ -15,12 +15,11 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Directory helper functions
-use std::env;
 
 /// Replaces `$HOME` str with home directory path.
 pub fn replace_home(base: &str, arg: &str) -> String {
 	// the $HOME directory on mac os should be `~/Library` or `~/Library/Application Support`
-	let r = arg.replace("$HOME", env::home_dir().unwrap().to_str().unwrap());
+	let r = arg.replace("$HOME", ::dirs::home_dir().unwrap().to_str().unwrap());
 	let r = r.replace("$BASE", base);
 	r.replace("/", &::std::path::MAIN_SEPARATOR.to_string())
 }

--- a/util/dir/src/lib.rs
+++ b/util/dir/src/lib.rs
@@ -18,11 +18,12 @@
 
 //! Dir utilities for platform-specific operations
 extern crate app_dirs;
+extern crate dirs;
 extern crate ethereum_types;
 extern crate journaldb;
 
 pub mod helpers;
-use std::{env, fs};
+use std::fs;
 use std::path::{PathBuf, Path};
 use ethereum_types::{H64, H256};
 use journaldb::Algorithm;
@@ -31,19 +32,21 @@ use app_dirs::{AppInfo, get_app_root, AppDataType};
 // re-export platform-specific functions
 use platform::*;
 
+pub use dirs::home_dir;
+
 /// Platform-specific chains path - Windows only
-#[cfg(target_os = "windows")] pub const CHAINS_PATH: &'static str = "$LOCAL/chains";
+#[cfg(target_os = "windows")] pub const CHAINS_PATH: &str = "$LOCAL/chains";
 /// Platform-specific chains path
-#[cfg(not(target_os = "windows"))] pub const CHAINS_PATH: &'static str = "$BASE/chains";
+#[cfg(not(target_os = "windows"))] pub const CHAINS_PATH: &str = "$BASE/chains";
 
 /// Platform-specific cache path - Windows only
-#[cfg(target_os = "windows")] pub const CACHE_PATH: &'static str = "$LOCAL/cache";
+#[cfg(target_os = "windows")] pub const CACHE_PATH: &str = "$LOCAL/cache";
 /// Platform-specific cache path
-#[cfg(not(target_os = "windows"))] pub const CACHE_PATH: &'static str = "$BASE/cache";
+#[cfg(not(target_os = "windows"))] pub const CACHE_PATH: &str = "$BASE/cache";
 
 // this const is irrelevent cause we do have migrations now,
 // but we still use it for backwards compatibility
-const LEGACY_CLIENT_DB_VER_STR: &'static str = "5.3";
+const LEGACY_CLIENT_DB_VER_STR: &str = "5.3";
 
 #[derive(Debug, PartialEq)]
 /// Parity local data directories
@@ -239,7 +242,7 @@ pub fn default_hypervisor_path() -> PathBuf {
 
 /// Get home directory.
 fn home() -> PathBuf {
-	env::home_dir().expect("Failed to get home dir")
+	dirs::home_dir().expect("Failed to get home dir")
 }
 
 /// Geth path
@@ -312,9 +315,9 @@ mod platform {
 #[cfg(not(any(target_os = "macos", windows)))]
 mod platform {
 	use std::path::PathBuf;
-	pub const AUTHOR: &'static str = "parity";
-	pub const PRODUCT: &'static str = "io.parity.ethereum";
-	pub const PRODUCT_HYPERVISOR: &'static str = "io.parity.ethereum-updates";
+	pub const AUTHOR: &str = "parity";
+	pub const PRODUCT: &str = "io.parity.ethereum";
+	pub const PRODUCT_HYPERVISOR: &str = "io.parity.ethereum-updates";
 
 	pub fn parity_base() -> PathBuf {
 		let mut home = super::home();

--- a/util/path/Cargo.toml
+++ b/util/path/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "path"
-version = "0.1.0"
-authors = ["debris <marek.kotewicz@gmail.com>"]
+version = "0.1.1"
+authors = ["Parity Technologies <admin@parity.io>"]
+license = "GPL3"
 
 [dependencies]
+dirs = "1.0.2"

--- a/util/path/src/lib.rs
+++ b/util/path/src/lib.rs
@@ -15,6 +15,8 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Path utilities
+extern crate dirs;
+
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -22,7 +24,7 @@ use std::path::PathBuf;
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push("Library");
 	home.push(name);
 	home
@@ -32,7 +34,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push("AppData");
 	home.push("Roaming");
 	home.push(name);
@@ -43,7 +45,7 @@ pub fn config_path(name: &str) -> PathBuf {
 /// Get the config path for application `name`.
 /// `name` should be capitalized, e.g. `"Ethereum"`, `"Parity"`.
 pub fn config_path(name: &str) -> PathBuf {
-	let mut home = ::std::env::home_dir().expect("Failed to get home dir");
+	let mut home = dirs::home_dir().expect("Failed to get home dir");
 	home.push(format!(".{}", name.to_lowercase()));
 	home
 }


### PR DESCRIPTION
`std::env::home_dir` is deprecated but will probably take a while until
it is deprecated on stable. For more info see https://github.com/rust-lang/rust/pull/51656