### PR TITLE
Changelogs for 1.11.7-stable and 2.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,639 +1,252 @@
-## Parity [v1.11.6](https://github.com/paritytech/parity/releases/tag/v1.11.6) (2018-07-09)
+## Parity-Ethereum [v2.0.0](https://github.com/paritytech/parity/releases/tag/v2.0.0) (2018-07-16)
 
-Parity 1.11.6 is a bug-fix release to improve performance and stability.
-
-The full list of included changes:
-
-- Beta: 1.11.6 backports ([#9015](https://github.com/paritytech/parity/pull/9015))
-  - Parity-version: bump beta to 1.11.6
-  - Scripts: remove md5 checksums ([#8884](https://github.com/paritytech/parity/pull/8884))
-  - Add support for --chain tobalaba
-    - Convert indents to tabs :)
-  - Fixes for misbehavior reporting in AuthorityRound ([#8998](https://github.com/paritytech/parity/pull/8998))
-    - Aura: only report after checking for repeated skipped primaries
-    - Aura: refactor duplicate code for getting epoch validator set
-    - Aura: verify_external: report on validator set contract instance
-    - Aura: use correct validator set epoch number when reporting
-    - Aura: use epoch set when verifying blocks
-    - Aura: report skipped primaries when generating seal
-    - Aura: handle immediate transitions
-    - Aura: don't report skipped steps from genesis to first block
-    - Aura: fix reporting test
-    - Aura: refactor duplicate code to handle immediate_transitions
-    - Aura: let reporting fail on verify_block_basic
-    - Aura: add comment about possible failure of reporting
-  - Only return error log for rustls ([#9025](https://github.com/paritytech/parity/pull/9025))
-  - Transaction Pool improvements ([#8470](https://github.com/paritytech/parity/pull/8470))
-    - Don't use ethereum_types in transaction pool.
-    - Hide internal insertion_id.
-    - Fix tests.
-    - Review grumbles.
-  - Improve should_replace on NonceAndGasPrice ([#8980](https://github.com/paritytech/parity/pull/8980))
-    - Additional tests for NonceAndGasPrice::should_replace.
-    - Fix should_replace in the distinct sender case.
-    - Use natural priority ordering to simplify should_replace.
-  - Minimal effective gas price in the queue ([#8934](https://github.com/paritytech/parity/pull/8934))
-    - Minimal effective gas price.
-    - Fix naming, add test
-    - Fix minimal entry score and add test.
-    - Fix worst_transaction.
-    - Remove effective gas price threshold.
-    - Don't leak gas_price decisions out of Scoring.
-  - Never drop local transactions from different senders. ([#9002](https://github.com/paritytech/parity/pull/9002))
-  - Recently rejected cache for transaction queue ([#9005](https://github.com/paritytech/parity/pull/9005))
-    - Store recently rejected transactions.
-    - Don't cache AlreadyImported rejections.
-    - Make the size of transaction verification queue dependent on pool size.
-    - Add a test for recently rejected.
-    - Fix logging for recently rejected.
-    - Make rejection cache smaller.
-    - Obsolete test removed
-    - Obsolete test removed
-    - Construct cache with_capacity.
-  - Optimize pending transactions filter ([#9026](https://github.com/paritytech/parity/pull/9026))
-    - Rpc: return unordered transactions in pending transactions filter
-    - Ethcore: use LruCache for nonce cache
-      - Only clear the nonce cache when a block is retracted
-    - Revert "ethcore: use LruCache for nonce cache"
-      - This reverts commit b382c19.
-    - Use only cached nonces when computing pending hashes.
-    - Give filters their own locks, so that they don't block one another.
-    - Fix pending transaction count if not sealing.
-    - Clear cache only when block is enacted.
-    - Fix RPC tests.
-    - Address review comments.
-  - A last bunch of txqueue performance optimizations ([#9024](https://github.com/paritytech/parity/pull/9024))
-    - Clear cache only when block is enacted.
-    - Add tracing for cull.
-    - Cull split.
-    - Cull after creating pending block.
-    - Add constant, remove sync::read tracing.
-    - Reset debug.
-    - Remove excessive tracing.
-    - Use struct for NonceCache.
-    - Fix build
-    - Remove warnings.
-    - Fix build again.
-  - Miner: add missing macro use for trace_time
-  - Ci: remove md5 merge leftovers
-
-## Parity [v1.11.5](https://github.com/paritytech/parity/releases/tag/v1.11.5) (2018-06-29)
-
-Parity 1.11.5 is a bug-fix release to improve performance and stability.
+This is the Parity-Ethereum 2.0.0-beta release! ~~Hurray!~~ @TODO
 
 The full list of included changes:
 
-- Bump beta to 1.11.5 / Backports ([#8955](https://github.com/paritytech/parity/pull/8955))
-  - Parity-version: bump beta to 1.11.5
-  - Update ropsten.json ([#8926](https://github.com/paritytech/parity/pull/8926))
-  - Update hardcoded headers ([#8925](https://github.com/paritytech/parity/pull/8925))
-    - Update kovan.json
-      - Update Kovan to block 7693549
-    - Update foundation.json
-      - Updated to block 5812225
-    - Update ropsten.json
-      - Update to 3465217
-  - Scripts: minor improvements ([#8930](https://github.com/paritytech/parity/pull/8930))
-    - CI: enable 'latest' docker tag on master pipeline
-    - CI: mark both beta and stable as stable snap.
-    - CI: sign all windows binaries
-  - Scripts: fix docker build tag on latest using master ([#8952](https://github.com/paritytech/parity/pull/8952))
-  - Rpc: cap gas limit of local calls ([#8943](https://github.com/paritytech/parity/pull/8943))
-  - Snap: downgrade rust to revision 1.26.2, ref snapcraft/+bug/1778530 ([#8984](https://github.com/paritytech/parity/pull/8984))
-    - Snap: downgrade rust to revision 1.26.2, ref snapcraft/+bug/1778530
-    - Snap: use plugin rust
-  - Fix deadlock in blockchain. ([#8977](https://github.com/paritytech/parity/pull/8977))
-  - Remove js-glue from workspace
-    - This fixes test error on Rust 1.27 but also prevents js-glue from building itself.
-    - Builtin dapp users can still use js-glue from crates.io.
-  - Fix Android build on beta ([#9003](https://github.com/paritytech/parity/pull/9003))
-
-## Parity [v1.11.4](https://github.com/paritytech/parity/releases/tag/v1.11.4) (2018-06-20)
-
-Parity 1.11.4 is a bug-fix release to improve performance and stability.
-
-The full list of included changes:
-
-- Backports ([#8916](https://github.com/paritytech/parity/pull/8916))
-  - `Duration_ns: u64 -> duration: Duration` ([#8457](https://github.com/paritytech/parity/pull/8457))
-    - Duration_ns: u64 -> duration: Duration
-    - Format on millis {:.2} -> {}
-  - Keep all enacted blocks notify in order ([#8524](https://github.com/paritytech/parity/pull/8524))
-    - Keep all enacted blocks notify in order
-    - Collect is unnecessary
-    - Update ChainNotify to use ChainRouteType
-    - Fix all ethcore fn defs
-    - Wrap the type within ChainRoute
-    - Fix private-tx and sync api
-    - Fix secret_store API
-    - Fix updater API
-    - Fix rpc api
-    - Fix informant api
-    - Eagerly cache enacted/retracted and remove contain_enacted/retracted
-    - Fix indent
-    - Tests: should use full expr form for struct constructor
-    - Use into_enacted_retracted to further avoid copy
-    - Typo: not a function
-    - Rpc/tests: ChainRoute -> ChainRoute::new
-  - Handle removed logs in filter changes and add geth compatibility field ([#8796](https://github.com/paritytech/parity/pull/8796))
-    - Add removed geth compatibility field in log
-    - Fix mocked tests
-    - Add field block hash in PollFilter
-    - Store last block hash info for log filters
-    - Implement canon route
-    - Use canon logs for fetching reorg logs
-    - Make sure removed flag is set
-    - Address grumbles
-  - Fixed AuthorityRound deadlock on shutdown, closes [#8088](https://github.com/paritytech/parity/issues/8088) ([#8803](https://github.com/paritytech/parity/pull/8803))
-  - Ci: Fix docker tags ([#8822](https://github.com/paritytech/parity/pull/8822))
-    - Scripts: enable docker builds for beta and stable
-    - Scripts: docker latest should be beta not master
-    - Scripts: docker latest is master
-  - Ethcore: fix ancient block error msg handling ([#8832](https://github.com/paritytech/parity/pull/8832))
-  - Disable parallel verification and skip verifiying already imported txs. ([#8834](https://github.com/paritytech/parity/pull/8834))
-    - Reject transactions that are already in pool without verifying them.
-    - Avoid verifying already imported transactions.
-  - Fix concurrent access to signer queue ([#8854](https://github.com/paritytech/parity/pull/8854))
-    - Fix concurrent access to signer queue
-    - Put request back to the queue if confirmation failed
-    - Typo: fix docs and rename functions to be more specific
-    - Change trace info "Transaction" -> "Request"
-  - Don't allocate in expect_valid_rlp unless necessary ([#8867](https://github.com/paritytech/parity/pull/8867))
-    - Don't allocate via format! in case there's no error
-    - Fix test?
-  - Fixed ipc leak, closes [#8774](https://github.com/paritytech/parity/issues/8774) ([#8876](https://github.com/paritytech/parity/pull/8876))
-  - Add new ovh bootnodes and fix port for foundation bootnode 3.2 ([#8886](https://github.com/paritytech/parity/pull/8886))
-    - Add new ovh bootnodes and fix port for foundation bootnode 3.2
-    - Remove old bootnodes.
-    - Remove duplicate 1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082
-  - Block 0 is valid in queries ([#8891](https://github.com/paritytech/parity/pull/8891))
-  - Add ETC Cooperative-run load balanced parity node ([#8892](https://github.com/paritytech/parity/pull/8892))
-  - Minor fix in chain supplier and light provider ([#8906](https://github.com/paritytech/parity/pull/8906))
-    - Fix chain supplier increment
-    - Fix light provider block_headers
-  - Check whether we need resealing in miner and unwrap has_account in account_provider ([#8853](https://github.com/paritytech/parity/pull/8853))
-    - Remove unused Result wrap in has_account
-    - Check whether we need to reseal for external transactions
-    - Fix reference to has_account interface
-    - Typo: missing )
-    - Refactor duplicates to prepare_and_update_sealing
-    - Fix build
-  - Allow disabling local-by-default for transactions with new config entry ([#8882](https://github.com/paritytech/parity/pull/8882))
-    - Add tx_queue_allow_unknown_local config option
-    - Refactor flag name + don't change import_own_tx behaviour
-    - Add fn to TestMinerService
-    - Avoid race condition from trusted sources
-- Parity-version: beta release 1.11.4 ([#8856](https://github.com/paritytech/parity/pull/8856))
-  - Cherry-pick network-specific release flag ([#8821](https://github.com/paritytech/parity/pull/8821))
-  - Parity-version: bump beta to 1.11.4
-  - Parity-version: remove merge leftovers
-
-## Parity [v1.11.3](https://github.com/paritytech/parity/releases/tag/v1.11.3) (2018-06-06)
-
-Parity 1.11.3 is a security-relevant release. Please upgrade your nodes as soon as possible to [v1.10.6](https://github.com/paritytech/parity/releases/tag/v1.10.6) or [v1.11.3](https://github.com/paritytech/parity/releases/tag/v1.11.3).
-
-The full list of included changes:
-
-- Parity-version: bump beta to 1.11.3 ([#8806](https://github.com/paritytech/parity/pull/8806))
-  - Parity-version: bump beta to 1.11.3
-  - Disallow unsigned transactions in case EIP-86 is disabled ([#8802](https://github.com/paritytech/parity/pull/8802))
-  - Fix ancient blocks queue deadlock ([#8751](https://github.com/paritytech/parity/pull/8751))
-- Update shell32-sys to fix windows build ([#8792](https://github.com/paritytech/parity/pull/8792))
-- Backports ([#8785](https://github.com/paritytech/parity/pull/8785))
-  - Fix light sync with initial validator-set contract ([#8528](https://github.com/paritytech/parity/pull/8528))
-    - Fix #8468
-    - Use U256::max_value() instead
-    - Also change initial transaction gas
-  - Resumable warp-sync / Seed downloaded snapshots ([#8544](https://github.com/paritytech/parity/pull/8544))
-    - Start dividing sync chain : first supplier method
-    - WIP - updated chain sync supplier
-    - Finish refactoring the Chain Sync Supplier
-    - Create Chain Sync Requester
-    - Add Propagator for Chain Sync
-    - Add the Chain Sync Handler
-    - Move tests from mod -> handler
-    - Move tests to propagator
-    - Refactor SyncRequester arguments
-    - Refactoring peer fork header handler
-    - Fix wrong highest block number in snapshot sync
-    - Small refactor...
-    - Resume warp-sync downloaded chunks
-    - Refactoring the previous chunks import
-    - Address PR grumbles
-    - Fix not seeding current snapshot
-    - Update SnapshotService readiness check
-    - Early abort importing previous chunks
-    - Update Gitlab CI config
-    - SyncState back to Waiting when Manifest peers disconnect
-    - Revert GitLab CI changes
-    - Refactor resuming snapshots
-    - Revert "Refactor resuming snapshots"
-    - Update informant log
-    - Refactor resuming snapshots
-    - Update informant message : show chunks done
-  - Don't open Browser post-install on Mac ([#8641](https://github.com/paritytech/parity/pull/8641))
-  - Fix not downloading old blocks ([#8642](https://github.com/paritytech/parity/pull/8642))
-  - Fix PoW blockchains sealing notifications in chain_new_blocks ([#8656](https://github.com/paritytech/parity/pull/8656))
-  - Shutdown the Snapshot Service early ([#8658](https://github.com/paritytech/parity/pull/8658))
-    - Shutdown the Snapshot Service when shutting down the runner
-    - Rename `service` to `client_service`
-    - Fix tests
-  - Fix cli signer ([#8682](https://github.com/paritytech/parity/pull/8682))
-    - Update ethereum-types so `{:#x}` applies 0x prefix
-  - Set the request index to that of the current request ([#8683](https://github.com/paritytech/parity/pull/8683))
-    - Set the request index to that of the current request
-  - Network-devp2p: handle UselessPeer disconnect ([#8686](https://github.com/paritytech/parity/pull/8686))
-  - Fix local transactions policy. ([#8691](https://github.com/paritytech/parity/pull/8691))
-  - CI: Fixes for Android Pipeline ([#8745](https://github.com/paritytech/parity/pull/8745))
-    - Ci: Remove check for shared libraries in gitlab script
-    - Ci: allow android arm build to fail
-  - Custom Error Messages on ENFILE and EMFILE IO Errors ([#8744](https://github.com/paritytech/parity/pull/8744))
-    - Custom Error Messages on ENFILE and EMFILE IO Errors
-    - Use assert-matches for more readable tests
-    - Fix Wording and consistency
-  - Ethcore-sync: fix connection to peers behind chain fork block ([#8710](https://github.com/paritytech/parity/pull/8710))
-- Parity-version: bump beta to 1.11.2 ([#8750](https://github.com/paritytech/parity/pull/8750))
-  - Parity-version: bump beta to 1.11.2
-  - Parity-version: unset critical flag
-
-## Parity [v1.11.1](https://github.com/paritytech/parity/releases/tag/v1.11.1) (2018-05-15)
-
-This is the Parity 1.11.1-beta release! Hurray!
-
-Notable changes in reversed alphabetical order:
-
-- TOOLING: **Whisper CLI** [#8201](https://github.com/paritytech/parity/pull/8201)
-  - `whisper-cli` is a standalone tool to communicate with the Whisper protocol.
-  - It provides functionality to specify `whisper-pool-size`, `port` and `address` to use.
-  - All whisper RPC APIs are enabled and can be directly accessed.
-- JSON-RPC API: **Return error in case eth_call returns VM errors** [#8448](https://github.com/paritytech/parity/pull/8448)
-  - This changes the behaviors of `eth_call` to respect VM errors if any.
-  - In case of `REVERT`, it will also return the reverted return data in hex format.
-- ENGINES: **Block Reward Contract** [#8419](https://github.com/paritytech/parity/pull/8419)
-  - The _AuRa_ PoA engine has now support for having a contract to calculate the block rewards.
-  - The engine passes a list of benefactors and reward types to the contract which then returns a list of addresses and respective rewards.
-- CORE: **Private Transactions** [#6422](https://github.com/paritytech/parity/pull/6422)
-  - Parity now provides a private transactions system.
-  - Please, check out our wiki to get an [overview and setup instructions](https://wiki.parity.io/Private-Transactions.html).
-- CORE: **New Transaction Queue implementation** [#8074](https://github.com/paritytech/parity/pull/8074)
-  - Verification is now done in parallel.
-  - Previous queue had `O(1)` time to get pending set, but `O(n^2)` insertion time. And obviously insertion/removal happens much more often than retrieving the pending set (only for propagation and pending block building) Currently we have `O(n * log(senders))` pending set time (with cache) and `O(tx_per_sender)` (usually within `log(tx_per_sender)`) insertion time.
-  - `Scoring` and `Readiness` are separated from the pool, so it's easier to customize them or introduce different definitions (for instance for [EIP-859](https://github.com/ethereum/EIPs/issues/859) or private transactions, etc).
-  - Banning removed, soft-penalization introduced instead: if transaction exceeds the limit other transactions from that sender get lower priority.
-  - There is no explicit distinction between current and future transactions in the pool - `Readiness` determines that. Because of this we additionally remove `future` transactions that occupy the pool for long time.
-- CONFIGURATION: **Warp-only sync with --warp-barrier [block-number] flag.** [#8228](https://github.com/paritytech/parity/pull/8228)
-  - Enables warp-only sync in case `--warp-barrier [block-number]` is provided.
-  - This avoids clients to warp to outdated snapshots that are too far away from the best block.
-  - This avoids clients to fall back to normal sync if there are no recent snapshots available currently.
-- CONFIGURATION: **Disable UI by default.** [#8105](https://github.com/paritytech/parity/pull/8105)
-  - The user interface is now disabled by default. It still can be activated with the `--force-ui` flag.
-  - To get the stand-alone Parity UI, please check the dedicated [releases page](https://github.com/parity-js/shell/releases).
-- CONFIGURATION: **Auto-updater improvements** [#8078](https://github.com/paritytech/parity/pull/8078)
-  - Added `--auto-update-delay` to randomly delay updates by `n` blocks. This takes into account the number of the block of the update release (old updates aren't delayed).
-  - Added `--auto-update-check-frequency` to define the periodicity of auto-update checks in number of blocks.
-  - This is an important improvement to ensure the network does not update all clients at the same time.
-- CHAIN SPECS: **Enable WebAssembly and Byzantium for Ellaism** [#8520](https://github.com/paritytech/parity/pull/8520)
-  - This activates the Ellaism Byzantium hardfork ([2018-0004-byzantium](https://github.com/ellaism/specs/blob/master/specs/2018-0004-byzantium.md)) at block `2_000_000`.
-  - This enables the Wasm VM on Ellaism ([2018-0003-wasm-hardfork](https://github.com/ellaism/specs/blob/master/specs/2018-0003-wasm-hardfork.md)) at block `2_000_000`.
-  - Please, upgrade your clients if you run an Ellaism configuration.
-- CHAIN SPECS: **Dev chain - increase gasLimit to 8_000_000** [#8362](https://github.com/paritytech/parity/pull/8362)
-  - This increases the default block gas limit on development chains to `8_000_000`.
-  - Please note, this makes previous dev chain configurations incompatible.
-- CHAIN SPECS: **Add MCIP-6 Byzyantium transition to Musicoin spec** [#7841](https://github.com/paritytech/parity/pull/7841)
-  - This activates the Musicoin Byzantium hardfork ([MCIP-6](https://github.com/Musicoin/MCIPs/blob/master/MCIPS/mcip-6.md)) at block `2_222_222`.
-  - Please, upgrade your clients if you run a Musicoin configuration.
-
-The full list of included changes:
-
-- Backports ([#8624](https://github.com/paritytech/parity/pull/8624))
-  - Trace precompiled contracts when the transfer value is not zero ([#8486](https://github.com/paritytech/parity/pull/8486))
-    - Trace precompiled contracts when the transfer value is not zero
-    - Add tests for precompiled CALL tracing
-    - Use byzantium test machine for the new test
-    - Add notes in comments on why we don't trace all precompiles
-    - Use is_transferred instead of transferred
-  - Return error if RLP size of transaction exceeds the limit ([#8473](https://github.com/paritytech/parity/pull/8473))
-    - Return error if RLP size of transaction exceeds the limit
-    - Review comments fixed
-    - RLP check moved to verifier, corresponding pool test added
-  - Don't block sync when importing old blocks ([#8530](https://github.com/paritytech/parity/pull/8530))
-    - Alter IO queueing.
-    - Don't require IoMessages to be Clone
-    - Ancient blocks imported via IoChannel.
-    - Get rid of private transactions io message.
-    - Get rid of deadlock and fix disconnected handler.
-    - Revert to old disconnect condition.
-    - Fix tests.
-    - Fix deadlock.
-  - Refactoring `ethcore-sync` - Fixing warp-sync barrier ([#8543](https://github.com/paritytech/parity/pull/8543))
-    - Start dividing sync chain : first supplier method
-    - WIP - updated chain sync supplier
-    - Finish refactoring the Chain Sync Supplier
-    - Create Chain Sync Requester
-    - Add Propagator for Chain Sync
-    - Add the Chain Sync Handler
-    - Move tests from mod -> handler
-    - Move tests to propagator
-    - Refactor SyncRequester arguments
-    - Refactoring peer fork header handler
-    - Fix wrong highest block number in snapshot sync
-    - Small refactor...
-    - Address PR grumbles
-    - Retry failed CI job
-    - Fix tests
-    - PR Grumbles
-  - Handle socket address parsing errors ([#8545](https://github.com/paritytech/parity/pull/8545))
-  - Fix packet count when talking with PAR2 peers ([#8555](https://github.com/paritytech/parity/pull/8555))
-    - Support diferent packet counts in different protocol versions.
-    - Fix light timeouts and eclipse protection.
-    - Fix devp2p tests.
-    - Fix whisper-cli compilation.
-    - Fix compilation.
-    - Fix ethcore-sync tests.
-    - Revert "Fix light timeouts and eclipse protection."
-    - Increase timeouts.
-  - Add whisper CLI to the pipelines ([#8578](https://github.com/paritytech/parity/pull/8578))
-    - Add whisper CLI to the pipelines
-    - Address todo, ref [#8579](https://github.com/paritytech/parity/pull/8579)
-  - Rename `whisper-cli binary` to `whisper` ([#8579](https://github.com/paritytech/parity/pull/8579))
-    - Rename whisper-cli binary to whisper
-    - Fix tests
-  - Remove manually added text to the errors ([#8595](https://github.com/paritytech/parity/pull/8595))
-  - Fix account list double 0x display ([#8596](https://github.com/paritytech/parity/pull/8596))
-    - Remove unused self import
-    - Fix account list double 0x display
-  - Fix BlockReward contract "arithmetic operation overflow" ([#8611](https://github.com/paritytech/parity/pull/8611))
-    - Fix BlockReward contract "arithmetic operation overflow"
-    - Add docs on how execute_as_system works
-    - Fix typo
-  - Rlp decode returns Result ([#8527](https://github.com/paritytech/parity/pull/8527))
-  - Remove expect ([#8536](https://github.com/paritytech/parity/pull/8536))
-    - Remove expect and propagate rlp::DecoderErrors as TrieErrors
-  - Decoding headers can fail ([#8570](https://github.com/paritytech/parity/pull/8570))
-    - Rlp::decode returns Result
-    - Fix journaldb to handle rlp::decode Result
-    - Fix ethcore to work with rlp::decode returning Result
-    - Light client handles rlp::decode returning Result
-    - Fix tests in rlp_derive
-    - Fix tests
-    - Cleanup
-    - Cleanup
-    - Allow panic rather than breaking out of iterator
-    - Let decoding failures when reading from disk blow up
-    - Syntax
-    - Fix the trivial grumbles
-    - Fix failing tests
-    - Make Account::from_rlp return Result
-    - Syntx, sigh
-    - Temp-fix for decoding failures
-    - Header::decode returns Result
-    - Do not continue reading from the DB when a value could not be read
-    - Fix tests
-    - Handle header decoding in light_sync
-    - Handling header decoding errors
-    - Let the DecodeError bubble up unchanged
-    - Remove redundant error conversion
-  - Fix compiler warning ([#8590](https://github.com/paritytech/parity/pull/8590))
-  - Attempt to fix intermittent test failures ([#8584](https://github.com/paritytech/parity/pull/8584))
-  - Block_header can fail so return Result ([#8581](https://github.com/paritytech/parity/pull/8581))
-    - Block_header can fail so return Result
-    - Restore previous return type based on feedback
-    - Fix failing doc tests running on non-code
-  - Block::decode() returns Result ([#8586](https://github.com/paritytech/parity/pull/8586))
-  - Gitlab test script fixes ([#8573](https://github.com/paritytech/parity/pull/8573))
-    - Exclude /docs from modified files.
-    - Ensure all references in the working tree are available
-    - Remove duplicated line from test script
-- Bump beta to 1.11.1 ([#8627](https://github.com/paritytech/parity/pull/8627))
-
-## Parity [v1.11.0](https://github.com/paritytech/parity/releases/tag/v1.11.0) (2018-05-09)
-
-This is the Parity 1.11.0-beta release! ~~Hurray!~~ This release has been pulled due to peering issues, please use 1.11.1-beta.
-
-The full list of included changes:
-
-- Backports ([#8558](https://github.com/paritytech/parity/pull/8558))
-  - Fetching logs by hash in blockchain database ([#8463](https://github.com/paritytech/parity/pull/8463))
-    - Fetch logs by hash in blockchain database
-    - Fix tests
-    - Add unit test for branch block logs fetching
-    - Add docs that blocks must already be sorted
-    - Handle branch block cases properly
-    - typo: empty -> is_empty
-    - Remove return_empty_if_none by using a closure
-    - Use BTreeSet to avoid sorting again
-    - Move is_canon to BlockChain
-    - typo: pass value by reference
-    - Use loop and wrap inside blocks to simplify the code
-    - typo: missed a comment
-  - Pass on storage keys tracing to handle the case when it is not modified ([#8491](https://github.com/paritytech/parity/pull/8491))
-    - Pass on storage keys even if it is not modified
-    - typo: account and storage query
-    - Fix tests
-    - Use state query directly because of suicided accounts
-    - Fix a RefCell borrow issue
-    - Add tests for unmodified storage trace
-    - Address grumbles
-    - typo: remove unwanted empty line
-    - ensure_cached compiles with the original signature
-  - Update wasmi and pwasm-utils ([#8493](https://github.com/paritytech/parity/pull/8493))
-    - Update wasmi to 0.2
-    - Update pwasm-utils to 0.1.5
-  - Show imported messages for light client ([#8517](https://github.com/paritytech/parity/pull/8517))
-  - Enable WebAssembly and Byzantium for Ellaism ([#8520](https://github.com/paritytech/parity/pull/8520))
-    - Enable WebAssembly and Byzantium for Ellaism
-    - Fix indentation
-    - Remove empty lines
-  - Don't panic in import_block if invalid rlp ([#8522](https://github.com/paritytech/parity/pull/8522))
-    - Don't panic in import_block if invalid rlp
-    - Remove redundant type annotation
-    - Replace RLP header view usage with safe decoding
-  - Node table sorting according to last contact data ([#8541](https://github.com/paritytech/parity/pull/8541))
-    - network-devp2p: sort nodes in node table using last contact data
-    - network-devp2p: rename node contact types in node table json output
-    - network-devp2p: fix node table tests
-    - network-devp2p: note node failure when failed to establish connection
-    - network-devp2p: handle UselessPeer error
-    - network-devp2p: note failure when marking node as useless
-- Betalize 1.11 :) ([#8475](https://github.com/paritytech/parity/pull/8475))
-  - Betalize 1.11 :)
-  - Update Gitlab scripts
-  - Use master as gitlab latest
-  - Fix snap builds ([#8483](https://github.com/paritytech/parity/pull/8483))
-  - Update hardcodedSync for Ethereum, Kovan, and Ropsten ([#8489](https://github.com/paritytech/parity/pull/8489))
-- Fix typos in vm description comment ([#8446](https://github.com/paritytech/parity/pull/8446))
-- Add changelog for 1.9.7 and 1.10.2 ([#8460](https://github.com/paritytech/parity/pull/8460))
-- Fix docker build ([#8462](https://github.com/paritytech/parity/pull/8462))
-- Parityshell::open `Return result` ([#8377](https://github.com/paritytech/parity/pull/8377))
-- Return error in case eth_call returns VM errors ([#8448](https://github.com/paritytech/parity/pull/8448))
-- Update wasmi ([#8452](https://github.com/paritytech/parity/pull/8452))
-- Allow 32 bit pipelines to fail ([#8454](https://github.com/paritytech/parity/pull/8454))
-- Update Cargo hidapi-rs dependency ([#8447](https://github.com/paritytech/parity/pull/8447))
-- Private transactions processing error handling ([#8431](https://github.com/paritytech/parity/pull/8431))
-- Improve VM executor stack size estimation rules ([#8439](https://github.com/paritytech/parity/pull/8439))
-- Block reward contract ([#8419](https://github.com/paritytech/parity/pull/8419))
-- Permission fix ([#8441](https://github.com/paritytech/parity/pull/8441))
-- Use forked app_dirs crate for reverted Windows dir behavior ([#8438](https://github.com/paritytech/parity/pull/8438))
-- Remove From::from. ([#8390](https://github.com/paritytech/parity/pull/8390))
-- Move ethcore::Error to error_chain ([#8386](https://github.com/paritytech/parity/pull/8386))
-- Changelogs for 1.9.6 and 1.10.1 ([#8411](https://github.com/paritytech/parity/pull/8411))
-- Fix receipts stripping. ([#8414](https://github.com/paritytech/parity/pull/8414))
-- Typo, docs parity_chainId: empty string -> None ([#8434](https://github.com/paritytech/parity/pull/8434))
-- Update zip to 0.3 ([#8381](https://github.com/paritytech/parity/pull/8381))
-- Fix TODO comments ([#8413](https://github.com/paritytech/parity/pull/8413))
-- Replace legacy Rlp with UntrustedRlp and use in ethcore rlp views ([#8316](https://github.com/paritytech/parity/pull/8316))
-- Tokio-core v0.1.16 -> v0.1.17 ([#8408](https://github.com/paritytech/parity/pull/8408))
-- More code refactoring to integrate Duration ([#8322](https://github.com/paritytech/parity/pull/8322))
-- Remove Tendermint extra_info due to seal inconsistencies ([#8367](https://github.com/paritytech/parity/pull/8367))
-- Use tokio::spawn in secret_store listener and fix Uri ([#8373](https://github.com/paritytech/parity/pull/8373))
-- Unify and limit rocksdb dependency places ([#8371](https://github.com/paritytech/parity/pull/8371))
-- Clarify that windows need perl and yasm ([#8402](https://github.com/paritytech/parity/pull/8402))
-- New Transaction Queue implementation ([#8074](https://github.com/paritytech/parity/pull/8074))
-- Some tweaks to main.rs for parity as a library ([#8370](https://github.com/paritytech/parity/pull/8370))
-- Handle queue import errors a bit more gracefully ([#8385](https://github.com/paritytech/parity/pull/8385))
-- Ci: fix change detection in master builds ([#8382](https://github.com/paritytech/parity/pull/8382))
-- Fix config test by adding no-hardcodec-sync ([#8380](https://github.com/paritytech/parity/pull/8380))
-- Fixed unsafe shell call on windows ([#8372](https://github.com/paritytech/parity/pull/8372))
-- Parity uses winapi 0.3.4 ([#8366](https://github.com/paritytech/parity/pull/8366))
-- No hardcoded client name ([#8368](https://github.com/paritytech/parity/pull/8368))
-- Add `util/mem` to zero out memory on drop. ([#8356](https://github.com/paritytech/parity/pull/8356))
-- Use atty instead of isatty ([#8365](https://github.com/paritytech/parity/pull/8365))
-- Increase gasLimit to 8'000'000 ([#8362](https://github.com/paritytech/parity/pull/8362))
-- Util `fake-fetch` ([#8363](https://github.com/paritytech/parity/pull/8363))
-- Bump snappy and ring, use single rayon version, closes [#8296](https://github.com/paritytech/parity/issues/8296) ([#8364](https://github.com/paritytech/parity/pull/8364))
-- Use async hyper server in secret_store and upgrade igd ([#8359](https://github.com/paritytech/parity/pull/8359))
-- Enable UI by default, but only display deprecation notice ([#8262](https://github.com/paritytech/parity/pull/8262))
-- Ethcrypto renamed to ethcore-crypto and moved to ethcore dir ([#8340](https://github.com/paritytech/parity/pull/8340))
-- Use hyper 0.11 in ethcore-miner and improvements in parity-reactor ([#8335](https://github.com/paritytech/parity/pull/8335))
-- Ethcore-sync ([#8347](https://github.com/paritytech/parity/pull/8347))
-- Rpc, eth_filter: return error if the filter id does not exist ([#8341](https://github.com/paritytech/parity/pull/8341))
-- Ethcore-stratum crate moved to ethcore directory ([#8338](https://github.com/paritytech/parity/pull/8338))
-- Secretstore: get rid of engine.signer dependency ([#8173](https://github.com/paritytech/parity/pull/8173))
-- Whisper cli ([#8201](https://github.com/paritytech/parity/pull/8201))
-- Replace_home for password_files, reserved_peers and log_file ([#8324](https://github.com/paritytech/parity/pull/8324))
-- Add Ethereum Social support ([#8325](https://github.com/paritytech/parity/pull/8325))
-- Private transactions integration pr ([#6422](https://github.com/paritytech/parity/pull/6422))
-- Decouple rocksdb dependency from ethcore ([#8320](https://github.com/paritytech/parity/pull/8320))
-- Remove the clone operation of code_cache ([#8334](https://github.com/paritytech/parity/pull/8334))
-- Fix the JSONRPC API not running with the light client ([#8326](https://github.com/paritytech/parity/pull/8326))
-- Read registry_address from block with REQUEST_CONFIRMATIONS_REQUIRED ([#8309](https://github.com/paritytech/parity/pull/8309))
-- Tweaks and add a Dockerfile for Android ([#8036](https://github.com/paritytech/parity/pull/8036))
-- Use associated type M::Error instead of Error ([#8308](https://github.com/paritytech/parity/pull/8308))
-- Remove InvalidParentHash in favor of assert! ([#8300](https://github.com/paritytech/parity/pull/8300))
-- Bump proc macro deps ([#8310](https://github.com/paritytech/parity/pull/8310))
-- Decouple timestamp open-block-assignment/verification to Engine ([#8305](https://github.com/paritytech/parity/pull/8305))
-- Validate if gas limit is not zero ([#8307](https://github.com/paritytech/parity/pull/8307))
-- Implement Easthub chain spec ([#8295](https://github.com/paritytech/parity/pull/8295))
-- Update some dependencies ([#8285](https://github.com/paritytech/parity/pull/8285))
-- Ethcore now uses Rayon 1.0 as a dependency ([#8296](https://github.com/paritytech/parity/pull/8296)) ([#8304](https://github.com/paritytech/parity/pull/8304))
-- Upgrader `remove raw unwrap` and bump semver ([#8251](https://github.com/paritytech/parity/pull/8251))
-- Cleaner binary shutdown system ([#8284](https://github.com/paritytech/parity/pull/8284))
-- Ethcore now uses rayon to 0.9 as a dependency ([#8296](https://github.com/paritytech/parity/pull/8296)) ([#8302](https://github.com/paritytech/parity/pull/8302))
-- Include suicided accounts in state diff ([#8297](https://github.com/paritytech/parity/pull/8297))
-- Remove evmjit ([#8229](https://github.com/paritytech/parity/pull/8229))
-- Build: fix updater rand dependency in Cargo.lock ([#8298](https://github.com/paritytech/parity/pull/8298))
-- Honor --max-peers if --min-peers is not specified ([#8087](https://github.com/paritytech/parity/pull/8087))
-- Auto-updater improvements ([#8078](https://github.com/paritytech/parity/pull/8078))
-- Dapps-fetcher: calculate keccak in-flight while reading the response ([#8294](https://github.com/paritytech/parity/pull/8294))
-- Cleanup Ellaism bootnodes ([#8276](https://github.com/paritytech/parity/pull/8276))
-- Allow unsafe js eval on Parity Wallet. ([#8204](https://github.com/paritytech/parity/pull/8204))
-- Remove RefCell from Header ([#8227](https://github.com/paritytech/parity/pull/8227))
-- Typo fix: todo with no content ([#8292](https://github.com/paritytech/parity/pull/8292))
-- Revert "ci: disable link-dead-code in coverage build ([#8118](https://github.com/paritytech/parity/pull/8118))" ([#8287](https://github.com/paritytech/parity/pull/8287))
-- Bump ethabi & ethereum-types. ([#8258](https://github.com/paritytech/parity/pull/8258))
-- Allow customization of max WS connections. ([#8257](https://github.com/paritytech/parity/pull/8257))
-- Supress TemporaryInvalid verification failures. ([#8256](https://github.com/paritytech/parity/pull/8256))
-- Return null number for pending block in eth_getBlockByNumber ([#8281](https://github.com/paritytech/parity/pull/8281))
-- Use constant durations ([#8278](https://github.com/paritytech/parity/pull/8278))
-- Typo fix: Mode doc - RLP should be client ([#8283](https://github.com/paritytech/parity/pull/8283))
-- Eth_uninstallfilter should return false for non-existent filter ([#8280](https://github.com/paritytech/parity/pull/8280))
-- Update `app_dirs` to 1.2.1 ([#8268](https://github.com/paritytech/parity/pull/8268))
-- Add missing license header for runtime.rs ([#8252](https://github.com/paritytech/parity/pull/8252))
-- Warp-only sync with warp-barrier [blocknumber] flag. ([#8228](https://github.com/paritytech/parity/pull/8228))
-- Replace all Rlp usages with UntrustedRlp except for ethcore views ([#8233](https://github.com/paritytech/parity/pull/8233))
-- Add test for ethstore-cli, fixes [#8027](https://github.com/paritytech/parity/issues/8027) ([#8187](https://github.com/paritytech/parity/pull/8187))
-- Update musicoin spec in line with gmc v2.6.2 ([#8242](https://github.com/paritytech/parity/pull/8242))
-- Fixed ethcore tx_filter ([#8200](https://github.com/paritytech/parity/pull/8200))
-- Update CLI help for jsonrpc-apis, ws-apis and ipc-apis ([#8234](https://github.com/paritytech/parity/pull/8234))
-- Remove network stats ([#8225](https://github.com/paritytech/parity/pull/8225))
-- Node-filter does not use ChainNotify ([#8231](https://github.com/paritytech/parity/pull/8231))
-- Implement hardcoded sync in the light client ([#8075](https://github.com/paritytech/parity/pull/8075))
-- Update some of the dependencies for WASM ([#8223](https://github.com/paritytech/parity/pull/8223))
-- Bump wasmi version ([#8209](https://github.com/paritytech/parity/pull/8209))
-- Updated jsonrpc to point to the 1.11 branch ([#8180](https://github.com/paritytech/parity/pull/8180))
-- Change name Wallet -> UI ([#8164](https://github.com/paritytech/parity/pull/8164))
-- Introduce Parity UI ([#8202](https://github.com/paritytech/parity/pull/8202))
-- Update Changelogs ([#8175](https://github.com/paritytech/parity/pull/8175))
-- Returns number of topcis to take fr.. ([#8199](https://github.com/paritytech/parity/pull/8199))
-- Make docopt usage non-const ([#8189](https://github.com/paritytech/parity/pull/8189))
-- Avoid allocations when computing triehash. ([#8176](https://github.com/paritytech/parity/pull/8176))
-- Handle rlp decoding Result in patricia trie ([#8166](https://github.com/paritytech/parity/pull/8166))
-- Bump wasm libs ([#8171](https://github.com/paritytech/parity/pull/8171))
-- Re-enable signer, even with no UI. ([#8167](https://github.com/paritytech/parity/pull/8167))
-- Update daemonize ([#8165](https://github.com/paritytech/parity/pull/8165))
-- Some tiny modifications. ([#8163](https://github.com/paritytech/parity/pull/8163))
-- Secretstore: store key author address in db ([#7887](https://github.com/paritytech/parity/pull/7887))
-- Rename DatabaseValueView::new to from_rlp ([#8159](https://github.com/paritytech/parity/pull/8159))
-- Dapps: update parity-ui dependencies ([#8160](https://github.com/paritytech/parity/pull/8160))
-- Disable UI by default. ([#8105](https://github.com/paritytech/parity/pull/8105))
-- Fix wasmi x32 builds ([#8155](https://github.com/paritytech/parity/pull/8155))
-- Postpone Kovan hard fork ([#8137](https://github.com/paritytech/parity/pull/8137))
-- Secretstore: ability to identify requester via Public/Address ([#7886](https://github.com/paritytech/parity/pull/7886))
-- Optional dependency on secp256k1 for ethcrypto ([#8109](https://github.com/paritytech/parity/pull/8109))
-- Network: init discovery using healthy nodes ([#8061](https://github.com/paritytech/parity/pull/8061))
-- Check one step deeper if we're on release track branches ([#8134](https://github.com/paritytech/parity/pull/8134))
-- Explicitly mention pruning_history uses RAM ([#8130](https://github.com/paritytech/parity/pull/8130))
-- Remove `ethcrypto::{en,de}crypt_single_message`. ([#8126](https://github.com/paritytech/parity/pull/8126))
-- Fix typo ([#8124](https://github.com/paritytech/parity/pull/8124))
-- Secret_store: use `ecies::encrypt`/`ecies::decrypt`. ([#8125](https://github.com/paritytech/parity/pull/8125))
-- Fix comment for fn gas() in wasm/runtime ([#8122](https://github.com/paritytech/parity/pull/8122))
-- Structured rlp encoding in journaldb ([#8047](https://github.com/paritytech/parity/pull/8047))
-- Ci: disable link-dead-code in coverage build ([#8118](https://github.com/paritytech/parity/pull/8118))
-- Fix trace filter returning returning unrelated reward calls, closes [#8070](https://github.com/paritytech/parity/issues/8070) ([#8098](https://github.com/paritytech/parity/pull/8098))
-- Const time comparison ([#8113](https://github.com/paritytech/parity/pull/8113))
-- Replace reqwest with hyper ([#8099](https://github.com/paritytech/parity/pull/8099))
-- More dos protection ([#8104](https://github.com/paritytech/parity/pull/8104))
-- Remove the time dependency where possible ([#8100](https://github.com/paritytech/parity/pull/8100))
-- Fix comment for gas extern in Wasm runtime ([#8101](https://github.com/paritytech/parity/pull/8101))
-- Replace std::env::temp_dir with tempdir in tests ([#8103](https://github.com/paritytech/parity/pull/8103))
-- Fix Cargo.lock not parsable ([#8102](https://github.com/paritytech/parity/pull/8102))
-- Additional data in EVMTestClient ([#7964](https://github.com/paritytech/parity/pull/7964))
-- Update serde, serde-derive, ethabi-derive, syn, quote and rlp_derive ([#8085](https://github.com/paritytech/parity/pull/8085))
-- Ethcore-service ([#8089](https://github.com/paritytech/parity/pull/8089))
-- [contract-client] refactor ([#7978](https://github.com/paritytech/parity/pull/7978))
-- Revert removing blooms ([#8066](https://github.com/paritytech/parity/pull/8066))
-- Ethcore test::helpers cleanup ([#8086](https://github.com/paritytech/parity/pull/8086))
-- Add some dos protection ([#8084](https://github.com/paritytech/parity/pull/8084))
-- Wasm libraries bump ([#7970](https://github.com/paritytech/parity/pull/7970))
-- Echo back the message hash of a ping in the pong request ([#8042](https://github.com/paritytech/parity/pull/8042))
-- Add Kovan WASM activation blocknumber ([#8057](https://github.com/paritytech/parity/pull/8057))
-- [ethkey] Unify debug/display for Address/Public/Secret ([#8076](https://github.com/paritytech/parity/pull/8076))
-- Limit incoming connections. ([#8060](https://github.com/paritytech/parity/pull/8060))
-- Max code size on Kovan ([#8067](https://github.com/paritytech/parity/pull/8067))
-- Updater: apply exponential backoff after download failure ([#8059](https://github.com/paritytech/parity/pull/8059))
-- Make blockchain functions more idiomatic, avoid needless writes to cache_man ([#8054](https://github.com/paritytech/parity/pull/8054))
-- Make patricia-trie more idiomatic and remove redundant code ([#8056](https://github.com/paritytech/parity/pull/8056))
-- Abstract devp2p ([#8048](https://github.com/paritytech/parity/pull/8048))
-- Update refs to shell ([#8051](https://github.com/paritytech/parity/pull/8051))
-- Fix cache & snapcraft CI build ([#8052](https://github.com/paritytech/parity/pull/8052))
-- Prelude to the block module cleanup ([#8025](https://github.com/paritytech/parity/pull/8025))
-- Add MCIP-6 Byzyantium transition to Musicoin spec ([#7841](https://github.com/paritytech/parity/pull/7841))
-- Bump master to 1.11.0 ([#8021](https://github.com/paritytech/parity/pull/8021))
-- `client` refactoring ([#7038](https://github.com/paritytech/parity/pull/7038))
-- [hardware wallet] sleeping -> pollling ([#8018](https://github.com/paritytech/parity/pull/8018))
-- Fixed broken link in README ([#8012](https://github.com/paritytech/parity/pull/8012))
-- Support parity protocol. ([#8035](https://github.com/paritytech/parity/pull/8035))
-- Add changelog for 1.8.11 stable and 1.9.4 beta ([#8017](https://github.com/paritytech/parity/pull/8017))
-- Fix for verify_block_basic crashing on invalid transaction rlp ([#8032](https://github.com/paritytech/parity/pull/8032))
-- Extract the hard dependency on rocksdb from the light client ([#8034](https://github.com/paritytech/parity/pull/8034))
-- Fixed parsing ethash seals and verify_block_undordered ([#8031](https://github.com/paritytech/parity/pull/8031))
-- Fixed ethstore sign ([#8026](https://github.com/paritytech/parity/pull/8026))
-- Ci: Fix cargo cache ([#7968](https://github.com/paritytech/parity/pull/7968))
-- Update ref to new shell ([#8024](https://github.com/paritytech/parity/pull/8024))
+- Backports to 2.0.0-beta ([#9094](https://github.com/paritytech/parity/pull/9094))
+  - Parity-version: betalize 2.0
+  - Multiple improvements to discovery ping handling ([#8771](https://github.com/paritytech/parity/pull/8771))
+  - Add separate database directory for light client ([#9064](https://github.com/paritytech/parity/pull/9064))
+- Parity Ethereum 2.0.0 ([#9052](https://github.com/paritytech/parity/pull/9052))
+- Don't fetch snapshot chunks at random ([#9088](https://github.com/paritytech/parity/pull/9088))
+- Remove the dapps system ([#9017](https://github.com/paritytech/parity/pull/9017))
+- Fix nightly warnings ([#9080](https://github.com/paritytech/parity/pull/9080))
+- Db: remove wal disabling / fast-and-loose option. ([#8963](https://github.com/paritytech/parity/pull/8963))
+- Transactions hashes missing in trace_replayBlockTransactions method result [#8725](https://github.com/paritytech/parity/issues/8725) ([#8883](https://github.com/paritytech/parity/pull/8883))
+- Delete crates from parity-ethereum and fetch them from parity-common instead ([#9083](https://github.com/paritytech/parity/pull/9083))
+- Updater verification ([#8787](https://github.com/paritytech/parity/pull/8787))
+- Phrasing, precisions and typos in CLI help ([#9060](https://github.com/paritytech/parity/pull/9060))
+- Some work towards iOS build ([#9045](https://github.com/paritytech/parity/pull/9045))
+- Clean up deprecated options and add CHECK macro ([#9036](https://github.com/paritytech/parity/pull/9036))
+- Replace `std::env::home_dir` with `dirs::home_dir` ([#9077](https://github.com/paritytech/parity/pull/9077))
+- Fix warning in secret-store test ([#9074](https://github.com/paritytech/parity/pull/9074))
+- Seedhashcompute remove needless `new` impl ([#9063](https://github.com/paritytech/parity/pull/9063))
+- Remove trait bounds from several structs ([#9055](https://github.com/paritytech/parity/pull/9055))
+- Docs: add changelog for 1.10.9 stable and 1.11.6 beta ([#9069](https://github.com/paritytech/parity/pull/9069))
+- Enable test in `miner/pool/test` ([#9072](https://github.com/paritytech/parity/pull/9072))
+- Fetch: replace futures-timer with tokio-timer ([#9066](https://github.com/paritytech/parity/pull/9066))
+- Remove util-error ([#9054](https://github.com/paritytech/parity/pull/9054))
+- Fixes for misbehavior reporting in AuthorityRound ([#8998](https://github.com/paritytech/parity/pull/8998))
+- A last bunch of txqueue performance optimizations ([#9024](https://github.com/paritytech/parity/pull/9024))
+- Reduce number of constraints for triedb types ([#9043](https://github.com/paritytech/parity/pull/9043))
+- Bump fs-swap to 0.2.3 so it is compatible with osx 10.11 again ([#9050](https://github.com/paritytech/parity/pull/9050))
+- Recursive test ([#9042](https://github.com/paritytech/parity/pull/9042))
+- Introduce more optional features in ethcore ([#9020](https://github.com/paritytech/parity/pull/9020))
+- Update ETSC bootnodes ([#9038](https://github.com/paritytech/parity/pull/9038))
+- Optimize pending transactions filter ([#9026](https://github.com/paritytech/parity/pull/9026))
+- Eip160/eip161 spec: u64 -> BlockNumber ([#9044](https://github.com/paritytech/parity/pull/9044))
+- Move the C/C++ example to another directory ([#9032](https://github.com/paritytech/parity/pull/9032))
+- Bump parking_lot to 0.6 ([#9013](https://github.com/paritytech/parity/pull/9013))
+- Never drop local transactions from different senders. ([#9002](https://github.com/paritytech/parity/pull/9002))
+- Precise HTTP or WebSockets for JSON-RPC options ([#9027](https://github.com/paritytech/parity/pull/9027))
+- Recently rejected cache for transaction queue ([#9005](https://github.com/paritytech/parity/pull/9005))
+- Make HashDB generic ([#8739](https://github.com/paritytech/parity/pull/8739))
+- Only return error log for rustls ([#9025](https://github.com/paritytech/parity/pull/9025))
+- Update Changelogs for 1.10.8 and 1.11.5 ([#9012](https://github.com/paritytech/parity/pull/9012))
+- Attempt to graceful shutdown in case of panics ([#8999](https://github.com/paritytech/parity/pull/8999))
+- Simplify kvdb error types ([#8924](https://github.com/paritytech/parity/pull/8924))
+- Add option for user to set max size limit for RPC requests ([#9010](https://github.com/paritytech/parity/pull/9010))
+- Bump ntp to 0.5.0 ([#9009](https://github.com/paritytech/parity/pull/9009))
+- Removed duplicate dependency ([#9021](https://github.com/paritytech/parity/pull/9021))
+- Minimal effective gas price in the queue ([#8934](https://github.com/paritytech/parity/pull/8934))
+- Parity: fix db path when migrating to blooms db ([#8975](https://github.com/paritytech/parity/pull/8975))
+- Preserve the current abort behavior ([#8995](https://github.com/paritytech/parity/pull/8995))
+- Improve should_replace on NonceAndGasPrice ([#8980](https://github.com/paritytech/parity/pull/8980))
+- Tentative fix for missing dependency error ([#8973](https://github.com/paritytech/parity/pull/8973))
+- Refactor evm Instruction to be a c-like enum ([#8914](https://github.com/paritytech/parity/pull/8914))
+- Fix deadlock in blockchain. ([#8977](https://github.com/paritytech/parity/pull/8977))
+- Snap: downgrade rust to revision 1.26.2, ref snapcraft/+bug/1778530 ([#8984](https://github.com/paritytech/parity/pull/8984))
+- Use local parity-dapps-glue instead of crate published at crates.io ([#8983](https://github.com/paritytech/parity/pull/8983))
+- Parity: omit redundant last imported block number in light sync informant ([#8962](https://github.com/paritytech/parity/pull/8962))
+- Disable hardware-wallets on platforms that don't support `libusb` ([#8464](https://github.com/paritytech/parity/pull/8464))
+- Bump error-chain and quick_error versions ([#8972](https://github.com/paritytech/parity/pull/8972))
+- Evm benchmark utilities ([#8944](https://github.com/paritytech/parity/pull/8944))
+- Parity: hide legacy options from cli --help ([#8967](https://github.com/paritytech/parity/pull/8967))
+- Scripts: fix docker build tag on latest using master ([#8952](https://github.com/paritytech/parity/pull/8952))
+- Add type for passwords. ([#8920](https://github.com/paritytech/parity/pull/8920))
+- Deps: bump fs-swap ([#8953](https://github.com/paritytech/parity/pull/8953))
+- Eliminate some more `transmute()` ([#8879](https://github.com/paritytech/parity/pull/8879))
+- Restrict vault.json permssion to owner and using random suffix for temp vault.json file ([#8932](https://github.com/paritytech/parity/pull/8932))
+- Print SS.self_public when starting SS node ([#8949](https://github.com/paritytech/parity/pull/8949))
+- Scripts: minor improvements ([#8930](https://github.com/paritytech/parity/pull/8930))
+- Rpc: cap gas limit of local calls ([#8943](https://github.com/paritytech/parity/pull/8943))
+- Docs: update changelogs ([#8931](https://github.com/paritytech/parity/pull/8931))
+- Ethcore: fix compilation when using slow-blocks or evm-debug features ([#8936](https://github.com/paritytech/parity/pull/8936))
+- Fixed blooms dir creation ([#8941](https://github.com/paritytech/parity/pull/8941))
+- Update hardcoded headers ([#8925](https://github.com/paritytech/parity/pull/8925))
+- New blooms database ([#8712](https://github.com/paritytech/parity/pull/8712))
+- Ethstore: retry deduplication of wallet file names until success ([#8910](https://github.com/paritytech/parity/pull/8910))
+- Update ropsten.json ([#8926](https://github.com/paritytech/parity/pull/8926))
+- Include node identity in the P2P advertised client version. ([#8830](https://github.com/paritytech/parity/pull/8830))
+- Allow disabling local-by-default for transactions with new config entry ([#8882](https://github.com/paritytech/parity/pull/8882))
+- Allow Poll Lifetime to be configured via CLI ([#8885](https://github.com/paritytech/parity/pull/8885))
+- Cleanup nibbleslice ([#8915](https://github.com/paritytech/parity/pull/8915))
+- Hardware-wallets `Clean up things I missed in the latest PR` ([#8890](https://github.com/paritytech/parity/pull/8890))
+- Remove debian/.deb and centos/.rpm packaging scripts ([#8887](https://github.com/paritytech/parity/pull/8887))
+- Remove a weird emoji in new_social docs ([#8913](https://github.com/paritytech/parity/pull/8913))
+- Minor fix in chain supplier and light provider ([#8906](https://github.com/paritytech/parity/pull/8906))
+- Block 0 is valid in queries ([#8891](https://github.com/paritytech/parity/pull/8891))
+- Fixed osx permissions ([#8901](https://github.com/paritytech/parity/pull/8901))
+- Atomic create new files with permissions to owner in ethstore ([#8896](https://github.com/paritytech/parity/pull/8896))
+- Add ETC Cooperative-run load balanced parity node ([#8892](https://github.com/paritytech/parity/pull/8892))
+- Add support for --chain tobalaba ([#8870](https://github.com/paritytech/parity/pull/8870))
+- Fix some warns on nightly ([#8889](https://github.com/paritytech/parity/pull/8889))
+- Add new ovh bootnodes and fix port for foundation bootnode 3.2 ([#8886](https://github.com/paritytech/parity/pull/8886))
+- Secretstore: service pack 1 ([#8435](https://github.com/paritytech/parity/pull/8435))
+- Handle removed logs in filter changes and add geth compatibility field ([#8796](https://github.com/paritytech/parity/pull/8796))
+- Fixed ipc leak, closes [#8774](https://github.com/paritytech/parity/issues/8774) ([#8876](https://github.com/paritytech/parity/pull/8876))
+- Scripts: remove md5 checksums ([#8884](https://github.com/paritytech/parity/pull/8884))
+- Hardware_wallet/Ledger `Sign messages` + some refactoring ([#8868](https://github.com/paritytech/parity/pull/8868))
+- Check whether we need resealing in miner and unwrap has_account in account_provider ([#8853](https://github.com/paritytech/parity/pull/8853))
+- Docker: Fix alpine build ([#8878](https://github.com/paritytech/parity/pull/8878))
+- Remove mac os installers etc ([#8875](https://github.com/paritytech/parity/pull/8875))
+- Readme.md: update the list of dependencies ([#8864](https://github.com/paritytech/parity/pull/8864))
+- Fix concurrent access to signer queue ([#8854](https://github.com/paritytech/parity/pull/8854))
+- Tx permission contract improvement ([#8400](https://github.com/paritytech/parity/pull/8400))
+- Limit the number of transactions in pending set ([#8777](https://github.com/paritytech/parity/pull/8777))
+- Use sealing.enabled to emit eth_mining information ([#8844](https://github.com/paritytech/parity/pull/8844))
+- Don't allocate in expect_valid_rlp unless necessary ([#8867](https://github.com/paritytech/parity/pull/8867))
+- Fix Cli Return Code on --help for ethkey, ethstore & whisper ([#8863](https://github.com/paritytech/parity/pull/8863))
+- Fix subcrate test compile ([#8862](https://github.com/paritytech/parity/pull/8862))
+- Network-devp2p: downgrade logging to debug, add target ([#8784](https://github.com/paritytech/parity/pull/8784))
+- Clearing up a comment about the prefix for signing ([#8828](https://github.com/paritytech/parity/pull/8828))
+- Disable parallel verification and skip verifiying already imported txs. ([#8834](https://github.com/paritytech/parity/pull/8834))
+- Devp2p: Move UDP socket handling from Discovery to Host. ([#8790](https://github.com/paritytech/parity/pull/8790))
+- Fixed AuthorityRound deadlock on shutdown, closes [#8088](https://github.com/paritytech/parity/issues/8088) ([#8803](https://github.com/paritytech/parity/pull/8803))
+- Specify critical release flag per network ([#8821](https://github.com/paritytech/parity/pull/8821))
+- Fix `deadlock_detection` feature branch compilation ([#8824](https://github.com/paritytech/parity/pull/8824))
+- Use system allocator when profiling memory ([#8831](https://github.com/paritytech/parity/pull/8831))
+- Added from and to to Receipt ([#8756](https://github.com/paritytech/parity/pull/8756))
+- Ethcore: fix ancient block error msg handling ([#8832](https://github.com/paritytech/parity/pull/8832))
+- Ci: Fix docker tags ([#8822](https://github.com/paritytech/parity/pull/8822))
+- Parity: fix indentation in sync logging ([#8794](https://github.com/paritytech/parity/pull/8794))
+- Removed obsolete IpcMode enum ([#8819](https://github.com/paritytech/parity/pull/8819))
+- Remove UI related settings from CLI ([#8783](https://github.com/paritytech/parity/pull/8783))
+- Remove windows tray and installer ([#8778](https://github.com/paritytech/parity/pull/8778))
+- Docs: add changelogs for 1.10.6 and 1.11.3 ([#8810](https://github.com/paritytech/parity/pull/8810))
+- Fix ancient blocks queue deadlock ([#8751](https://github.com/paritytech/parity/pull/8751))
+- Disallow unsigned transactions in case EIP-86 is disabled ([#8802](https://github.com/paritytech/parity/pull/8802))
+- Fix evmbin compilation ([#8795](https://github.com/paritytech/parity/pull/8795))
+- Have space between feature cfg flag ([#8791](https://github.com/paritytech/parity/pull/8791))
+- Rpc: fix address formatting in TransactionRequest Display ([#8786](https://github.com/paritytech/parity/pull/8786))
+- Conditionally compile ethcore public test helpers ([#8743](https://github.com/paritytech/parity/pull/8743))
+- Remove Result wrapper from AccountProvider in RPC impls ([#8763](https://github.com/paritytech/parity/pull/8763))
+- Update `license header` and `scripts` ([#8666](https://github.com/paritytech/parity/pull/8666))
+- Remove HostTrait altogether ([#8681](https://github.com/paritytech/parity/pull/8681))
+- Ethcore-sync: fix connection to peers behind chain fork block ([#8710](https://github.com/paritytech/parity/pull/8710))
+- Remove public node settings from cli ([#8758](https://github.com/paritytech/parity/pull/8758))
+- Custom Error Messages on ENFILE and EMFILE IO Errors ([#8744](https://github.com/paritytech/parity/pull/8744))
+- Ci: Fixes for Android Pipeline ([#8745](https://github.com/paritytech/parity/pull/8745))
+- Remove NetworkService::config() ([#8653](https://github.com/paritytech/parity/pull/8653))
+- Fix XOR distance calculation in discovery Kademlia impl ([#8589](https://github.com/paritytech/parity/pull/8589))
+- Print warnings when fetching pending blocks ([#8711](https://github.com/paritytech/parity/pull/8711))
+- Fix PoW blockchains sealing notifications in chain_new_blocks ([#8656](https://github.com/paritytech/parity/pull/8656))
+- Remove -k/--insecure option from curl installer ([#8719](https://github.com/paritytech/parity/pull/8719))
+- Ease tiny-keccak version requirements (1.4.1 -> 1.4) ([#8726](https://github.com/paritytech/parity/pull/8726))
+- Bump tinykeccak to 1.4 ([#8728](https://github.com/paritytech/parity/pull/8728))
+- Remove a couple of unnecessary `transmute()` ([#8736](https://github.com/paritytech/parity/pull/8736))
+- Fix some nits using clippy ([#8731](https://github.com/paritytech/parity/pull/8731))
+- Add 'interface' option to cli ([#8699](https://github.com/paritytech/parity/pull/8699))
+- Remove unused function new_pow_test_spec ([#8735](https://github.com/paritytech/parity/pull/8735))
+- Add a deadlock detection thread ([#8727](https://github.com/paritytech/parity/pull/8727))
+- Fix local transactions policy. ([#8691](https://github.com/paritytech/parity/pull/8691))
+- Shutdown the Snapshot Service early ([#8658](https://github.com/paritytech/parity/pull/8658))
+- Network-devp2p: handle UselessPeer disconnect ([#8686](https://github.com/paritytech/parity/pull/8686))
+- Fix compilation error on nightly rust ([#8707](https://github.com/paritytech/parity/pull/8707))
+- Add a test for decoding corrupt data ([#8713](https://github.com/paritytech/parity/pull/8713))
+- Update dev chain ([#8717](https://github.com/paritytech/parity/pull/8717))
+- Remove unused imports ([#8722](https://github.com/paritytech/parity/pull/8722))
+- Implement recursive Debug for Nodes in patrica_trie::TrieDB ([#8697](https://github.com/paritytech/parity/pull/8697))
+- Parity: trim whitespace when parsing duration strings ([#8692](https://github.com/paritytech/parity/pull/8692))
+- Set the request index to that of the current request ([#8683](https://github.com/paritytech/parity/pull/8683))
+- Remove empty file ([#8705](https://github.com/paritytech/parity/pull/8705))
+- Update mod.rs ([#8695](https://github.com/paritytech/parity/pull/8695))
+- Use impl Future in the light client RPC helpers ([#8628](https://github.com/paritytech/parity/pull/8628))
+- Fix cli signer ([#8682](https://github.com/paritytech/parity/pull/8682))
+- Allow making direct RPC queries from the C API ([#8588](https://github.com/paritytech/parity/pull/8588))
+- Remove the error when stopping the network ([#8671](https://github.com/paritytech/parity/pull/8671))
+- Move connection_filter to the network crate ([#8674](https://github.com/paritytech/parity/pull/8674))
+- Remove HostInfo::client_version() and secret() ([#8677](https://github.com/paritytech/parity/pull/8677))
+- Refactor EIP150, EIP160 and EIP161 forks to be specified in CommonParams ([#8614](https://github.com/paritytech/parity/pull/8614))
+- Parity: improve cli help and logging ([#8665](https://github.com/paritytech/parity/pull/8665))
+- Updated tiny-keccak to 1.4.2 ([#8669](https://github.com/paritytech/parity/pull/8669))
+- Remove the Keccak C library and use the pure Rust impl ([#8657](https://github.com/paritytech/parity/pull/8657))
+- Remove HostInfo::next_nonce ([#8644](https://github.com/paritytech/parity/pull/8644))
+- Fix not downloading old blocks ([#8642](https://github.com/paritytech/parity/pull/8642))
+- Resumable warp-sync / Seed downloaded snapshots ([#8544](https://github.com/paritytech/parity/pull/8544))
+- Don't open Browser post-install on Mac ([#8641](https://github.com/paritytech/parity/pull/8641))
+- Changelog for 1.10.4-stable and 1.11.1-beta ([#8637](https://github.com/paritytech/parity/pull/8637))
+- Typo ([#8640](https://github.com/paritytech/parity/pull/8640))
+- Fork choice and metadata framework for Engine ([#8401](https://github.com/paritytech/parity/pull/8401))
+- Check that the Android build doesn't dep on c++_shared ([#8538](https://github.com/paritytech/parity/pull/8538))
+- Remove NetworkContext::io_channel() ([#8625](https://github.com/paritytech/parity/pull/8625))
+- Fix light sync with initial validator-set contract ([#8528](https://github.com/paritytech/parity/pull/8528))
+- Store morden db and keys in "path/to/parity/data/Morden" (ropsten uses "test", like before) ([#8621](https://github.com/paritytech/parity/pull/8621))
+- ´main.rs´ typo ([#8629](https://github.com/paritytech/parity/pull/8629))
+- Fix BlockReward contract "arithmetic operation overflow" ([#8611](https://github.com/paritytech/parity/pull/8611))
+- Gitlab test script fixes ([#8573](https://github.com/paritytech/parity/pull/8573))
+- Remove manually added text to the errors ([#8595](https://github.com/paritytech/parity/pull/8595))
+- Fix account list double 0x display ([#8596](https://github.com/paritytech/parity/pull/8596))
+- Typo: wrong indentation in kovan config ([#8610](https://github.com/paritytech/parity/pull/8610))
+- Fix packet count when talking with PAR2 peers ([#8555](https://github.com/paritytech/parity/pull/8555))
+- Use full qualified syntax for itertools::Itertools::flatten ([#8606](https://github.com/paritytech/parity/pull/8606))
+- 2 tiny modification on snapshot ([#8601](https://github.com/paritytech/parity/pull/8601))
+- Fix the mio test again ([#8602](https://github.com/paritytech/parity/pull/8602))
+- Remove inject.js server-side injection for dapps ([#8539](https://github.com/paritytech/parity/pull/8539))
+- Block_header can fail so return Result ([#8581](https://github.com/paritytech/parity/pull/8581))
+- Block::decode() returns Result ([#8586](https://github.com/paritytech/parity/pull/8586))
+- Fix compiler warning ([#8590](https://github.com/paritytech/parity/pull/8590))
+- Fix Parity UI link ([#8600](https://github.com/paritytech/parity/pull/8600))
+- Make mio optional in ethcore-io ([#8537](https://github.com/paritytech/parity/pull/8537))
+- Attempt to fix intermittent test failures ([#8584](https://github.com/paritytech/parity/pull/8584))
+- Changelog and Readme ([#8591](https://github.com/paritytech/parity/pull/8591))
+- Added Dockerfile for alpine linux by @andresilva, closes [#3565](https://github.com/paritytech/parity/issues/3565) ([#8587](https://github.com/paritytech/parity/pull/8587))
+- Add whisper CLI to the pipelines ([#8578](https://github.com/paritytech/parity/pull/8578))
+- Rename `whisper-cli binary` to `whisper` ([#8579](https://github.com/paritytech/parity/pull/8579))
+- Changelog nit ([#8585](https://github.com/paritytech/parity/pull/8585))
+- Remove unnecessary cloning in overwrite_with ([#8580](https://github.com/paritytech/parity/pull/8580))
+- Handle socket address parsing errors ([#8545](https://github.com/paritytech/parity/pull/8545))
+- Update CHANGELOG for 1.9, 1.10, and 1.11 ([#8556](https://github.com/paritytech/parity/pull/8556))
+- Decoding headers can fail ([#8570](https://github.com/paritytech/parity/pull/8570))
+- Refactoring `ethcore-sync` - Fixing warp-sync barrier ([#8543](https://github.com/paritytech/parity/pull/8543))
+- Remove State::replace_backend ([#8569](https://github.com/paritytech/parity/pull/8569))
+- Make trace-time publishable. ([#8568](https://github.com/paritytech/parity/pull/8568))
+- Don't block sync when importing old blocks ([#8530](https://github.com/paritytech/parity/pull/8530))
+- Trace precompiled contracts when the transfer value is not zero ([#8486](https://github.com/paritytech/parity/pull/8486))
+- Parity as a library ([#8412](https://github.com/paritytech/parity/pull/8412))
+- Rlp decode returns Result ([#8527](https://github.com/paritytech/parity/pull/8527))
+- Node table sorting according to last contact data ([#8541](https://github.com/paritytech/parity/pull/8541))
+- Keep all enacted blocks notify in order ([#8524](https://github.com/paritytech/parity/pull/8524))
+- Ethcore, rpc, machine: refactor block reward application and tracing ([#8490](https://github.com/paritytech/parity/pull/8490))
+- Consolidate crypto functionality in `ethcore-crypto`. ([#8432](https://github.com/paritytech/parity/pull/8432))
+- Eip 145: Bitwise shifting instructions in EVM ([#8451](https://github.com/paritytech/parity/pull/8451))
+- Remove expect ([#8536](https://github.com/paritytech/parity/pull/8536))
+- Don't panic in import_block if invalid rlp ([#8522](https://github.com/paritytech/parity/pull/8522))
+- Pass on storage keys tracing to handle the case when it is not modified ([#8491](https://github.com/paritytech/parity/pull/8491))
+- Fetching logs by hash in blockchain database ([#8463](https://github.com/paritytech/parity/pull/8463))
+- Transaction Pool improvements ([#8470](https://github.com/paritytech/parity/pull/8470))
+- More changes for Android ([#8421](https://github.com/paritytech/parity/pull/8421))
+- Enable WebAssembly and Byzantium for Ellaism ([#8520](https://github.com/paritytech/parity/pull/8520))
+- Secretstore: merge two types of errors into single one + Error::is_non_fatal ([#8357](https://github.com/paritytech/parity/pull/8357))
+- Hardware Wallet trait ([#8071](https://github.com/paritytech/parity/pull/8071))
+- Directly return None if tracing is disabled ([#8504](https://github.com/paritytech/parity/pull/8504))
+- Show imported messages for light client ([#8517](https://github.com/paritytech/parity/pull/8517))
+- Remove unused dependency `bigint` ([#8505](https://github.com/paritytech/parity/pull/8505))
+- `duration_ns: u64 -> duration: Duration` ([#8457](https://github.com/paritytech/parity/pull/8457))
+- Return error if RLP size of transaction exceeds the limit ([#8473](https://github.com/paritytech/parity/pull/8473))
+- Remove three old warp boot nodes. ([#8497](https://github.com/paritytech/parity/pull/8497))
+- Update wasmi and pwasm-utils ([#8493](https://github.com/paritytech/parity/pull/8493))
+- Update hardcodedSync for Ethereum, Kovan, and Ropsten ([#8489](https://github.com/paritytech/parity/pull/8489))
+- Fix snap builds ([#8483](https://github.com/paritytech/parity/pull/8483))
+- Bump master to 1.12 ([#8477](https://github.com/paritytech/parity/pull/8477))
+- Don't require write lock when fetching status. ([#8481](https://github.com/paritytech/parity/pull/8481))
+- Use rename_all for RichBlock and RichHeader serialization ([#8471](https://github.com/paritytech/parity/pull/8471))
 
 ## Previous releases
 
-- [CHANGELOG-1.10](docs/CHANGELOG-1.10.md) (_stable_)
+- [CHANGELOG-1.11](docs/CHANGELOG-1.11.md) (_stable_)
+- [CHANGELOG-1.10](docs/CHANGELOG-1.10.md) (EOL: 2018-07-16)
 - [CHANGELOG-1.9](docs/CHANGELOG-1.9.md) (EOL: 2018-05-09)
 - [CHANGELOG-1.8](docs/CHANGELOG-1.8.md) (EOL: 2018-03-22)
 - [CHANGELOG-1.7](docs/CHANGELOG-1.7.md) (EOL: 2018-01-25)

--- a/docs/CHANGELOG-1.10.md
+++ b/docs/CHANGELOG-1.10.md
@@ -1,3 +1,5 @@
+Note: Parity 1.10 reached End-of-Life on 2018-07-16 (EOL).
+
 ## Parity [v1.10.9](https://github.com/paritytech/parity/releases/tag/v1.10.9) (2018-07-07)
 
 Parity 1.10.9 is a bug-fix release to improve performance and stability.

--- a/docs/CHANGELOG-1.11.md
+++ b/docs/CHANGELOG-1.11.md
@@ -1,3 +1,14 @@
+## Parity [v1.11.7](https://github.com/paritytech/parity/releases/tag/v1.11.7) (2018-07-16)
+
+Parity 1.11.7 is a bug-fix release to improve performance and stability and marks the 1.11 release track as `stable`.
+
+The full list of included changes:
+
+- Backports to 1.11.7-stable ([#9093](https://github.com/paritytech/parity/pull/9093))
+  - Parity-version: stabelize 1.11
+  - Parity-version: bump stable to 1.11.7
+  - Don't fetch snapshot chunks at random ([#9088](https://github.com/paritytech/parity/pull/9088))
+
 ## Parity [v1.11.6](https://github.com/paritytech/parity/releases/tag/v1.11.6) (2018-07-09)
 
 Parity 1.11.6 is a bug-fix release to improve performance and stability.

--- a/docs/CHANGELOG-1.11.md
+++ b/docs/CHANGELOG-1.11.md
@@ -1,0 +1,632 @@
+## Parity [v1.11.6](https://github.com/paritytech/parity/releases/tag/v1.11.6) (2018-07-09)
+
+Parity 1.11.6 is a bug-fix release to improve performance and stability.
+
+The full list of included changes:
+
+- Beta: 1.11.6 backports ([#9015](https://github.com/paritytech/parity/pull/9015))
+  - Parity-version: bump beta to 1.11.6
+  - Scripts: remove md5 checksums ([#8884](https://github.com/paritytech/parity/pull/8884))
+  - Add support for --chain tobalaba
+    - Convert indents to tabs :)
+  - Fixes for misbehavior reporting in AuthorityRound ([#8998](https://github.com/paritytech/parity/pull/8998))
+    - Aura: only report after checking for repeated skipped primaries
+    - Aura: refactor duplicate code for getting epoch validator set
+    - Aura: verify_external: report on validator set contract instance
+    - Aura: use correct validator set epoch number when reporting
+    - Aura: use epoch set when verifying blocks
+    - Aura: report skipped primaries when generating seal
+    - Aura: handle immediate transitions
+    - Aura: don't report skipped steps from genesis to first block
+    - Aura: fix reporting test
+    - Aura: refactor duplicate code to handle immediate_transitions
+    - Aura: let reporting fail on verify_block_basic
+    - Aura: add comment about possible failure of reporting
+  - Only return error log for rustls ([#9025](https://github.com/paritytech/parity/pull/9025))
+  - Transaction Pool improvements ([#8470](https://github.com/paritytech/parity/pull/8470))
+    - Don't use ethereum_types in transaction pool.
+    - Hide internal insertion_id.
+    - Fix tests.
+    - Review grumbles.
+  - Improve should_replace on NonceAndGasPrice ([#8980](https://github.com/paritytech/parity/pull/8980))
+    - Additional tests for NonceAndGasPrice::should_replace.
+    - Fix should_replace in the distinct sender case.
+    - Use natural priority ordering to simplify should_replace.
+  - Minimal effective gas price in the queue ([#8934](https://github.com/paritytech/parity/pull/8934))
+    - Minimal effective gas price.
+    - Fix naming, add test
+    - Fix minimal entry score and add test.
+    - Fix worst_transaction.
+    - Remove effective gas price threshold.
+    - Don't leak gas_price decisions out of Scoring.
+  - Never drop local transactions from different senders. ([#9002](https://github.com/paritytech/parity/pull/9002))
+  - Recently rejected cache for transaction queue ([#9005](https://github.com/paritytech/parity/pull/9005))
+    - Store recently rejected transactions.
+    - Don't cache AlreadyImported rejections.
+    - Make the size of transaction verification queue dependent on pool size.
+    - Add a test for recently rejected.
+    - Fix logging for recently rejected.
+    - Make rejection cache smaller.
+    - Obsolete test removed
+    - Obsolete test removed
+    - Construct cache with_capacity.
+  - Optimize pending transactions filter ([#9026](https://github.com/paritytech/parity/pull/9026))
+    - Rpc: return unordered transactions in pending transactions filter
+    - Ethcore: use LruCache for nonce cache
+      - Only clear the nonce cache when a block is retracted
+    - Revert "ethcore: use LruCache for nonce cache"
+      - This reverts commit b382c19.
+    - Use only cached nonces when computing pending hashes.
+    - Give filters their own locks, so that they don't block one another.
+    - Fix pending transaction count if not sealing.
+    - Clear cache only when block is enacted.
+    - Fix RPC tests.
+    - Address review comments.
+  - A last bunch of txqueue performance optimizations ([#9024](https://github.com/paritytech/parity/pull/9024))
+    - Clear cache only when block is enacted.
+    - Add tracing for cull.
+    - Cull split.
+    - Cull after creating pending block.
+    - Add constant, remove sync::read tracing.
+    - Reset debug.
+    - Remove excessive tracing.
+    - Use struct for NonceCache.
+    - Fix build
+    - Remove warnings.
+    - Fix build again.
+  - Miner: add missing macro use for trace_time
+  - Ci: remove md5 merge leftovers
+
+## Parity [v1.11.5](https://github.com/paritytech/parity/releases/tag/v1.11.5) (2018-06-29)
+
+Parity 1.11.5 is a bug-fix release to improve performance and stability.
+
+The full list of included changes:
+
+- Bump beta to 1.11.5 / Backports ([#8955](https://github.com/paritytech/parity/pull/8955))
+  - Parity-version: bump beta to 1.11.5
+  - Update ropsten.json ([#8926](https://github.com/paritytech/parity/pull/8926))
+  - Update hardcoded headers ([#8925](https://github.com/paritytech/parity/pull/8925))
+    - Update kovan.json
+      - Update Kovan to block 7693549
+    - Update foundation.json
+      - Updated to block 5812225
+    - Update ropsten.json
+      - Update to 3465217
+  - Scripts: minor improvements ([#8930](https://github.com/paritytech/parity/pull/8930))
+    - CI: enable 'latest' docker tag on master pipeline
+    - CI: mark both beta and stable as stable snap.
+    - CI: sign all windows binaries
+  - Scripts: fix docker build tag on latest using master ([#8952](https://github.com/paritytech/parity/pull/8952))
+  - Rpc: cap gas limit of local calls ([#8943](https://github.com/paritytech/parity/pull/8943))
+  - Snap: downgrade rust to revision 1.26.2, ref snapcraft/+bug/1778530 ([#8984](https://github.com/paritytech/parity/pull/8984))
+    - Snap: downgrade rust to revision 1.26.2, ref snapcraft/+bug/1778530
+    - Snap: use plugin rust
+  - Fix deadlock in blockchain. ([#8977](https://github.com/paritytech/parity/pull/8977))
+  - Remove js-glue from workspace
+    - This fixes test error on Rust 1.27 but also prevents js-glue from building itself.
+    - Builtin dapp users can still use js-glue from crates.io.
+  - Fix Android build on beta ([#9003](https://github.com/paritytech/parity/pull/9003))
+
+## Parity [v1.11.4](https://github.com/paritytech/parity/releases/tag/v1.11.4) (2018-06-20)
+
+Parity 1.11.4 is a bug-fix release to improve performance and stability.
+
+The full list of included changes:
+
+- Backports ([#8916](https://github.com/paritytech/parity/pull/8916))
+  - `Duration_ns: u64 -> duration: Duration` ([#8457](https://github.com/paritytech/parity/pull/8457))
+    - Duration_ns: u64 -> duration: Duration
+    - Format on millis {:.2} -> {}
+  - Keep all enacted blocks notify in order ([#8524](https://github.com/paritytech/parity/pull/8524))
+    - Keep all enacted blocks notify in order
+    - Collect is unnecessary
+    - Update ChainNotify to use ChainRouteType
+    - Fix all ethcore fn defs
+    - Wrap the type within ChainRoute
+    - Fix private-tx and sync api
+    - Fix secret_store API
+    - Fix updater API
+    - Fix rpc api
+    - Fix informant api
+    - Eagerly cache enacted/retracted and remove contain_enacted/retracted
+    - Fix indent
+    - Tests: should use full expr form for struct constructor
+    - Use into_enacted_retracted to further avoid copy
+    - Typo: not a function
+    - Rpc/tests: ChainRoute -> ChainRoute::new
+  - Handle removed logs in filter changes and add geth compatibility field ([#8796](https://github.com/paritytech/parity/pull/8796))
+    - Add removed geth compatibility field in log
+    - Fix mocked tests
+    - Add field block hash in PollFilter
+    - Store last block hash info for log filters
+    - Implement canon route
+    - Use canon logs for fetching reorg logs
+    - Make sure removed flag is set
+    - Address grumbles
+  - Fixed AuthorityRound deadlock on shutdown, closes [#8088](https://github.com/paritytech/parity/issues/8088) ([#8803](https://github.com/paritytech/parity/pull/8803))
+  - Ci: Fix docker tags ([#8822](https://github.com/paritytech/parity/pull/8822))
+    - Scripts: enable docker builds for beta and stable
+    - Scripts: docker latest should be beta not master
+    - Scripts: docker latest is master
+  - Ethcore: fix ancient block error msg handling ([#8832](https://github.com/paritytech/parity/pull/8832))
+  - Disable parallel verification and skip verifiying already imported txs. ([#8834](https://github.com/paritytech/parity/pull/8834))
+    - Reject transactions that are already in pool without verifying them.
+    - Avoid verifying already imported transactions.
+  - Fix concurrent access to signer queue ([#8854](https://github.com/paritytech/parity/pull/8854))
+    - Fix concurrent access to signer queue
+    - Put request back to the queue if confirmation failed
+    - Typo: fix docs and rename functions to be more specific
+    - Change trace info "Transaction" -> "Request"
+  - Don't allocate in expect_valid_rlp unless necessary ([#8867](https://github.com/paritytech/parity/pull/8867))
+    - Don't allocate via format! in case there's no error
+    - Fix test?
+  - Fixed ipc leak, closes [#8774](https://github.com/paritytech/parity/issues/8774) ([#8876](https://github.com/paritytech/parity/pull/8876))
+  - Add new ovh bootnodes and fix port for foundation bootnode 3.2 ([#8886](https://github.com/paritytech/parity/pull/8886))
+    - Add new ovh bootnodes and fix port for foundation bootnode 3.2
+    - Remove old bootnodes.
+    - Remove duplicate 1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082
+  - Block 0 is valid in queries ([#8891](https://github.com/paritytech/parity/pull/8891))
+  - Add ETC Cooperative-run load balanced parity node ([#8892](https://github.com/paritytech/parity/pull/8892))
+  - Minor fix in chain supplier and light provider ([#8906](https://github.com/paritytech/parity/pull/8906))
+    - Fix chain supplier increment
+    - Fix light provider block_headers
+  - Check whether we need resealing in miner and unwrap has_account in account_provider ([#8853](https://github.com/paritytech/parity/pull/8853))
+    - Remove unused Result wrap in has_account
+    - Check whether we need to reseal for external transactions
+    - Fix reference to has_account interface
+    - Typo: missing )
+    - Refactor duplicates to prepare_and_update_sealing
+    - Fix build
+  - Allow disabling local-by-default for transactions with new config entry ([#8882](https://github.com/paritytech/parity/pull/8882))
+    - Add tx_queue_allow_unknown_local config option
+    - Refactor flag name + don't change import_own_tx behaviour
+    - Add fn to TestMinerService
+    - Avoid race condition from trusted sources
+- Parity-version: beta release 1.11.4 ([#8856](https://github.com/paritytech/parity/pull/8856))
+  - Cherry-pick network-specific release flag ([#8821](https://github.com/paritytech/parity/pull/8821))
+  - Parity-version: bump beta to 1.11.4
+  - Parity-version: remove merge leftovers
+
+## Parity [v1.11.3](https://github.com/paritytech/parity/releases/tag/v1.11.3) (2018-06-06)
+
+Parity 1.11.3 is a security-relevant release. Please upgrade your nodes as soon as possible to [v1.10.6](https://github.com/paritytech/parity/releases/tag/v1.10.6) or [v1.11.3](https://github.com/paritytech/parity/releases/tag/v1.11.3).
+
+The full list of included changes:
+
+- Parity-version: bump beta to 1.11.3 ([#8806](https://github.com/paritytech/parity/pull/8806))
+  - Parity-version: bump beta to 1.11.3
+  - Disallow unsigned transactions in case EIP-86 is disabled ([#8802](https://github.com/paritytech/parity/pull/8802))
+  - Fix ancient blocks queue deadlock ([#8751](https://github.com/paritytech/parity/pull/8751))
+- Update shell32-sys to fix windows build ([#8792](https://github.com/paritytech/parity/pull/8792))
+- Backports ([#8785](https://github.com/paritytech/parity/pull/8785))
+  - Fix light sync with initial validator-set contract ([#8528](https://github.com/paritytech/parity/pull/8528))
+    - Fix #8468
+    - Use U256::max_value() instead
+    - Also change initial transaction gas
+  - Resumable warp-sync / Seed downloaded snapshots ([#8544](https://github.com/paritytech/parity/pull/8544))
+    - Start dividing sync chain : first supplier method
+    - WIP - updated chain sync supplier
+    - Finish refactoring the Chain Sync Supplier
+    - Create Chain Sync Requester
+    - Add Propagator for Chain Sync
+    - Add the Chain Sync Handler
+    - Move tests from mod -> handler
+    - Move tests to propagator
+    - Refactor SyncRequester arguments
+    - Refactoring peer fork header handler
+    - Fix wrong highest block number in snapshot sync
+    - Small refactor...
+    - Resume warp-sync downloaded chunks
+    - Refactoring the previous chunks import
+    - Address PR grumbles
+    - Fix not seeding current snapshot
+    - Update SnapshotService readiness check
+    - Early abort importing previous chunks
+    - Update Gitlab CI config
+    - SyncState back to Waiting when Manifest peers disconnect
+    - Revert GitLab CI changes
+    - Refactor resuming snapshots
+    - Revert "Refactor resuming snapshots"
+    - Update informant log
+    - Refactor resuming snapshots
+    - Update informant message : show chunks done
+  - Don't open Browser post-install on Mac ([#8641](https://github.com/paritytech/parity/pull/8641))
+  - Fix not downloading old blocks ([#8642](https://github.com/paritytech/parity/pull/8642))
+  - Fix PoW blockchains sealing notifications in chain_new_blocks ([#8656](https://github.com/paritytech/parity/pull/8656))
+  - Shutdown the Snapshot Service early ([#8658](https://github.com/paritytech/parity/pull/8658))
+    - Shutdown the Snapshot Service when shutting down the runner
+    - Rename `service` to `client_service`
+    - Fix tests
+  - Fix cli signer ([#8682](https://github.com/paritytech/parity/pull/8682))
+    - Update ethereum-types so `{:#x}` applies 0x prefix
+  - Set the request index to that of the current request ([#8683](https://github.com/paritytech/parity/pull/8683))
+    - Set the request index to that of the current request
+  - Network-devp2p: handle UselessPeer disconnect ([#8686](https://github.com/paritytech/parity/pull/8686))
+  - Fix local transactions policy. ([#8691](https://github.com/paritytech/parity/pull/8691))
+  - CI: Fixes for Android Pipeline ([#8745](https://github.com/paritytech/parity/pull/8745))
+    - Ci: Remove check for shared libraries in gitlab script
+    - Ci: allow android arm build to fail
+  - Custom Error Messages on ENFILE and EMFILE IO Errors ([#8744](https://github.com/paritytech/parity/pull/8744))
+    - Custom Error Messages on ENFILE and EMFILE IO Errors
+    - Use assert-matches for more readable tests
+    - Fix Wording and consistency
+  - Ethcore-sync: fix connection to peers behind chain fork block ([#8710](https://github.com/paritytech/parity/pull/8710))
+- Parity-version: bump beta to 1.11.2 ([#8750](https://github.com/paritytech/parity/pull/8750))
+  - Parity-version: bump beta to 1.11.2
+  - Parity-version: unset critical flag
+
+## Parity [v1.11.1](https://github.com/paritytech/parity/releases/tag/v1.11.1) (2018-05-15)
+
+This is the Parity 1.11.1-beta release! Hurray!
+
+Notable changes in reversed alphabetical order:
+
+- TOOLING: **Whisper CLI** [#8201](https://github.com/paritytech/parity/pull/8201)
+  - `whisper-cli` is a standalone tool to communicate with the Whisper protocol.
+  - It provides functionality to specify `whisper-pool-size`, `port` and `address` to use.
+  - All whisper RPC APIs are enabled and can be directly accessed.
+- JSON-RPC API: **Return error in case eth_call returns VM errors** [#8448](https://github.com/paritytech/parity/pull/8448)
+  - This changes the behaviors of `eth_call` to respect VM errors if any.
+  - In case of `REVERT`, it will also return the reverted return data in hex format.
+- ENGINES: **Block Reward Contract** [#8419](https://github.com/paritytech/parity/pull/8419)
+  - The _AuRa_ PoA engine has now support for having a contract to calculate the block rewards.
+  - The engine passes a list of benefactors and reward types to the contract which then returns a list of addresses and respective rewards.
+- CORE: **Private Transactions** [#6422](https://github.com/paritytech/parity/pull/6422)
+  - Parity now provides a private transactions system.
+  - Please, check out our wiki to get an [overview and setup instructions](https://wiki.parity.io/Private-Transactions.html).
+- CORE: **New Transaction Queue implementation** [#8074](https://github.com/paritytech/parity/pull/8074)
+  - Verification is now done in parallel.
+  - Previous queue had `O(1)` time to get pending set, but `O(n^2)` insertion time. And obviously insertion/removal happens much more often than retrieving the pending set (only for propagation and pending block building) Currently we have `O(n * log(senders))` pending set time (with cache) and `O(tx_per_sender)` (usually within `log(tx_per_sender)`) insertion time.
+  - `Scoring` and `Readiness` are separated from the pool, so it's easier to customize them or introduce different definitions (for instance for [EIP-859](https://github.com/ethereum/EIPs/issues/859) or private transactions, etc).
+  - Banning removed, soft-penalization introduced instead: if transaction exceeds the limit other transactions from that sender get lower priority.
+  - There is no explicit distinction between current and future transactions in the pool - `Readiness` determines that. Because of this we additionally remove `future` transactions that occupy the pool for long time.
+- CONFIGURATION: **Warp-only sync with --warp-barrier [block-number] flag.** [#8228](https://github.com/paritytech/parity/pull/8228)
+  - Enables warp-only sync in case `--warp-barrier [block-number]` is provided.
+  - This avoids clients to warp to outdated snapshots that are too far away from the best block.
+  - This avoids clients to fall back to normal sync if there are no recent snapshots available currently.
+- CONFIGURATION: **Disable UI by default.** [#8105](https://github.com/paritytech/parity/pull/8105)
+  - The user interface is now disabled by default. It still can be activated with the `--force-ui` flag.
+  - To get the stand-alone Parity UI, please check the dedicated [releases page](https://github.com/parity-js/shell/releases).
+- CONFIGURATION: **Auto-updater improvements** [#8078](https://github.com/paritytech/parity/pull/8078)
+  - Added `--auto-update-delay` to randomly delay updates by `n` blocks. This takes into account the number of the block of the update release (old updates aren't delayed).
+  - Added `--auto-update-check-frequency` to define the periodicity of auto-update checks in number of blocks.
+  - This is an important improvement to ensure the network does not update all clients at the same time.
+- CHAIN SPECS: **Enable WebAssembly and Byzantium for Ellaism** [#8520](https://github.com/paritytech/parity/pull/8520)
+  - This activates the Ellaism Byzantium hardfork ([2018-0004-byzantium](https://github.com/ellaism/specs/blob/master/specs/2018-0004-byzantium.md)) at block `2_000_000`.
+  - This enables the Wasm VM on Ellaism ([2018-0003-wasm-hardfork](https://github.com/ellaism/specs/blob/master/specs/2018-0003-wasm-hardfork.md)) at block `2_000_000`.
+  - Please, upgrade your clients if you run an Ellaism configuration.
+- CHAIN SPECS: **Dev chain - increase gasLimit to 8_000_000** [#8362](https://github.com/paritytech/parity/pull/8362)
+  - This increases the default block gas limit on development chains to `8_000_000`.
+  - Please note, this makes previous dev chain configurations incompatible.
+- CHAIN SPECS: **Add MCIP-6 Byzyantium transition to Musicoin spec** [#7841](https://github.com/paritytech/parity/pull/7841)
+  - This activates the Musicoin Byzantium hardfork ([MCIP-6](https://github.com/Musicoin/MCIPs/blob/master/MCIPS/mcip-6.md)) at block `2_222_222`.
+  - Please, upgrade your clients if you run a Musicoin configuration.
+
+The full list of included changes:
+
+- Backports ([#8624](https://github.com/paritytech/parity/pull/8624))
+  - Trace precompiled contracts when the transfer value is not zero ([#8486](https://github.com/paritytech/parity/pull/8486))
+    - Trace precompiled contracts when the transfer value is not zero
+    - Add tests for precompiled CALL tracing
+    - Use byzantium test machine for the new test
+    - Add notes in comments on why we don't trace all precompiles
+    - Use is_transferred instead of transferred
+  - Return error if RLP size of transaction exceeds the limit ([#8473](https://github.com/paritytech/parity/pull/8473))
+    - Return error if RLP size of transaction exceeds the limit
+    - Review comments fixed
+    - RLP check moved to verifier, corresponding pool test added
+  - Don't block sync when importing old blocks ([#8530](https://github.com/paritytech/parity/pull/8530))
+    - Alter IO queueing.
+    - Don't require IoMessages to be Clone
+    - Ancient blocks imported via IoChannel.
+    - Get rid of private transactions io message.
+    - Get rid of deadlock and fix disconnected handler.
+    - Revert to old disconnect condition.
+    - Fix tests.
+    - Fix deadlock.
+  - Refactoring `ethcore-sync` - Fixing warp-sync barrier ([#8543](https://github.com/paritytech/parity/pull/8543))
+    - Start dividing sync chain : first supplier method
+    - WIP - updated chain sync supplier
+    - Finish refactoring the Chain Sync Supplier
+    - Create Chain Sync Requester
+    - Add Propagator for Chain Sync
+    - Add the Chain Sync Handler
+    - Move tests from mod -> handler
+    - Move tests to propagator
+    - Refactor SyncRequester arguments
+    - Refactoring peer fork header handler
+    - Fix wrong highest block number in snapshot sync
+    - Small refactor...
+    - Address PR grumbles
+    - Retry failed CI job
+    - Fix tests
+    - PR Grumbles
+  - Handle socket address parsing errors ([#8545](https://github.com/paritytech/parity/pull/8545))
+  - Fix packet count when talking with PAR2 peers ([#8555](https://github.com/paritytech/parity/pull/8555))
+    - Support diferent packet counts in different protocol versions.
+    - Fix light timeouts and eclipse protection.
+    - Fix devp2p tests.
+    - Fix whisper-cli compilation.
+    - Fix compilation.
+    - Fix ethcore-sync tests.
+    - Revert "Fix light timeouts and eclipse protection."
+    - Increase timeouts.
+  - Add whisper CLI to the pipelines ([#8578](https://github.com/paritytech/parity/pull/8578))
+    - Add whisper CLI to the pipelines
+    - Address todo, ref [#8579](https://github.com/paritytech/parity/pull/8579)
+  - Rename `whisper-cli binary` to `whisper` ([#8579](https://github.com/paritytech/parity/pull/8579))
+    - Rename whisper-cli binary to whisper
+    - Fix tests
+  - Remove manually added text to the errors ([#8595](https://github.com/paritytech/parity/pull/8595))
+  - Fix account list double 0x display ([#8596](https://github.com/paritytech/parity/pull/8596))
+    - Remove unused self import
+    - Fix account list double 0x display
+  - Fix BlockReward contract "arithmetic operation overflow" ([#8611](https://github.com/paritytech/parity/pull/8611))
+    - Fix BlockReward contract "arithmetic operation overflow"
+    - Add docs on how execute_as_system works
+    - Fix typo
+  - Rlp decode returns Result ([#8527](https://github.com/paritytech/parity/pull/8527))
+  - Remove expect ([#8536](https://github.com/paritytech/parity/pull/8536))
+    - Remove expect and propagate rlp::DecoderErrors as TrieErrors
+  - Decoding headers can fail ([#8570](https://github.com/paritytech/parity/pull/8570))
+    - Rlp::decode returns Result
+    - Fix journaldb to handle rlp::decode Result
+    - Fix ethcore to work with rlp::decode returning Result
+    - Light client handles rlp::decode returning Result
+    - Fix tests in rlp_derive
+    - Fix tests
+    - Cleanup
+    - Cleanup
+    - Allow panic rather than breaking out of iterator
+    - Let decoding failures when reading from disk blow up
+    - Syntax
+    - Fix the trivial grumbles
+    - Fix failing tests
+    - Make Account::from_rlp return Result
+    - Syntx, sigh
+    - Temp-fix for decoding failures
+    - Header::decode returns Result
+    - Do not continue reading from the DB when a value could not be read
+    - Fix tests
+    - Handle header decoding in light_sync
+    - Handling header decoding errors
+    - Let the DecodeError bubble up unchanged
+    - Remove redundant error conversion
+  - Fix compiler warning ([#8590](https://github.com/paritytech/parity/pull/8590))
+  - Attempt to fix intermittent test failures ([#8584](https://github.com/paritytech/parity/pull/8584))
+  - Block_header can fail so return Result ([#8581](https://github.com/paritytech/parity/pull/8581))
+    - Block_header can fail so return Result
+    - Restore previous return type based on feedback
+    - Fix failing doc tests running on non-code
+  - Block::decode() returns Result ([#8586](https://github.com/paritytech/parity/pull/8586))
+  - Gitlab test script fixes ([#8573](https://github.com/paritytech/parity/pull/8573))
+    - Exclude /docs from modified files.
+    - Ensure all references in the working tree are available
+    - Remove duplicated line from test script
+- Bump beta to 1.11.1 ([#8627](https://github.com/paritytech/parity/pull/8627))
+
+## Parity [v1.11.0](https://github.com/paritytech/parity/releases/tag/v1.11.0) (2018-05-09)
+
+This is the Parity 1.11.0-beta release! ~~Hurray!~~ This release has been pulled due to peering issues, please use 1.11.1-beta.
+
+The full list of included changes:
+
+- Backports ([#8558](https://github.com/paritytech/parity/pull/8558))
+  - Fetching logs by hash in blockchain database ([#8463](https://github.com/paritytech/parity/pull/8463))
+    - Fetch logs by hash in blockchain database
+    - Fix tests
+    - Add unit test for branch block logs fetching
+    - Add docs that blocks must already be sorted
+    - Handle branch block cases properly
+    - typo: empty -> is_empty
+    - Remove return_empty_if_none by using a closure
+    - Use BTreeSet to avoid sorting again
+    - Move is_canon to BlockChain
+    - typo: pass value by reference
+    - Use loop and wrap inside blocks to simplify the code
+    - typo: missed a comment
+  - Pass on storage keys tracing to handle the case when it is not modified ([#8491](https://github.com/paritytech/parity/pull/8491))
+    - Pass on storage keys even if it is not modified
+    - typo: account and storage query
+    - Fix tests
+    - Use state query directly because of suicided accounts
+    - Fix a RefCell borrow issue
+    - Add tests for unmodified storage trace
+    - Address grumbles
+    - typo: remove unwanted empty line
+    - ensure_cached compiles with the original signature
+  - Update wasmi and pwasm-utils ([#8493](https://github.com/paritytech/parity/pull/8493))
+    - Update wasmi to 0.2
+    - Update pwasm-utils to 0.1.5
+  - Show imported messages for light client ([#8517](https://github.com/paritytech/parity/pull/8517))
+  - Enable WebAssembly and Byzantium for Ellaism ([#8520](https://github.com/paritytech/parity/pull/8520))
+    - Enable WebAssembly and Byzantium for Ellaism
+    - Fix indentation
+    - Remove empty lines
+  - Don't panic in import_block if invalid rlp ([#8522](https://github.com/paritytech/parity/pull/8522))
+    - Don't panic in import_block if invalid rlp
+    - Remove redundant type annotation
+    - Replace RLP header view usage with safe decoding
+  - Node table sorting according to last contact data ([#8541](https://github.com/paritytech/parity/pull/8541))
+    - network-devp2p: sort nodes in node table using last contact data
+    - network-devp2p: rename node contact types in node table json output
+    - network-devp2p: fix node table tests
+    - network-devp2p: note node failure when failed to establish connection
+    - network-devp2p: handle UselessPeer error
+    - network-devp2p: note failure when marking node as useless
+- Betalize 1.11 :) ([#8475](https://github.com/paritytech/parity/pull/8475))
+  - Betalize 1.11 :)
+  - Update Gitlab scripts
+  - Use master as gitlab latest
+  - Fix snap builds ([#8483](https://github.com/paritytech/parity/pull/8483))
+  - Update hardcodedSync for Ethereum, Kovan, and Ropsten ([#8489](https://github.com/paritytech/parity/pull/8489))
+- Fix typos in vm description comment ([#8446](https://github.com/paritytech/parity/pull/8446))
+- Add changelog for 1.9.7 and 1.10.2 ([#8460](https://github.com/paritytech/parity/pull/8460))
+- Fix docker build ([#8462](https://github.com/paritytech/parity/pull/8462))
+- Parityshell::open `Return result` ([#8377](https://github.com/paritytech/parity/pull/8377))
+- Return error in case eth_call returns VM errors ([#8448](https://github.com/paritytech/parity/pull/8448))
+- Update wasmi ([#8452](https://github.com/paritytech/parity/pull/8452))
+- Allow 32 bit pipelines to fail ([#8454](https://github.com/paritytech/parity/pull/8454))
+- Update Cargo hidapi-rs dependency ([#8447](https://github.com/paritytech/parity/pull/8447))
+- Private transactions processing error handling ([#8431](https://github.com/paritytech/parity/pull/8431))
+- Improve VM executor stack size estimation rules ([#8439](https://github.com/paritytech/parity/pull/8439))
+- Block reward contract ([#8419](https://github.com/paritytech/parity/pull/8419))
+- Permission fix ([#8441](https://github.com/paritytech/parity/pull/8441))
+- Use forked app_dirs crate for reverted Windows dir behavior ([#8438](https://github.com/paritytech/parity/pull/8438))
+- Remove From::from. ([#8390](https://github.com/paritytech/parity/pull/8390))
+- Move ethcore::Error to error_chain ([#8386](https://github.com/paritytech/parity/pull/8386))
+- Changelogs for 1.9.6 and 1.10.1 ([#8411](https://github.com/paritytech/parity/pull/8411))
+- Fix receipts stripping. ([#8414](https://github.com/paritytech/parity/pull/8414))
+- Typo, docs parity_chainId: empty string -> None ([#8434](https://github.com/paritytech/parity/pull/8434))
+- Update zip to 0.3 ([#8381](https://github.com/paritytech/parity/pull/8381))
+- Fix TODO comments ([#8413](https://github.com/paritytech/parity/pull/8413))
+- Replace legacy Rlp with UntrustedRlp and use in ethcore rlp views ([#8316](https://github.com/paritytech/parity/pull/8316))
+- Tokio-core v0.1.16 -> v0.1.17 ([#8408](https://github.com/paritytech/parity/pull/8408))
+- More code refactoring to integrate Duration ([#8322](https://github.com/paritytech/parity/pull/8322))
+- Remove Tendermint extra_info due to seal inconsistencies ([#8367](https://github.com/paritytech/parity/pull/8367))
+- Use tokio::spawn in secret_store listener and fix Uri ([#8373](https://github.com/paritytech/parity/pull/8373))
+- Unify and limit rocksdb dependency places ([#8371](https://github.com/paritytech/parity/pull/8371))
+- Clarify that windows need perl and yasm ([#8402](https://github.com/paritytech/parity/pull/8402))
+- New Transaction Queue implementation ([#8074](https://github.com/paritytech/parity/pull/8074))
+- Some tweaks to main.rs for parity as a library ([#8370](https://github.com/paritytech/parity/pull/8370))
+- Handle queue import errors a bit more gracefully ([#8385](https://github.com/paritytech/parity/pull/8385))
+- Ci: fix change detection in master builds ([#8382](https://github.com/paritytech/parity/pull/8382))
+- Fix config test by adding no-hardcodec-sync ([#8380](https://github.com/paritytech/parity/pull/8380))
+- Fixed unsafe shell call on windows ([#8372](https://github.com/paritytech/parity/pull/8372))
+- Parity uses winapi 0.3.4 ([#8366](https://github.com/paritytech/parity/pull/8366))
+- No hardcoded client name ([#8368](https://github.com/paritytech/parity/pull/8368))
+- Add `util/mem` to zero out memory on drop. ([#8356](https://github.com/paritytech/parity/pull/8356))
+- Use atty instead of isatty ([#8365](https://github.com/paritytech/parity/pull/8365))
+- Increase gasLimit to 8'000'000 ([#8362](https://github.com/paritytech/parity/pull/8362))
+- Util `fake-fetch` ([#8363](https://github.com/paritytech/parity/pull/8363))
+- Bump snappy and ring, use single rayon version, closes [#8296](https://github.com/paritytech/parity/issues/8296) ([#8364](https://github.com/paritytech/parity/pull/8364))
+- Use async hyper server in secret_store and upgrade igd ([#8359](https://github.com/paritytech/parity/pull/8359))
+- Enable UI by default, but only display deprecation notice ([#8262](https://github.com/paritytech/parity/pull/8262))
+- Ethcrypto renamed to ethcore-crypto and moved to ethcore dir ([#8340](https://github.com/paritytech/parity/pull/8340))
+- Use hyper 0.11 in ethcore-miner and improvements in parity-reactor ([#8335](https://github.com/paritytech/parity/pull/8335))
+- Ethcore-sync ([#8347](https://github.com/paritytech/parity/pull/8347))
+- Rpc, eth_filter: return error if the filter id does not exist ([#8341](https://github.com/paritytech/parity/pull/8341))
+- Ethcore-stratum crate moved to ethcore directory ([#8338](https://github.com/paritytech/parity/pull/8338))
+- Secretstore: get rid of engine.signer dependency ([#8173](https://github.com/paritytech/parity/pull/8173))
+- Whisper cli ([#8201](https://github.com/paritytech/parity/pull/8201))
+- Replace_home for password_files, reserved_peers and log_file ([#8324](https://github.com/paritytech/parity/pull/8324))
+- Add Ethereum Social support ([#8325](https://github.com/paritytech/parity/pull/8325))
+- Private transactions integration pr ([#6422](https://github.com/paritytech/parity/pull/6422))
+- Decouple rocksdb dependency from ethcore ([#8320](https://github.com/paritytech/parity/pull/8320))
+- Remove the clone operation of code_cache ([#8334](https://github.com/paritytech/parity/pull/8334))
+- Fix the JSONRPC API not running with the light client ([#8326](https://github.com/paritytech/parity/pull/8326))
+- Read registry_address from block with REQUEST_CONFIRMATIONS_REQUIRED ([#8309](https://github.com/paritytech/parity/pull/8309))
+- Tweaks and add a Dockerfile for Android ([#8036](https://github.com/paritytech/parity/pull/8036))
+- Use associated type M::Error instead of Error ([#8308](https://github.com/paritytech/parity/pull/8308))
+- Remove InvalidParentHash in favor of assert! ([#8300](https://github.com/paritytech/parity/pull/8300))
+- Bump proc macro deps ([#8310](https://github.com/paritytech/parity/pull/8310))
+- Decouple timestamp open-block-assignment/verification to Engine ([#8305](https://github.com/paritytech/parity/pull/8305))
+- Validate if gas limit is not zero ([#8307](https://github.com/paritytech/parity/pull/8307))
+- Implement Easthub chain spec ([#8295](https://github.com/paritytech/parity/pull/8295))
+- Update some dependencies ([#8285](https://github.com/paritytech/parity/pull/8285))
+- Ethcore now uses Rayon 1.0 as a dependency ([#8296](https://github.com/paritytech/parity/pull/8296)) ([#8304](https://github.com/paritytech/parity/pull/8304))
+- Upgrader `remove raw unwrap` and bump semver ([#8251](https://github.com/paritytech/parity/pull/8251))
+- Cleaner binary shutdown system ([#8284](https://github.com/paritytech/parity/pull/8284))
+- Ethcore now uses rayon to 0.9 as a dependency ([#8296](https://github.com/paritytech/parity/pull/8296)) ([#8302](https://github.com/paritytech/parity/pull/8302))
+- Include suicided accounts in state diff ([#8297](https://github.com/paritytech/parity/pull/8297))
+- Remove evmjit ([#8229](https://github.com/paritytech/parity/pull/8229))
+- Build: fix updater rand dependency in Cargo.lock ([#8298](https://github.com/paritytech/parity/pull/8298))
+- Honor --max-peers if --min-peers is not specified ([#8087](https://github.com/paritytech/parity/pull/8087))
+- Auto-updater improvements ([#8078](https://github.com/paritytech/parity/pull/8078))
+- Dapps-fetcher: calculate keccak in-flight while reading the response ([#8294](https://github.com/paritytech/parity/pull/8294))
+- Cleanup Ellaism bootnodes ([#8276](https://github.com/paritytech/parity/pull/8276))
+- Allow unsafe js eval on Parity Wallet. ([#8204](https://github.com/paritytech/parity/pull/8204))
+- Remove RefCell from Header ([#8227](https://github.com/paritytech/parity/pull/8227))
+- Typo fix: todo with no content ([#8292](https://github.com/paritytech/parity/pull/8292))
+- Revert "ci: disable link-dead-code in coverage build ([#8118](https://github.com/paritytech/parity/pull/8118))" ([#8287](https://github.com/paritytech/parity/pull/8287))
+- Bump ethabi & ethereum-types. ([#8258](https://github.com/paritytech/parity/pull/8258))
+- Allow customization of max WS connections. ([#8257](https://github.com/paritytech/parity/pull/8257))
+- Supress TemporaryInvalid verification failures. ([#8256](https://github.com/paritytech/parity/pull/8256))
+- Return null number for pending block in eth_getBlockByNumber ([#8281](https://github.com/paritytech/parity/pull/8281))
+- Use constant durations ([#8278](https://github.com/paritytech/parity/pull/8278))
+- Typo fix: Mode doc - RLP should be client ([#8283](https://github.com/paritytech/parity/pull/8283))
+- Eth_uninstallfilter should return false for non-existent filter ([#8280](https://github.com/paritytech/parity/pull/8280))
+- Update `app_dirs` to 1.2.1 ([#8268](https://github.com/paritytech/parity/pull/8268))
+- Add missing license header for runtime.rs ([#8252](https://github.com/paritytech/parity/pull/8252))
+- Warp-only sync with warp-barrier [blocknumber] flag. ([#8228](https://github.com/paritytech/parity/pull/8228))
+- Replace all Rlp usages with UntrustedRlp except for ethcore views ([#8233](https://github.com/paritytech/parity/pull/8233))
+- Add test for ethstore-cli, fixes [#8027](https://github.com/paritytech/parity/issues/8027) ([#8187](https://github.com/paritytech/parity/pull/8187))
+- Update musicoin spec in line with gmc v2.6.2 ([#8242](https://github.com/paritytech/parity/pull/8242))
+- Fixed ethcore tx_filter ([#8200](https://github.com/paritytech/parity/pull/8200))
+- Update CLI help for jsonrpc-apis, ws-apis and ipc-apis ([#8234](https://github.com/paritytech/parity/pull/8234))
+- Remove network stats ([#8225](https://github.com/paritytech/parity/pull/8225))
+- Node-filter does not use ChainNotify ([#8231](https://github.com/paritytech/parity/pull/8231))
+- Implement hardcoded sync in the light client ([#8075](https://github.com/paritytech/parity/pull/8075))
+- Update some of the dependencies for WASM ([#8223](https://github.com/paritytech/parity/pull/8223))
+- Bump wasmi version ([#8209](https://github.com/paritytech/parity/pull/8209))
+- Updated jsonrpc to point to the 1.11 branch ([#8180](https://github.com/paritytech/parity/pull/8180))
+- Change name Wallet -> UI ([#8164](https://github.com/paritytech/parity/pull/8164))
+- Introduce Parity UI ([#8202](https://github.com/paritytech/parity/pull/8202))
+- Update Changelogs ([#8175](https://github.com/paritytech/parity/pull/8175))
+- Returns number of topcis to take fr.. ([#8199](https://github.com/paritytech/parity/pull/8199))
+- Make docopt usage non-const ([#8189](https://github.com/paritytech/parity/pull/8189))
+- Avoid allocations when computing triehash. ([#8176](https://github.com/paritytech/parity/pull/8176))
+- Handle rlp decoding Result in patricia trie ([#8166](https://github.com/paritytech/parity/pull/8166))
+- Bump wasm libs ([#8171](https://github.com/paritytech/parity/pull/8171))
+- Re-enable signer, even with no UI. ([#8167](https://github.com/paritytech/parity/pull/8167))
+- Update daemonize ([#8165](https://github.com/paritytech/parity/pull/8165))
+- Some tiny modifications. ([#8163](https://github.com/paritytech/parity/pull/8163))
+- Secretstore: store key author address in db ([#7887](https://github.com/paritytech/parity/pull/7887))
+- Rename DatabaseValueView::new to from_rlp ([#8159](https://github.com/paritytech/parity/pull/8159))
+- Dapps: update parity-ui dependencies ([#8160](https://github.com/paritytech/parity/pull/8160))
+- Disable UI by default. ([#8105](https://github.com/paritytech/parity/pull/8105))
+- Fix wasmi x32 builds ([#8155](https://github.com/paritytech/parity/pull/8155))
+- Postpone Kovan hard fork ([#8137](https://github.com/paritytech/parity/pull/8137))
+- Secretstore: ability to identify requester via Public/Address ([#7886](https://github.com/paritytech/parity/pull/7886))
+- Optional dependency on secp256k1 for ethcrypto ([#8109](https://github.com/paritytech/parity/pull/8109))
+- Network: init discovery using healthy nodes ([#8061](https://github.com/paritytech/parity/pull/8061))
+- Check one step deeper if we're on release track branches ([#8134](https://github.com/paritytech/parity/pull/8134))
+- Explicitly mention pruning_history uses RAM ([#8130](https://github.com/paritytech/parity/pull/8130))
+- Remove `ethcrypto::{en,de}crypt_single_message`. ([#8126](https://github.com/paritytech/parity/pull/8126))
+- Fix typo ([#8124](https://github.com/paritytech/parity/pull/8124))
+- Secret_store: use `ecies::encrypt`/`ecies::decrypt`. ([#8125](https://github.com/paritytech/parity/pull/8125))
+- Fix comment for fn gas() in wasm/runtime ([#8122](https://github.com/paritytech/parity/pull/8122))
+- Structured rlp encoding in journaldb ([#8047](https://github.com/paritytech/parity/pull/8047))
+- Ci: disable link-dead-code in coverage build ([#8118](https://github.com/paritytech/parity/pull/8118))
+- Fix trace filter returning returning unrelated reward calls, closes [#8070](https://github.com/paritytech/parity/issues/8070) ([#8098](https://github.com/paritytech/parity/pull/8098))
+- Const time comparison ([#8113](https://github.com/paritytech/parity/pull/8113))
+- Replace reqwest with hyper ([#8099](https://github.com/paritytech/parity/pull/8099))
+- More dos protection ([#8104](https://github.com/paritytech/parity/pull/8104))
+- Remove the time dependency where possible ([#8100](https://github.com/paritytech/parity/pull/8100))
+- Fix comment for gas extern in Wasm runtime ([#8101](https://github.com/paritytech/parity/pull/8101))
+- Replace std::env::temp_dir with tempdir in tests ([#8103](https://github.com/paritytech/parity/pull/8103))
+- Fix Cargo.lock not parsable ([#8102](https://github.com/paritytech/parity/pull/8102))
+- Additional data in EVMTestClient ([#7964](https://github.com/paritytech/parity/pull/7964))
+- Update serde, serde-derive, ethabi-derive, syn, quote and rlp_derive ([#8085](https://github.com/paritytech/parity/pull/8085))
+- Ethcore-service ([#8089](https://github.com/paritytech/parity/pull/8089))
+- [contract-client] refactor ([#7978](https://github.com/paritytech/parity/pull/7978))
+- Revert removing blooms ([#8066](https://github.com/paritytech/parity/pull/8066))
+- Ethcore test::helpers cleanup ([#8086](https://github.com/paritytech/parity/pull/8086))
+- Add some dos protection ([#8084](https://github.com/paritytech/parity/pull/8084))
+- Wasm libraries bump ([#7970](https://github.com/paritytech/parity/pull/7970))
+- Echo back the message hash of a ping in the pong request ([#8042](https://github.com/paritytech/parity/pull/8042))
+- Add Kovan WASM activation blocknumber ([#8057](https://github.com/paritytech/parity/pull/8057))
+- [ethkey] Unify debug/display for Address/Public/Secret ([#8076](https://github.com/paritytech/parity/pull/8076))
+- Limit incoming connections. ([#8060](https://github.com/paritytech/parity/pull/8060))
+- Max code size on Kovan ([#8067](https://github.com/paritytech/parity/pull/8067))
+- Updater: apply exponential backoff after download failure ([#8059](https://github.com/paritytech/parity/pull/8059))
+- Make blockchain functions more idiomatic, avoid needless writes to cache_man ([#8054](https://github.com/paritytech/parity/pull/8054))
+- Make patricia-trie more idiomatic and remove redundant code ([#8056](https://github.com/paritytech/parity/pull/8056))
+- Abstract devp2p ([#8048](https://github.com/paritytech/parity/pull/8048))
+- Update refs to shell ([#8051](https://github.com/paritytech/parity/pull/8051))
+- Fix cache & snapcraft CI build ([#8052](https://github.com/paritytech/parity/pull/8052))
+- Prelude to the block module cleanup ([#8025](https://github.com/paritytech/parity/pull/8025))
+- Add MCIP-6 Byzyantium transition to Musicoin spec ([#7841](https://github.com/paritytech/parity/pull/7841))
+- Bump master to 1.11.0 ([#8021](https://github.com/paritytech/parity/pull/8021))
+- `client` refactoring ([#7038](https://github.com/paritytech/parity/pull/7038))
+- [hardware wallet] sleeping -> pollling ([#8018](https://github.com/paritytech/parity/pull/8018))
+- Fixed broken link in README ([#8012](https://github.com/paritytech/parity/pull/8012))
+- Support parity protocol. ([#8035](https://github.com/paritytech/parity/pull/8035))
+- Add changelog for 1.8.11 stable and 1.9.4 beta ([#8017](https://github.com/paritytech/parity/pull/8017))
+- Fix for verify_block_basic crashing on invalid transaction rlp ([#8032](https://github.com/paritytech/parity/pull/8032))
+- Extract the hard dependency on rocksdb from the light client ([#8034](https://github.com/paritytech/parity/pull/8034))
+- Fixed parsing ethash seals and verify_block_undordered ([#8031](https://github.com/paritytech/parity/pull/8031))
+- Fixed ethstore sign ([#8026](https://github.com/paritytech/parity/pull/8026))
+- Ci: Fix cargo cache ([#7968](https://github.com/paritytech/parity/pull/7968))
+- Update ref to new shell ([#8024](https://github.com/paritytech/parity/pull/8024))


### PR DESCRIPTION
- [x] docs: mark 1.10 as end-of-life
- [x] docs: move changelog for 1.11
- [x] docs: Add changelog for 1.11.7-stable
- [x] docs: add changelog for 2.0.0-beta
- [ ] docs: add release notes for 2.0.0-beta