### PR TITLE
Make sure to create full pending blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ winapi = { version = "0.3.4", features = ["winsock2", "winuser", "shellapi"] }
 daemonize = { git = "https://github.com/paritytech/daemonize" }
 
 [features]
+miner-debug = ["ethcore/miner-debug"]
 json-tests = ["ethcore/json-tests"]
 test-heavy = ["ethcore/test-heavy"]
 evm-debug = ["ethcore/evm-debug"]

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -80,6 +80,10 @@ tempdir = "0.3"
 trie-standardmap = { git = "https://github.com/paritytech/parity-common" }
 
 [features]
+# Disables seal verification for mined blocks.
+# This allows you to submit any seal via RPC to test and benchmark
+# how fast pending block get's created while running on the mainnet.
+miner-debug = []
 # Display EVM debug traces.
 evm-debug = ["evm/evm-debug"]
 # Display EVM debug traces when running tests.

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -280,9 +280,16 @@ impl Engine<EthereumMachine> for Arc<Ethash> {
 		block_reward::apply_block_rewards(&rewards, block, &self.machine)
 	}
 
+	#[cfg(not(feature = "miner-debug"))]
 	fn verify_local_seal(&self, header: &Header) -> Result<(), Error> {
 		self.verify_block_basic(header)
 			.and_then(|_| self.verify_block_unordered(header))
+	}
+
+	#[cfg(feature = "miner-debug")]
+	fn verify_local_seal(&self, _header: &Header) -> Result<(), Error> {
+		warn!("Skipping seal verification, running in miner testing mode.");
+		Ok(())
 	}
 
 	fn verify_block_basic(&self, header: &Header) -> Result<(), Error> {

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -96,7 +96,7 @@ const DEFAULT_MINIMAL_GAS_PRICE: u64 = 20_000_000_000;
 /// before stopping attempts to push more transactions to the block.
 /// This is an optimization that prevents traversing the entire pool
 /// in case we have only a fraction of available block gas limit left.
-const MAX_SKIPPED_TRANSACTIONS: usize = 8;
+const MAX_SKIPPED_TRANSACTIONS: usize = 128;
 
 /// Configures the behaviour of the miner.
 #[derive(Debug, PartialEq)]
@@ -384,7 +384,7 @@ impl Miner {
 		let max_transactions = if min_tx_gas.is_zero() {
 			usize::max_value()
 		} else {
-			(*open_block.block().header().gas_limit() / min_tx_gas).as_u64() as usize
+			MAX_SKIPPED_TRANSACTIONS.saturating_add((*open_block.block().header().gas_limit() / min_tx_gas).as_u64() as usize)
 		};
 
 		let pending: Vec<Arc<_>> = self.transaction_queue.pending(


### PR DESCRIPTION
With recent optimizations we only query `block_gas_limit / min_tx_gas` transactions from the pending set.
This however might be a bit too little to fill up the entire block (since you can get couple of high-gas transactions that won't fit). This in turn produces blocks that have like 90% gas limit utilization.

To prevent that, the PR:
1. Increases the `MAX_SKIPPED_TRANSACTIONS` constant, so we will now try at most 128 transactions before quitting
2. Always gets `MAX_SKIPPED_TRANSACTIONS` more transactions from the pending set.

Also I've added a feature to the main `Cargo.toml` that allows you to test mined block import while syncing mainnet (so you get all the transactions and dynamics of mainnet), by sending `eth_submitWork` with any seal. The seal for local import is ignored.