### PR TITLE
Add RPC eth_symbol test (eip-3014)

### DIFF
--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -597,6 +597,11 @@ impl<C, SN: ?Sized, S: ?Sized, M, EM, T: StateInfo + 'static> Eth for EthClient<
 		Ok(self.client.signing_chain_id().map(U64::from))
 	}
 
+	fn symbol(&self) -> Result<String> {
+		// TODO: symbol should be configurable
+		Ok("ETH".to_string())
+	}
+
 	fn hashrate(&self) -> Result<U256> {
 		Ok(self.external_miner.hashrate())
 	}

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -266,6 +266,11 @@ where
 		Ok(self.client.signing_chain_id().map(U64::from))
 	}
 
+	fn symbol(&self) -> Result<String> {
+		// TODO: symbol should be configurable
+		Ok("ETH".to_string())
+	}
+
 	fn hashrate(&self) -> Result<U256> {
 		Ok(Default::default())
 	}

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -188,6 +188,15 @@ fn rpc_eth_chain_id() {
 }
 
 #[test]
+fn rpc_eth_symbol() {
+	let tester = EthTester::default();
+	let request = r#"{"jsonrpc": "2.0", "method": "eth_symbol", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":null,"id":1}"#;
+
+	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_owned()));
+}
+
+#[test]
 fn rpc_eth_hashrate() {
 	let tester = EthTester::default();
 	tester.hashrates.lock().insert(H256::from_low_u64_be(0), (Instant::now() + Duration::from_secs(2), U256::from(0xfffa)));

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -54,6 +54,10 @@ pub trait Eth {
 	#[rpc(name = "eth_chainId")]
 	fn chain_id(&self) -> Result<Option<U64>>;
 
+	/// Returns native coin symbol.
+	#[rpc(name = "eth_symbol")]
+	fn symbol(&self) -> Result<String>;
+
 	/// Returns current gas_price.
 	#[rpc(name = "eth_gasPrice")]
 	fn gas_price(&self) -> BoxFuture<U256>;


### PR DESCRIPTION
Add RPC eth_symbol test ([eip-3014](https://github.com/ethereum/EIPs/issues/3012))

The eth_symbol endpoint still needs to be implemented.