### PR TITLE
Add `wasmDisableTransition` spec option

### DIFF
--- a/ethcore/res/ethereum/test-specs/kovan_wasm_test.json
+++ b/ethcore/res/ethereum/test-specs/kovan_wasm_test.json
@@ -42,7 +42,8 @@
 		"eip211Transition": 5067000,
 		"eip214Transition": 5067000,
 		"eip658Transition": 5067000,
-		"wasmActivationTransition": 10
+		"wasmActivationTransition": 10,
+		"wasmDisableTransition": 200
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/spec/src/spec.rs
+++ b/ethcore/spec/src/spec.rs
@@ -411,6 +411,7 @@ impl Spec {
 			params.eip2315_transition,
 			params.dust_protection_transition,
 			params.wasm_activation_transition,
+			params.wasm_disable_transition,
 			params.kip4_transition,
 			params.kip6_transition,
 			params.max_code_size_transition,

--- a/ethcore/types/src/engines/params.rs
+++ b/ethcore/types/src/engines/params.rs
@@ -114,6 +114,8 @@ pub struct CommonParams {
 	pub remove_dust_contracts: bool,
 	/// Wasm activation blocknumber, if any disabled initially.
 	pub wasm_activation_transition: BlockNumber,
+	/// Wasm deactivation blocknumber, if enabled.
+	pub wasm_disable_transition: BlockNumber,
 	/// Wasm account version, activated after `wasm_activation_transition`. If this field is defined, do not use code
 	/// prefix to determine VM to execute.
 	pub wasm_version: Option<U256>,
@@ -208,7 +210,7 @@ impl CommonParams {
 				false => vm::CleanDustMode::BasicOnly,
 			};
 		}
-		if block_number >= self.wasm_activation_transition {
+		if block_number >= self.wasm_activation_transition && block_number < self.wasm_disable_transition {
 			let mut wasm = vm::WasmCosts::default();
 			if block_number >= self.kip4_transition {
 				wasm.have_create2 = true;
@@ -364,6 +366,10 @@ impl From<ethjson::spec::Params> for CommonParams {
 			transaction_permission_contract_transition:
 			p.transaction_permission_contract_transition.map_or(0, Into::into),
 			wasm_activation_transition: p.wasm_activation_transition.map_or_else(
+				BlockNumber::max_value,
+				Into::into
+			),
+			wasm_disable_transition: p.wasm_disable_transition.map_or_else(
 				BlockNumber::max_value,
 				Into::into
 			),

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -139,6 +139,8 @@ pub struct Params {
 	pub transaction_permission_contract_transition: Option<Uint>,
 	/// Wasm activation block height, if not activated from start.
 	pub wasm_activation_transition: Option<Uint>,
+	/// Wasm deactivation block height, if activated.
+	pub wasm_disable_transition: Option<Uint>,
 	/// Define a separate wasm version instead of using the prefix.
 	pub wasm_version: Option<Uint>,
 	/// KIP4 activiation block height.
@@ -163,7 +165,8 @@ mod tests {
 			"accountStartNonce": "0x01",
 			"gasLimitBoundDivisor": "0x20",
 			"maxCodeSize": "0x1000",
-			"wasmActivationTransition": "0x1010"
+			"wasmActivationTransition": "0x1010",
+			"wasmDisableTransition": "0x2010"
 		}"#;
 
 		let deserialized: Params = serde_json::from_str(s).unwrap();
@@ -176,6 +179,7 @@ mod tests {
 		assert_eq!(deserialized.gas_limit_bound_divisor, Uint(U256::from(0x20)));
 		assert_eq!(deserialized.max_code_size, Some(Uint(U256::from(0x1000))));
 		assert_eq!(deserialized.wasm_activation_transition, Some(Uint(U256::from(0x1010))));
+		assert_eq!(deserialized.wasm_disable_transition, Some(Uint(U256::from(0x2010))));
 	}
 
 	#[test]


### PR DESCRIPTION
Adds `wasmDisableTransition` spec option to disable WASM on Kovan on a certain block.

POA Team needs this to avoid splitting the Kovan chain after some Kovan validators replace their node with Nethermind client (which doesn't support WASM).