### PR TITLE
ethcore: Minor cleanup in Receipt constructor

### DIFF
--- a/ethcore/types/src/receipt.rs
+++ b/ethcore/types/src/receipt.rs
@@ -20,7 +20,7 @@ use ethereum_types::{H160, H256, U256, Address, Bloom};
 use heapsize::HeapSizeOf;
 use rlp::{Rlp, RlpStream, Encodable, Decodable, DecoderError};
 
-use {BlockNumber};
+use BlockNumber;
 use log_entry::{LogEntry, LocalizedLogEntry};
 
 /// Transaction outcome store in the receipt.
@@ -49,12 +49,12 @@ pub struct Receipt {
 
 impl Receipt {
 	/// Create a new receipt.
-	pub fn new(outcome: TransactionOutcome, gas_used: U256, logs: Vec<LogEntry>) -> Receipt {
-		Receipt {
-			gas_used: gas_used,
-			log_bloom: logs.iter().fold(Bloom::default(), |mut b, l| { b = &b | &l.bloom(); b }), //TODO: use |= operator
-			logs: logs,
-			outcome: outcome,
+	pub fn new(outcome: TransactionOutcome, gas_used: U256, logs: Vec<LogEntry>) -> Self {
+		Self {
+			gas_used,
+			log_bloom: logs.iter().fold(Bloom::default(), |b, l| b | l.bloom()),
+			logs,
+			outcome,
 		}
 	}
 }


### PR DESCRIPTION
Remove needless mutable variable and assignment for the Bloom filter when `folding`.