### PR TITLE
Fix nightly warnings

### DIFF
--- a/parity/lib.rs
+++ b/parity/lib.rs
@@ -17,7 +17,6 @@
 //! Ethcore client application.
 
 #![warn(missing_docs)]
-#![cfg_attr(feature = "memory_profiling", feature(alloc_system, global_allocator, allocator_api))]
 
 extern crate ansi_term;
 extern crate docopt;
@@ -93,9 +92,6 @@ extern crate pretty_assertions;
 #[cfg(test)]
 extern crate tempdir;
 
-#[cfg(feature = "memory_profiling")]
-extern crate alloc_system;
-
 mod account;
 mod blockchain;
 mod cache;
@@ -131,7 +127,7 @@ use configuration::{Cmd, Execute};
 use deprecated::find_deprecated;
 use ethcore_logger::setup_log;
 #[cfg(feature = "memory_profiling")]
-use alloc_system::System;
+use std::alloc::System;
 
 pub use self::configuration::Configuration;
 pub use self::run::RunningClient;

--- a/rpc/src/v1/helpers/light_fetch.rs
+++ b/rpc/src/v1/helpers/light_fetch.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 
 use ethcore::basic_account::BasicAccount;
 use ethcore::encoded;
-use ethcore::executed::{Executed, ExecutionError};
 use ethcore::ids::BlockId;
 use ethcore::filter::Filter as EthcoreFilter;
 use ethcore::receipt::Receipt;
@@ -33,7 +32,10 @@ use jsonrpc_macros::Trailing;
 use light::cache::Cache;
 use light::client::LightChainClient;
 use light::cht;
-use light::on_demand::{request, OnDemand, HeaderRef, Request as OnDemandRequest, Response as OnDemandResponse};
+use light::on_demand::{
+	request, OnDemand, HeaderRef, Request as OnDemandRequest,
+	Response as OnDemandResponse, ExecutionResult,
+};
 use light::request::Field;
 
 use sync::LightSync;
@@ -85,9 +87,6 @@ pub fn extract_transaction_at_index(block: encoded::Block, index: usize, eip86_t
 		})
 		.map(|tx| Transaction::from_localized(tx, eip86_transition))
 }
-
-/// Type alias for convenience.
-pub type ExecutionResult = ::std::result::Result<Executed, ExecutionError>;
 
 // extract the header indicated by the given `HeaderRef` from the given responses.
 // fails only if they do not correspond.


### PR DESCRIPTION
The first commit switches to stable (since 1.28) API for global allocators when using `memory_profiling` feature. 