### PR TITLE
`evm bench` fix broken dependencies

### DIFF
--- a/ethcore/benches/evm.rs
+++ b/ethcore/benches/evm.rs
@@ -16,17 +16,16 @@
 
 #![feature(test)]
 
-extern crate test;
-extern crate ethcore_util as util;
-extern crate rand;
 extern crate bn;
-extern crate parity_crypto;
+extern crate ethereum_types;
 extern crate ethkey;
+extern crate parity_crypto;
+extern crate rand;
 extern crate rustc_hex;
-extern crate ethcore_bigint;
+extern crate test;
 
-use self::test::{Bencher};
-use rand::{StdRng};
+use self::test::Bencher;
+use rand::StdRng;
 
 #[bench]
 fn bn_128_pairing(b: &mut Bencher) {
@@ -74,7 +73,7 @@ fn sha256(b: &mut Bencher) {
 fn ecrecover(b: &mut Bencher) {
 	use rustc_hex::FromHex;
 	use ethkey::{Signature, recover as ec_recover};
-	use ethcore_bigint::hash::H256;
+	use ethereum_types::H256;
 	let input = FromHex::from_hex("47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad000000000000000000000000000000000000000000000000000000000000001b650acf9d3f5f0a2c799776a1254355d5f4061762a237396a99a0e0e3fc2bcd6729514a0dacb2e623ac4abd157cb18163ff942280db4d5caad66ddf941ba12e03").unwrap();
 	let hash = H256::from_slice(&input[0..32]);
 	let v = H256::from_slice(&input[32..64]);

--- a/ethcore/benches/evm.rs
+++ b/ethcore/benches/evm.rs
@@ -61,8 +61,7 @@ fn bn_128_mul(b: &mut Bencher) {
 fn sha256(b: &mut Bencher) {
 	use parity_crypto::digest::sha256;
 
-	let mut input: [u8; 256] = [0; 256];
-	let mut out = [0; 32];
+	let input = [0_u8; 256];
 
 	b.iter(|| {
 		sha256(&input);


### PR DESCRIPTION
Closes #9124 

Benchmarks of the `evm` used stale versions of a couple of crates that
this commit fixes!